### PR TITLE
Write animation fallback message to stderr

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 dev
 
 - Include machinery to build a manpage for pipx with [argparse-manpage](https://pypi.org/project/argparse-manpage/).
+- Fixed animations sending output to stdout, which can break JSON output. (#769)
 
 0.17.0
 

--- a/src/pipx/animate.py
+++ b/src/pipx/animate.py
@@ -36,7 +36,7 @@ def animate(
 
     if not do_animation or not _env_supports_animation():
         # No animation, just a single print of message
-        print(f"{message}...")
+        sys.stderr.write(f"{message}...\n")
         yield
         return
 

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -55,6 +55,7 @@ def check_animate_output(
 
 def test_delay_suppresses_output(capsys, monkeypatch):
     monkeypatch.setattr(pipx.animate, "stderr_is_tty", True)
+    monkeypatch.setenv("COLUMNS", "80")
 
     test_string = "asdf"
 

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -138,5 +138,5 @@ def test_env_no_animate(capsys, monkeypatch, env_columns, stderr_is_tty):
     time.sleep(extra_after_thread_time)
     captured = capsys.readouterr()
 
-    assert captured.out == expected_string
-    assert captured.err == ""
+    assert captured.out == ""
+    assert captured.err == expected_string


### PR DESCRIPTION
Attempt at fixing #769, although I couldn't get the test `test_delay_suppresses_output` to pass. Any suggestions would be appreciated!

Fixes #769.

<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
