### PR TITLE
1.1.0 release candidate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   - id: isort
     args: ['--profile','black']
 - repo: https://github.com/psf/black
-  rev: 21.12b0
+  rev: 22.3.0
   hooks:
   - id: black
 - repo: https://gitlab.com/PyCQA/flake8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## dev
 
+## 1.1.0
+
 - Fix encoding issue on Windows when pip fails to install a package
 - Improve the behaviour of `shlex.split` on Windows, so paths on Windows can be handled peoperly when they are passed in `--pip-args`. (#794)
 - Add `pipx environment` command (#793)

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,7 +9,7 @@ PYTHON_DEFAULT_VERSION = "3.10"
 DOC_DEPENDENCIES = [".", "jinja2", "mkdocs", "mkdocs-material"]
 MAN_DEPENDENCIES = [".", "argparse-manpage"]
 LINT_DEPENDENCIES = [
-    "black==22.1.0",
+    "black==22.3.0",
     "flake8==4.0.1",
     "flake8-bugbear==21.11.29",
     "mypy==0.930",
@@ -19,12 +19,7 @@ LINT_DEPENDENCIES = [
 ]
 # Packages whose dependencies need an intact system PATH to compile
 # pytest setup clears PATH.  So pre-build some wheels to the pip cache.
-PREBUILD_PACKAGES = {
-    "all": ["jupyter==1.0.0"],
-    "macos": ["black==20.8b1"],
-    "unix": [],
-    "win": [],
-}
+PREBUILD_PACKAGES = {"all": ["jupyter==1.0.0"], "macos": [], "unix": [], "win": []}
 PIPX_TESTS_CACHE_DIR = Path("./.pipx_tests/package_cache")
 PIPX_TESTS_PACKAGE_LIST_DIR = Path("testdata/tests_packages")
 

--- a/src/pipx/version.py
+++ b/src/pipx/version.py
@@ -1,2 +1,2 @@
-__version_info__ = (1, 0, 0, 1, "dev0")
+__version_info__ = (1, 1, 0, "rc0")
 __version__ = ".".join(str(i) for i in __version_info__)


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

Update version of black due to some sort of incompatibility that has arisen:
```
ImportError: cannot import name '_unicodefun' from 'click' (/home/csmith/.cache/pre-commit/repo45x5sxzu/py_env-python3.10/lib/python3.10/site-packages/click/__init__.py)
```