### PR TITLE
Fix app name in help message

### DIFF
--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -163,7 +163,7 @@ def _download_and_run(
                 app_filename = app
         else:
             all_apps = (
-                f"{a} - usage: 'pipx run --spec {package_name} {app} [arguments?]'"
+                f"{a} - usage: 'pipx run --spec {package_name} {a} [arguments?]'"
                 for a in apps
             )
             raise PipxError(


### PR DESCRIPTION
## Summary of changes

The help message has a small bug:

```console
$ pipx run --spec=pylint something
'something' executable script not found in package 'pylint'.
Available executable scripts:
    epylint - usage: 'pipx run --spec pylint something [arguments?]'
    pylint - usage: 'pipx run --spec pylint something [arguments?]'
    pyreverse - usage: 'pipx run --spec pylint something [arguments?]'
    symilar - usage: 'pipx run --spec pylint something [arguments?]'
```

Notice how the example commands all say `something`.

After the fix:

```console
$ pipx run --spec=pylint something
'something' executable script not found in package 'pylint'.
Available executable scripts:
    epylint - usage: 'pipx run --spec pylint epylint [arguments?]'
    pylint - usage: 'pipx run --spec pylint pylint [arguments?]'
    pyreverse - usage: 'pipx run --spec pylint pyreverse [arguments?]'
    symilar - usage: 'pipx run --spec pylint symilar [arguments?]'
```