### PR TITLE
Forgotten release dance

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,6 @@
+dev
+
+
 0.16.5
 
 - Fixed `pipx list` output phrasing to convey that python version displayed is the one with which package was installed. 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,4 +1,4 @@
-dev
+0.16.5
 
 - Fixed `pipx list` output phrasing to convey that python version displayed is the one with which package was installed. 
 - Fixed `pipx install` to provide return code 0 if venv already exists, similar to pip’s behavior. (#736)

--- a/src/pipx/version.py
+++ b/src/pipx/version.py
@@ -1,2 +1,2 @@
-__version_info__ = (0, 16, 4, 1, "dev0")
+__version_info__ = (0, 16, 5)
 __version__ = ".".join(str(i) for i in __version_info__)

--- a/src/pipx/version.py
+++ b/src/pipx/version.py
@@ -1,2 +1,2 @@
-__version_info__ = (0, 16, 5)
+__version_info__ = (0, 16, 5, 1, "dev0")
 __version__ = ".".join(str(i) for i in __version_info__)


### PR DESCRIPTION
The pre- and post-release steps were forgotten around 0.16.5.

Apply them before someone adds changelog entries to 0.16.5, by mistake.