### PR TITLE
Build manpage with argparse-manpage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ venv
 __pycache__
 site
 docs/docs.md
+pipx.1
 .pipx_tests
 /.coverage*

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,6 @@
 dev
 
+- Include machinery to build a manpage for pipx with [argparse-manpage](https://pypi.org/project/argparse-manpage/).
 
 0.17.0
 

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-.PHONY: test docs develop build publish publish_docs lint
+.PHONY: test docs develop build publish publish_docs lint man
 
 develop:
 	pipx run nox -s develop
@@ -20,3 +20,6 @@ watch_docs:
 
 publish_docs:
 	pipx run nox -s publish_docs -r
+
+man:
+	pipx run nox -s build_man -r

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,6 +7,7 @@ import nox  # type: ignore
 PYTHON_ALL_VERSIONS = ["3.6", "3.7", "3.8", "3.9", "3.10"]
 PYTHON_DEFAULT_VERSION = "3.10"
 DOC_DEPENDENCIES = [".", "jinja2", "mkdocs", "mkdocs-material"]
+MAN_DEPENDENCIES = [".", "argparse-manpage"]
 LINT_DEPENDENCIES = [
     "black==21.12b0",
     "flake8==4.0.1",
@@ -39,9 +40,9 @@ else:
 # Set nox options
 if PLATFORM == "win":
     # build_docs fail on Windows, even if `chcp.com 65001` is used
-    nox.options.sessions = ["tests", "lint"]
+    nox.options.sessions = ["tests", "lint", "build_man"]
 else:
-    nox.options.sessions = ["tests", "lint", "build_docs"]
+    nox.options.sessions = ["tests", "lint", "build_docs", "build_man"]
 nox.options.reuse_existing_virtualenvs = True
 
 
@@ -224,6 +225,16 @@ def publish_docs(session):
 def watch_docs(session):
     session.install(*DOC_DEPENDENCIES)
     session.run("mkdocs", "serve")
+
+
+@nox.session(python=PYTHON_DEFAULT_VERSION)
+def build_man(session):
+    session.run("python", "-m", "pip", "install", "--upgrade", "pip")
+    session.install(*MAN_DEPENDENCIES)
+    session.env[
+        "PIPX__DOC_DEFAULT_PYTHON"
+    ] = "typically the python used to execute pipx"
+    session.run("python", "scripts/generate_man.py")
 
 
 @nox.session(python=PYTHON_DEFAULT_VERSION)

--- a/scripts/generate_man.py
+++ b/scripts/generate_man.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os.path
+import textwrap
+
+from build_manpages.manpage import Manpage
+
+from pipx.main import get_command_parser
+
+
+def main():
+    parser = get_command_parser()
+    parser.man_short_description = parser.description.splitlines()[1]
+
+    manpage = Manpage(parser)
+    body = str(manpage)
+
+    # Avoid hardcoding build paths in manpages (and improve readability)
+    body = body.replace(os.path.expanduser("~"), "~")
+
+    # Add a credit section
+    body += textwrap.dedent(
+        """
+        .SH AUTHORS
+        .IR pipx (1)
+        was written by Chad Smith and contributors.
+        The project can be found online at
+        .UR https://pypa.github.io/pipx/
+        .UE
+        .SH SEE ALSO
+        .IR pip (1),
+        .IR virtualenv (1)
+        """
+    )
+
+    with open("pipx.1", "w") as f:
+        f.write(body)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_man.py
+++ b/scripts/generate_man.py
@@ -17,7 +17,7 @@ def main():
     body = str(manpage)
 
     # Avoid hardcoding build paths in manpages (and improve readability)
-    body = body.replace(os.path.expanduser("~"), "~")
+    body = body.replace(os.path.expanduser("~").replace("-", "\\-"), "~")
 
     # Add a credit section
     body += textwrap.dedent(

--- a/scripts/generate_man.py
+++ b/scripts/generate_man.py
@@ -4,7 +4,7 @@
 import os.path
 import textwrap
 
-from build_manpages.manpage import Manpage
+from build_manpages.manpage import Manpage  # type: ignore
 
 from pipx.main import get_command_parser
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -615,7 +615,7 @@ def get_command_parser() -> argparse.ArgumentParser:
         formatter_class=LineWrapRawTextHelpFormatter,
         description=PIPX_DESCRIPTION,
     )
-    parser.man_short_description = PIPX_DESCRIPTION.splitlines()[1]
+    parser.man_short_description = PIPX_DESCRIPTION.splitlines()[1]  # type: ignore
 
     subparsers = parser.add_subparsers(
         dest="command", description="Get help for commands with pipx COMMAND --help"

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -615,6 +615,7 @@ def get_command_parser() -> argparse.ArgumentParser:
         formatter_class=LineWrapRawTextHelpFormatter,
         description=PIPX_DESCRIPTION,
     )
+    parser.man_short_description = PIPX_DESCRIPTION.splitlines()[1]
 
     subparsers = parser.add_subparsers(
         dest="command", description="Get help for commands with pipx COMMAND --help"

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -611,7 +611,9 @@ def get_command_parser() -> argparse.ArgumentParser:
     completer_venvs = InstalledVenvsCompleter(venv_container)
 
     parser = argparse.ArgumentParser(
-        formatter_class=LineWrapRawTextHelpFormatter, description=PIPX_DESCRIPTION
+        prog="pipx",
+        formatter_class=LineWrapRawTextHelpFormatter,
+        description=PIPX_DESCRIPTION,
     )
 
     subparsers = parser.add_subparsers(


### PR DESCRIPTION
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

Add a script to generate a manpage with argparse-manpage.

In Debian we strive to have manpages for all command line utilities.

An explicitly written manpage usually gives the best result, but falls out of date quickly, unless maintained, and editing nroff source directly isn't fun. Sphinx has tooling for generating manpages from rst, but mkdocs doesn't seem to have any for manpages from markdown, yet. There are third-party tools that do this (ronn in the ruby world, and go-md2man in the Go world).

But argparse-manpage automatically generates a reasonable looking manpage, with minimal effort.

## Test plan
Tested by running
```
$ make man
$ man -l pipx.1
```