### PR TITLE
Add --include-deps to ansible install command in "Programs to Try" doc

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@ dev
 
 - Fixed `pipx list` output phrasing to convey that python version displayed is the one with which package was installed. 
 - Fixed `pipx install` to provide return code 0 if venv already exists, similar to pip’s behavior. (#736)
+- [docs] Update ansible's install command in [Programs to Try document](https://pypa.github.io/pipx/programs-to-try/#ansible) to work with Ansible 2.10+ (#742)
 
 0.16.4
 

--- a/docs/programs-to-try.md
+++ b/docs/programs-to-try.md
@@ -7,7 +7,7 @@ Here are some programs you can try out. If you've never used the program before,
 IT automation
 
 ```
-pipx install ansible
+pipx install --include-deps ansible
 ```
 
 ### asciinema


### PR DESCRIPTION
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Added `--include-deps` to the `pipx install` command for ansible.

## Test plan
This is a documentation-only change.