### PR TITLE
Make the docs reproducible

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,6 @@
 dev
 
+- Use $HOME instead of the explicit path in generated documentation.
 
 0.17.0
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -57,7 +57,7 @@ PIPX_DESCRIPTION = textwrap.dedent(
     Virtual Environment location is {str(constants.PIPX_LOCAL_VENVS)}.
     Symlinks to apps are placed in {str(constants.LOCAL_BIN_DIR)}.
 
-    """
+    """.replace(str(Path.home()), "$HOME")
 )
 PIPX_DESCRIPTION += pipx_wrap(
     """
@@ -104,7 +104,7 @@ INSTALL_DESCRIPTION = textwrap.dedent(
     The default python executable used to install a package is
     {DOC_DEFAULT_PYTHON} and can be overridden
     by setting the environment variable `PIPX_DEFAULT_PYTHON`.
-    """
+    """.replace(str(Path.home()), "$HOME")
 )
 
 


### PR DESCRIPTION
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

Forwarded from: https://bugs.debian.org/995865

Whilst working on the Reproducible Builds effort [0] I noticed that python-pipx could not be built reproducibly.

This is because the generated manpages uses values from the build system, specifically the $HOME directory.

A patch is attached that replaces this with a literal "$HOME" string (which is arguably more informative...).

[0] https://reproducible-builds.org/