### PR TITLE
improving installation instructions for windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ WARNING: The script pipx.exe is installed in `<USER folder>\AppData\Roaming\Pyth
 ```
 
 If so, go to the mentioned folder, allowing you to run the pipx executable directly.
-Enter the following line (even if you did not get the warning.):
+Enter the following line (even if you did not get the warning):
 
 ```
 pipx ensurepath
@@ -67,7 +67,7 @@ Restart your terminal session and verify `pipx` does run.
 
 Upgrade pipx with `python3 -m pip install --user -U pipx`.
 
-### Shell completions.
+### Shell completions
 
 Shell completions are available by following the instructions printed with this command:
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ _For comparison to other tools including pipsi, see [Comparison to Other Tools](
 
 ## Install pipx
 
-On macOS:
+### On macOS
 
 ```
 brew install pipx
@@ -34,14 +34,40 @@ pipx ensurepath
 
 Upgrade pipx with `brew update && brew upgrade pipx`.
 
-Otherwise, install via pip (requires pip 19.0 or later):
+### On Linux, install via pip (requires pip 19.0 or later)
 
 ```
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath
 ```
+Upgrade pipx with `python3 -m pip install --user -U pipx`.
+
+### On Windows, install via pip (requires pip 19.0 or later)
+
+```
+# If you installed python using the app-store, replace `python` with `python3` in the next line.
+python -m pip install --user pipx
+```
+
+It is possible (even most likely) the above finishes with a WARNING looking similar to this:
+
+```
+WARNING: The script pipx.exe is installed in `<USER folder>\AppData\Roaming\Python\Python3x\Scripts` which is not on PATH
+```
+
+If so, go to the mentioned folder, allowing you to run the pipx executable directly.
+Enter the following line (even if you did not get the warning.):
+
+```
+pipx ensurepath
+```
+
+This will add both the above mentioned path and the `%USERPROFILE%.local\bin` folder to your search path.
+Restart your terminal session and verify `pipx` does run.
 
 Upgrade pipx with `python3 -m pip install --user -U pipx`.
+
+### Shell completions.
 
 Shell completions are available by following the instructions printed with this command:
 ```


### PR DESCRIPTION
In my experience the windows instructions are minimal and not always correct (due to the nature of windows mostly I guess).
For this reason I am assuming installation will fail many times due to this, discouraging new users to actually use this nice tool.

This pull request should -hopefully- improve on this. I have now only updated the readme file and understand there is also some  things to change in the documentation, but I'd like to see where this goes first before I put energy in this.

Sander.