### PR TITLE
Update Workflow badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align="center">
-<a href="https://github.com/pypa/pipx/actions?query=workflow%3ATest"><img src="https://github.com/pypa/pipx/workflows/Test/badge.svg?branch=main" alt="Test CI" ></a>
+<a href="https://github.com/pypa/pipx/actions?query=workflow%3ATest"><img src="https://github.com/pypa/pipx/actions/workflows/test_all_packages_slow.yml/badge.svg" alt="Test CI" ></a>
 <a href="https://badge.fury.io/py/pipx"><img src="https://badge.fury.io/py/pipx.svg" alt="PyPI version"></a>
 </p>
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,8 @@
 dev
 
+0.16.5.1
+
+- Update GitHUb actions' Workflow badge based on the [updated docs](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge)
 
 0.16.5
 

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -27,7 +27,15 @@ def reinstall(
         print(f"Nothing to reinstall for {venv_dir.name} {sleep}")
         return EXIT_CODE_REINSTALL_VENV_NONEXISTENT
 
-    if Path(python).is_relative_to(venv_dir):
+    try:
+        # use PurePath.relative_to in a try block instead
+        # of PurePath.is_relative_to, for python 3.6-3.8 compatability
+        Path(python).relative_to(venv_dir)
+        python_relative_to_venv_dir = True
+    except ValueError:
+        python_relative_to_venv_dir = False
+
+    if python_relative_to_venv_dir:
         print(
             f"{error} Error, the python executable would be deleted!",
             "Change it using the --python option or PIPX_DEFAULT_PYTHON environment variable.",


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

Update the link to the GitHub actions workflow status badge based on the [updated docs](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge).

### Considerations

- I've not used the branch parameter (by appending `?branch=main`) to the link since that shows `no status`:

    ![](https://github.com/pypa/pipx/actions/workflows/test_all_packages_slow.yml/badge.svg?branch=main)

- I've not used the `test_all_packages_slow.yml` workflow file since that is what was originally linked to.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running the following commands (in a python virtual environment):

```
pip install nox
nox -s watch_docs
```

The resultant home page of the docs, published locally, has a working GitHub actions workflow status badge.

Green arrow points to a working badge.

<img width="1518" alt="Screenshot 2021-11-16 at 15 41 43" src="https://user-images.githubusercontent.com/15629602/141987123-c2b37fd7-70d6-4e10-9504-26118b8cc31a.png">

