### PR TITLE
remove python 3.6 from tests and PyPI classifiers

### DIFF
--- a/.github/workflows/create_tests_package_lists.yml
+++ b/.github/workflows/create_tests_package_lists.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/exhaustive_package_test.yml
+++ b/.github/workflows/exhaustive_package_test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         include:
           - os: windows-latest
             python-version: "3.10"

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ docs/docs.md
 pipx.1
 .pipx_tests
 /.coverage*
+testdata

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,6 @@
 dev
 
+- Fix encoding issue on Windows when pip fails to install a package
 - [docs] Fix the command for [installing development version](https://pypa.github.io/pipx/installation/#install-pipx-development-versions). (#801)
 - [docs] Fix test status badge in readme file
 - [dev] Change test names

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,6 @@
 ## System Requirements
-python 3.6+ is required to install pipx. pipx can run binaries from packages with Python 3.3+. Don't have Python 3.6 or later? See [Python 3 Installation & Setup Guide](https://realpython.com/installing-python/).
+
+python 3.7+ is required to install pipx. pipx can run binaries from packages with Python 3.3+. Don't have Python 3.7 or later? See [Python 3 Installation & Setup Guide](https://realpython.com/installing-python/).
 
 You also need to have `pip` installed on your machine for `python3`. Installing it varies from system to system. Consult [pip's installation instructions](https://pip.pypa.io/en/stable/installing/). Installing on Linux works best with a [Linux Package Manager](https://packaging.python.org/guides/installing-using-linux-tools/#installing-pip-setuptools-wheel-with-linux-package-managers).
 
@@ -22,6 +23,7 @@ python3 -m pipx ensurepath
 ```
 
 ### Installation Options
+
 The default binary location for pipx-installed apps is `~/.local/bin`. This can be overridden with the environment variable `PIPX_BIN_DIR`.
 
 pipx's default virtual environment location is `~/.local/pipx`. This can be overridden with the environment variable `PIPX_HOME`.
@@ -41,6 +43,7 @@ python3 -m pip install --user -U pipx
 ```
 
 ### Note: Upgrading pipx from a pre-0.15.0.0 version to 0.15.0.0 or later
+
 After upgrading to pipx 0.15.0.0 or above from a pre-0.15.0.0 version, you must re-install all packages to take advantage of the new persistent pipx metadata files introduced in the 0.15.0.0 release. These metadata files store pip specification values, injected packages, any custom pip arguments, and more in each main package's venv.
 
 If you have no packages installed using the `--spec` option, and no venvs with injected packages, you can do this by running `pipx reinstall-all`.
@@ -48,13 +51,17 @@ If you have no packages installed using the `--spec` option, and no venvs with i
 If you have any packages installed using the `--spec` option or venvs with injected packages, you should reinstall packages manually using `pipx uninstall-all`, followed by `pipx install` and possibly `pipx inject`.
 
 ## Shell Completion
+
 You can easily get your shell's tab completions working by following instructions printed with this command:
+
 ```
 pipx completions
 ```
 
 ## Install pipx Development Versions
+
 New versions of pipx are published as beta or release candidates. These versions look something like `0.13.0b1`, where `b1` signifies the first beta release of version 0.13. These releases can be tested with
+
 ```
 pip install --user --upgrade --pre pipx
 ```

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,7 +9,7 @@ PYTHON_DEFAULT_VERSION = "3.10"
 DOC_DEPENDENCIES = [".", "jinja2", "mkdocs", "mkdocs-material"]
 MAN_DEPENDENCIES = [".", "argparse-manpage"]
 LINT_DEPENDENCIES = [
-    "black==21.12b0",
+    "black==22.1.0",
     "flake8==4.0.1",
     "flake8-bugbear==21.11.29",
     "mypy==0.930",

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import nox  # type: ignore
 
-PYTHON_ALL_VERSIONS = ["3.6", "3.7", "3.8", "3.9", "3.10"]
+PYTHON_ALL_VERSIONS = ["3.7", "3.8", "3.9", "3.10"]
 PYTHON_DEFAULT_VERSION = "3.10"
 DOC_DEPENDENCIES = [".", "jinja2", "mkdocs", "mkdocs-material"]
 MAN_DEPENDENCIES = [".", "argparse-manpage"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = pipx
 version = attr: pipx.version.__version__
 author = Chad Smith
-author_email = Chad Smith <grassfedcode@gmail.com>
+author_email = Chad Smith <chadsmith.software@gmail.com>
 description = Install and Run Python Applications in Isolated Environments
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -17,10 +17,10 @@ classifiers =
     Operating System :: OS Independent
     License :: OSI Approved :: MIT License
     Programming Language :: Python
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3 :: Only
 
 [options]

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -119,7 +119,6 @@ if WINDOWS:
         python_path = bin_path / "python.exe"
         return bin_path, python_path
 
-
 else:
 
     def get_venv_paths(root: Path) -> Tuple[Path, Path]:

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -119,6 +119,7 @@ if WINDOWS:
         python_path = bin_path / "python.exe"
         return bin_path, python_path
 
+
 else:
 
     def get_venv_paths(root: Path) -> Tuple[Path, Path]:
@@ -150,6 +151,7 @@ def _fix_subprocess_env(env: Dict[str, str]) -> Dict[str, str]:
     env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
     # Make sure that Python writes output in UTF-8
     env["PYTHONIOENCODING"] = "utf-8"
+    env["PYTHONLEGACYWINDOWSSTDIO"] = "utf-8"
     # Make sure we install package to venv, not userbase dir
     env["PIP_USER"] = "0"
     return env
@@ -338,7 +340,7 @@ def subprocess_post_check_handle_pip_error(
         pip_error_file = pipx.constants.pipx_log_file.parent / (
             pipx.constants.pipx_log_file.stem + "_pip_errors.log"
         )
-        with pip_error_file.open("w") as pip_error_fh:
+        with pip_error_file.open("w", encoding="utf-8") as pip_error_fh:
             print("PIP STDOUT", file=pip_error_fh)
             print("----------", file=pip_error_fh)
             if completed_process.stdout is not None:


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
* Python 3.6 has reached its [end of life](https://www.python.org/dev/peps/pep-0494/#lifespan) and is therefore being removed from CI tests
* Fix windows encoding issue when pip fails to install a package 
* Upgrade black to [first non-beta release](https://github.com/psf/black/issues/517) :tada: 
* Unit tests now pass, which unblocks other PRs from landing. Maintainers (@gaborbernat @uranusjr ): From now on let's please keep the CI tests green so we have a clear testing signal on all PRs, and don't start committing broken code on top of broken code.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
nox -s tests-3.10
```
