### PR TITLE
Add list --short option

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,7 @@
 dev
 
 - [docs] Fix the command for [installing development version](https://pypa.github.io/pipx/installation/#install-pipx-development-versions). (#801)
-- Add `list --short` option. (#804)
+- Add `list --short` option to list only package names. (#804)
 
 1.0.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 dev
 
 - [docs] Fix the command for [installing development version](https://pypa.github.io/pipx/installation/#install-pipx-development-versions). (#801)
+- Add `list --short` option. (#804)
 
 1.0.0
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -57,4 +57,8 @@ binaries are exposed on your $PATH at /Users/user/.local/bin
     - blackd
    package pipx 0.10.0, Python 3.7.0
     - pipx
+
+> pipx list --short
+black 18.9b0
+pipx 0.10.0
 ```

--- a/src/pipx/commands/list_packages.py
+++ b/src/pipx/commands/list_packages.py
@@ -27,6 +27,22 @@ def get_venv_metadata_summary(venv_dir: Path) -> Tuple[PipxMetadata, VenvProblem
     return (venv.pipx_metadata, venv_problems, "")
 
 
+def list_short(venv_dirs: Collection[Path]) -> VenvProblems:
+    all_venv_problems = VenvProblems()
+    for venv_dir in venv_dirs:
+        venv_metadata, venv_problems, warning_str = get_venv_metadata_summary(venv_dir)
+        if venv_problems.any_():
+            logger.warning(warning_str)
+        else:
+            print(
+                venv_metadata.main_package.package,
+                venv_metadata.main_package.package_version,
+            )
+        all_venv_problems.or_(venv_problems)
+
+    return all_venv_problems
+
+
 def list_text(
     venv_dirs: Collection[Path], include_injected: bool, venv_root_dir: str
 ) -> VenvProblems:
@@ -76,7 +92,10 @@ def list_json(venv_dirs: Collection[Path]) -> VenvProblems:
 
 
 def list_packages(
-    venv_container: VenvContainer, include_injected: bool, json_format: bool
+    venv_container: VenvContainer,
+    include_injected: bool,
+    json_format: bool,
+    short_format: bool,
 ) -> ExitCode:
     """Returns pipx exit code."""
     venv_dirs: Collection[Path] = sorted(venv_container.iter_venv_dirs())
@@ -87,6 +106,8 @@ def list_packages(
 
     if json_format:
         all_venv_problems = list_json(venv_dirs)
+    elif short_format:
+        all_venv_problems = list_short(venv_dirs)
     else:
         if not venv_dirs:
             return EXIT_CODE_OK

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -499,10 +499,11 @@ def _add_list(subparsers: argparse._SubParsersAction) -> None:
         action="store_true",
         help="Show packages injected into the main app's environment",
     )
-    p.add_argument(
+    g = p.add_mutually_exclusive_group()
+    g.add_argument(
         "--json", action="store_true", help="Output rich data in json format."
     )
-    p.add_argument("--short", action="store_true", help="List packages only.")
+    g.add_argument("--short", action="store_true", help="List packages only.")
     p.add_argument("--verbose", action="store_true")
 
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -240,7 +240,9 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:  # noqa: C901
             force=args.force,
         )
     elif args.command == "list":
-        return commands.list_packages(venv_container, args.include_injected, args.json)
+        return commands.list_packages(
+            venv_container, args.include_injected, args.json, args.short
+        )
     elif args.command == "uninstall":
         return commands.uninstall(venv_dir, constants.LOCAL_BIN_DIR, verbose)
     elif args.command == "uninstall-all":
@@ -500,6 +502,7 @@ def _add_list(subparsers: argparse._SubParsersAction) -> None:
     p.add_argument(
         "--json", action="store_true", help="Output rich data in json format."
     )
+    p.add_argument("--short", action="store_true", help="List packages only.")
     p.add_argument("--verbose", action="store_true")
 
 

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -132,3 +132,15 @@ def test_list_json(pipx_temp_env, capsys):
         ),
         isort_package_ref,
     )
+
+
+def test_list_short(pipx_temp_env, monkeypatch, capsys):
+    assert not run_pipx_cli(["install", PKG["pycowsay"]["spec"]])
+    assert not run_pipx_cli(["install", PKG["pylint"]["spec"]])
+    captured = capsys.readouterr()
+
+    assert not run_pipx_cli(["list", "--short"])
+    captured = capsys.readouterr()
+
+    assert "pycowsay 0.0.0.1" in captured.out
+    assert "pylint 2.3.1" in captured.out


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
#792
Should `--short` flag have precedence over `--json` flag?
Should `--include-injected` flag be accepted with `--short`?
## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
> pipx list --short
black 18.9b0
pipx 0.10.0
```
