### PR TITLE
Fix Python version inspection for pre-release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 dev
 
 - Fix to `pipx ensurepath` to fix behavior in user locales other than UTF-8, to fix #644. The internal change is to use userpath v1.6.0 or greater. (#700)
+- Fix virtual environment inspection for Python releases that uses an int for its release serial number. (#706)
 
 0.16.3
 

--- a/src/pipx/venv_inspect.py
+++ b/src/pipx/venv_inspect.py
@@ -172,7 +172,11 @@ def fetch_info_in_venv(venv_python_path: Path) -> Tuple[List[str], Dict[str, str
         impl_ver = sys.implementation.version
         implementation_version = "{0.major}.{0.minor}.{0.micro}".format(impl_ver)
         if impl_ver.releaselevel != "final":
-            implementation_version += impl_ver.releaselevel[0] + impl_ver.serial
+            implementation_version = "{}{}{}".format(
+                implementation_version,
+                impl_ver.releaselevel[0],
+                impl_ver.serial,
+            )
 
         sys_path = sys.path
         try:


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

pipx failed on my when I tried to run it against a pre-release Python:

```
$ ./python -c "import sys; print(sys.implementation)"
sys.version_info(major=3, minor=10, micro=0, releaselevel='beta', serial=2)
```

This fixes that.

## Test plan

Tested by running

1. Build a pre-release Python from source
2. `pipx install --python=path/to/prerelease/python cowsay`
