### PR TITLE
Standalone generate docs

### DIFF
--- a/makefile
+++ b/makefile
@@ -13,7 +13,7 @@ publish:
 	pipx run nox -s publish
 
 docs:
-	pipx run nox -s docs -r
+	pipx run nox -s build_docs -r
 
 watch_docs:
 	pipx run nox -s watch_docs -r

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -3,6 +3,7 @@
 
 import os
 import subprocess
+import sys
 import textwrap
 from typing import Optional
 
@@ -12,10 +13,10 @@ from pipx.main import __version__
 
 
 def get_help(pipxcmd: Optional[str]) -> str:
+    cmd = [sys.executable, "-m", "pipx"]
     if pipxcmd:
-        cmd = ["pipx", pipxcmd, "--help"]
-    else:
-        cmd = ["pipx", "--help"]
+        cmd.append(pipxcmd)
+    cmd.append("--help")
 
     helptext = (
         subprocess.run(cmd, stdout=subprocess.PIPE, check=True)


### PR DESCRIPTION
## Summary of changes

Allow `scripts/generate_docs.py` to be run directly on the source tree (with `PYTHONPATH=src`, for example).
This makes it easier to run during a Debian package build.

While we're here, update the makefile, the `docs` target wasn't updated after a noxfile reorg.

## Test plan
Tested by running
```
$ PYTHONPATH=src python3 scripts/generate_docs.py
$ make docs
```