### PR TITLE
Upgrade userpath to 1.6.0 for locale enoding fix

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 dev
 
-- Fix to `pipx ensurepath` to fix behavior in user locales other than UTF-8, to fix #644. The internal change is to use userpath v1.6.0 or greater. ()
+- Fix to `pipx ensurepath` to fix behavior in user locales other than UTF-8, to fix #644. The internal change is to use userpath v1.6.0 or greater. (#700)
 
 0.16.3
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,6 @@
 dev
 
+- Fix to `pipx ensurepath` to fix behavior in user locales other than UTF-8, to fix #644. The internal change is to use userpath v1.6.0 or greater. ()
 
 0.16.3
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ zip_safe = true
 python_requires = >=3.6
 install_requires =
     colorama>=0.4.4;sys_platform=="win32"
-    userpath>=1.5.0
+    userpath>=1.6.0
     argcomplete>=1.9.4, <2.0
     packaging>=20.0
     importlib-metadata>=3.3.0; python_version < '3.8'


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Closes #644.

This increases the required `userpath` version to 1.6.0.  This version of userpath includes a bug fix to decode the stdout from a subprocess command using the platform encoding, instead of always using "utf-8" as the code did before.  This should prevent `UnicodeError`s from occurring during the decode of the subprocess stdout.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
