### PR TITLE
Replace `master` with `main`

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -12,7 +12,7 @@ jobs:
     name: Deploy docs
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout master
+      - name: Checkout main
         uses: actions/checkout@v2
       - name: Set up Python ${{ env.default-python }}
         uses: actions/setup-python@v2

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,10 @@
 dev
 
 
+0.16.5.1
+
+- Updated `master` to `main` through out the repository since the `master` branch is non-existent.
+
 0.16.5
 
 - Fixed `pipx list` output phrasing to convey that python version displayed is the one with which package was installed. 

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -52,10 +52,10 @@ None. Either one or the other should be used. These tools compete for a similar 
 
 ### Migrating to pipx from pipsi
 
-After you have installed pipx, run [migrate_pipsi_to_pipx.py](https://raw.githubusercontent.com/pypa/pipx/master/scripts/migrate_pipsi_to_pipx.py). Why not do this with your new pipx installation?
+After you have installed pipx, run [migrate_pipsi_to_pipx.py](https://raw.githubusercontent.com/pypa/pipx/main/scripts/migrate_pipsi_to_pipx.py). Why not do this with your new pipx installation?
 
 ```
-pipx run https://raw.githubusercontent.com/pypa/pipx/master/scripts/migrate_pipsi_to_pipx.py
+pipx run https://raw.githubusercontent.com/pypa/pipx/main/scripts/migrate_pipsi_to_pipx.py
 ```
 
 ## pipx vs brew

--- a/noxfile.py
+++ b/noxfile.py
@@ -79,12 +79,12 @@ def get_branch():
     )
 
 
-def on_master_no_changes(session):
+def on_main_no_changes(session):
     if has_changes():
         session.error("All changes must be committed or removed before publishing")
     branch = get_branch()
-    if branch != "master":
-        session.error(f"Must be on 'master' branch. Currently on {branch!r} branch")
+    if branch != "main":
+        session.error(f"Must be on 'main' branch. Currently on {branch!r} branch")
 
 
 @nox.session(python=PYTHON_ALL_VERSIONS)
@@ -192,7 +192,7 @@ def build(session):
 
 @nox.session(python=PYTHON_DEFAULT_VERSION)
 def publish(session):
-    on_master_no_changes(session)
+    on_main_no_changes(session)
     session.run("python", "-m", "pip", "install", "--upgrade", "pip")
     session.install("twine")
     build(session)
@@ -227,7 +227,7 @@ def watch_docs(session):
 
 @nox.session(python=PYTHON_DEFAULT_VERSION)
 def pre_release(session):
-    on_master_no_changes(session)
+    on_main_no_changes(session)
     session.run("python", "-m", "pip", "install", "--upgrade", "pip")
     session.install("mypy")
     if session.posargs:
@@ -245,7 +245,7 @@ def pre_release(session):
 
 @nox.session(python=PYTHON_DEFAULT_VERSION)
 def post_release(session):
-    on_master_no_changes(session)
+    on_main_no_changes(session)
     session.run("python", "-m", "pip", "install", "--upgrade", "pip")
     session.install("mypy")
     session.run("python", "scripts/pipx_postrelease.py")


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

Updated the fllowing files to refer to `main` branch instead of `master` branch:

- https://github.com/pypa/pipx/blob/main/.github/workflows/publish_docs.yml
- https://github.com/pypa/pipx/blob/main/docs/comparisons.md#migrating-to-pipx-from-pipsi
- https://github.com/pypa/pipx/blob/main/noxfile.py#L86

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running the following in a python virtual environment:
```
pip install nox
nox -s watch_docs
```

Any `nox` command that's dependent on the `noxfile.py` (which had the most edits in this PR) runs successfully.
