### PR TITLE
Improve the behaviour of `shlex.split` on Windows

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,8 +1,7 @@
 dev
 
 - [docs] Fix the command for [installing development version](https://pypa.github.io/pipx/installation/#install-pipx-development-versions). (#801)
-- Improve the behaviour of `shlex.split` on Windows (#794)
-
+- Improve the behaviour of `shlex.split` on Windows, so paths on Windows can be handled peoperly when they are passed in `--pip-args`. (#794)
 
 1.0.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 dev
 
-- Fix the behaviour of `shlex.split` on Windows (#794)
+- Improve the behaviour of `shlex.split` on Windows (#794)
 
 1.0.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,6 @@
 dev
 
+- Fix the behaviour of `shlex.split` on Windows (#794)
 
 1.0.0
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -132,7 +132,9 @@ def get_pip_args(parsed_args: Dict[str, str]) -> List[str]:
         pip_args += ["--index-url", parsed_args["index_url"]]
 
     if parsed_args.get("pip_args"):
-        pip_args += shlex.split(parsed_args.get("pip_args", ""))
+        pip_args += shlex.split(
+            parsed_args.get("pip_args", ""), posix="win" not in sys.platform
+        )
 
     # make sure --editable is last because it needs to be right before
     #   package specification

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -23,7 +23,7 @@ import pipx.constants
 from pipx import commands, constants
 from pipx.animate import hide_cursor, show_cursor
 from pipx.colors import bold, green
-from pipx.constants import ExitCode
+from pipx.constants import ExitCode, WINDOWS
 from pipx.emojis import hazard
 from pipx.interpreter import DEFAULT_PYTHON
 from pipx.util import PipxError, mkdir, pipx_wrap, rmdir
@@ -132,9 +132,7 @@ def get_pip_args(parsed_args: Dict[str, str]) -> List[str]:
         pip_args += ["--index-url", parsed_args["index_url"]]
 
     if parsed_args.get("pip_args"):
-        pip_args += shlex.split(
-            parsed_args.get("pip_args", ""), posix="win" not in sys.platform
-        )
+        pip_args += shlex.split(parsed_args.get("pip_args", ""), posix=not WINDOWS)
 
     # make sure --editable is last because it needs to be right before
     #   package specification

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -23,7 +23,7 @@ import pipx.constants
 from pipx import commands, constants
 from pipx.animate import hide_cursor, show_cursor
 from pipx.colors import bold, green
-from pipx.constants import ExitCode, WINDOWS
+from pipx.constants import WINDOWS, ExitCode
 from pipx.emojis import hazard
 from pipx.interpreter import DEFAULT_PYTHON
 from pipx.util import PipxError, mkdir, pipx_wrap, rmdir

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -211,7 +211,7 @@ def test_pip_args_with_windows_path(pipx_temp_env, capsys):
     assert run_pipx_cli(
         [
             "install",
-            "https://github.com/ambv/black/archive/18.9b0.zip",
+            "pycowsay",
             "--verbose",
             "--pip-args='--no-index --find-links=D:\\TEST\\DIR'",
         ]

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -204,6 +204,22 @@ def test_pip_args_forwarded_to_package_name_determination(pipx_temp_env, capsys)
     assert "Cannot determine package name from spec" in captured.err
 
 
+def test_pip_args_with_windows_path(pipx_temp_env, capsys):
+    if not sys.platform.startswith("win"):
+        pytest.skip("Test pip arguments with Windows path on Windows only.")
+
+    assert run_pipx_cli(
+        [
+            "install",
+            "https://github.com/ambv/black/archive/18.9b0.zip",
+             "--verbose",
+            "--pip-args='--no-index --find-links=D:\\TEST\\DIR'",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert r"D:\\TEST\\DIR" in captured.err
+
+
 def test_install_suffix(pipx_temp_env, capsys):
     name = "pbr"
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -212,7 +212,7 @@ def test_pip_args_with_windows_path(pipx_temp_env, capsys):
         [
             "install",
             "https://github.com/ambv/black/archive/18.9b0.zip",
-             "--verbose",
+            "--verbose",
             "--pip-args='--no-index --find-links=D:\\TEST\\DIR'",
         ]
     )


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

Fixes #781 

On Windows, `shlex.split` will make path like `D:\MODULES_WHEEL\SDK` become `D:MODULES_WHEELSDK`, which may cause issues when running `--pip-args`.
This PR adds `posix` argument in `shlex.split` so that it can handle paths on Windows properly.
## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
On Windows, 
```py
print(shlex.split("D:\MODULES_WHEEL\SDK arg1 arg2"))
```
Output: 
```
['D:MODULES_WHEELSDK', 'arg1', 'arg2']
```

With `posix` argument:
```py
print(shlex.split("D:\MODULES_WHEEL\SDK arg1 arg2", posix="win" not in sys.platform))
```
Output:
```
['D:\\MODULES_WHEEL\\SDK', 'arg1', 'arg2']
```