### PR TITLE
Fix python 3.6-3.8 compatibility error

### DIFF
--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -27,7 +27,15 @@ def reinstall(
         print(f"Nothing to reinstall for {venv_dir.name} {sleep}")
         return EXIT_CODE_REINSTALL_VENV_NONEXISTENT
 
-    if Path(python).is_relative_to(venv_dir):
+    try:
+        # use PurePath.relative_to in a try block instead
+        # of PurePath.is_relative_to, for python 3.6-3.8 compatability
+        Path(python).relative_to(venv_dir)
+        python_relative_to_venv_dir = True
+    except ValueError:
+        python_relative_to_venv_dir = False
+    
+    if python_relative_to_venv_dir:
         print(
             f"{error} Error, the python executable would be deleted!",
             "Change it using the --python option or PIPX_DEFAULT_PYTHON environment variable.",

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -34,7 +34,7 @@ def reinstall(
         python_relative_to_venv_dir = True
     except ValueError:
         python_relative_to_venv_dir = False
-    
+
     if python_relative_to_venv_dir:
         print(
             f"{error} Error, the python executable would be deleted!",


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes
All PR CI checks are currently failing because a method call was added to the `pipx.commands.reinstall.reinstall` function which was only added in python 3.9

Replaced that method call with a python >=3.6 workaround

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
