### PR TITLE
Use value of `#egg=` to determine package name if provided

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@ dev
 
 - Fix to `pipx ensurepath` to fix behavior in user locales other than UTF-8, to fix #644. The internal change is to use userpath v1.6.0 or greater. (#700)
 - Fix virtual environment inspection for Python releases that uses an int for its release serial number. (#706)
+- Use package name from `#egg=` if present.
 
 0.16.3
 

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -265,6 +265,10 @@ class Venv:
         with animate(
             f"determining package name from {package_or_url!r}", self.do_animation
         ):
+            match = re.search(r"#egg=(.+)$", package_or_url)
+            if match:
+                package_name = match.group(1)
+                return package_name
             old_package_set = self.list_installed_packages()
             cmd = ["install"] + ["--no-dependencies"] + pip_args + [package_or_url]
             pip_process = self._run_pip(cmd)


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
If `#egg=` is provided on the command line, it will be used to determine the package name, which is faster than trying to resolve it.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
pipx install git+https://github.com/nyuszika7h/poetry.git@vcs-disable-hashes\#egg=poetry
```
