### PR TITLE
Fix typo in `pipx upgrade-all` output

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@ dev
 - Include machinery to build a manpage for pipx with [argparse-manpage](https://pypi.org/project/argparse-manpage/).
 - Add better handling for 'app not found' when a single app is present in the project, and an improved error message (#733)
 - Fixed animations sending output to stdout, which can break JSON output. (#769)
+- Fix typo in `pipx upgrade-all` output
 
 0.17.0
 

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -207,7 +207,7 @@ def upgrade_all(
 
     if venvs_upgraded == 0:
         print(
-            f"Versions did not change after running 'pip upgrade' for each package {sleep}"
+            f"Versions did not change after running 'pipx upgrade' for each package {sleep}"
         )
     if venv_error:
         raise PipxError(


### PR DESCRIPTION
Signed-off-by: Maxwell G <gotmax@e.email>

<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
This change is self explanatory; it just fixes a typo.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
pipx upgrade-all
```
