### PR TITLE
Support argcomplete 2.0.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,6 @@
 dev
 
+- Support [argcomplete 2.0.0](https://pypi.org/project/argcomplete/2.0.0) (#790)
 - Include machinery to build a manpage for pipx with [argparse-manpage](https://pypi.org/project/argparse-manpage/).
 - Add better handling for 'app not found' when a single app is present in the project, and an improved error message (#733)
 - Fixed animations sending output to stdout, which can break JSON output. (#769)

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ python_requires = >=3.6
 install_requires =
     colorama>=0.4.4;sys_platform=="win32"
     userpath>=1.6.0
-    argcomplete>=1.9.4, <2.0
+    argcomplete>=1.9.4
     packaging>=20.0
     importlib-metadata>=3.3.0; python_version < '3.8'
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

argcomplete 2.0.0 released on 2022-01-03:

  - https://pypi.org/project/argcomplete/2.0.0/
  - https://github.com/kislyuk/argcomplete/releases/tag/v2.0.0
  - https://github.com/kislyuk/argcomplete/blob/develop/Changes.rst#changes-for-v200-2022-01-03

Since it just drop support for Python 2.7 and 3.5, which align with pipx requirement, we should able to remove the version constraint for `<2.0`.

Signed-off-by: Wong Hoi Sing Edison <hswong3i@pantarei-design.com>


## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
pip install pipx
pip list | grep argcomplete
```
