### PR TITLE
Change the program name to `path/to/python -m pipx` when running as `python -m pipx`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## dev
 
+- Change the program name to `path/to/python -m pipx` when running as `python -m pipx`
+
 ## 1.1.0
 
 - Fix encoding issue on Windows when pip fails to install a package

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -39,6 +39,18 @@ def print_version() -> None:
     print(__version__)
 
 
+def prog_name() -> str:
+    try:
+        prog = os.path.basename(sys.argv[0])
+        if prog == "__main__.py":
+            return f"{sys.executable} -m pipx"
+        else:
+            return prog
+    except Exception:
+        pass
+    return "pipx"
+
+
 SPEC_HELP = textwrap.dedent(
     """\
     The package name or specific installation source passed to pip.
@@ -638,7 +650,7 @@ def get_command_parser() -> argparse.ArgumentParser:
     completer_venvs = InstalledVenvsCompleter(venv_container)
 
     parser = argparse.ArgumentParser(
-        prog="pipx",
+        prog=prog_name(),
         formatter_class=LineWrapRawTextHelpFormatter,
         description=PIPX_DESCRIPTION,
     )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -26,3 +26,16 @@ def test_version(monkeypatch, capsys):
     captured = capsys.readouterr()
     mock_exit.assert_called_with(0)
     assert main.__version__ in captured.out.strip()
+
+
+@pytest.mark.parametrize(
+    ("argv", "executable", "expected"),
+    [
+        ("/usr/bin/pipx", "", "pipx"),
+        ("__main__.py", "/usr/bin/python", "/usr/bin/python -m pipx"),
+    ],
+)
+def test_get_prog(monkeypatch, argv, executable, expected):
+    monkeypatch.setattr("pipx.main.sys.argv", [argv])
+    monkeypatch.setattr("pipx.main.sys.executable", executable)
+    assert main.prog_name() == expected

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -35,7 +35,7 @@ def test_version(monkeypatch, capsys):
         ("__main__.py", "/usr/bin/python", "/usr/bin/python -m pipx"),
     ],
 )
-def test_get_prog(monkeypatch, argv, executable, expected):
+def test_prog_name(monkeypatch, argv, executable, expected):
     monkeypatch.setattr("pipx.main.sys.argv", [argv])
     monkeypatch.setattr("pipx.main.sys.executable", executable)
     assert main.prog_name() == expected


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

Change the program name to `path/to/python -m pipx` when running as `python -m pipx`.

Closes #433

Before:

```shell
$ python -m pipx -h
usage: pipx [-h] [--version]
            {install,inject,upgrade,upgrade-all,uninstall,uninstall-all,reinstall,reinstall-all,list,run,runpip,ensurepath,environment,completions} ...
```

After:

```shell
$ python -m pipx -h
usage: /usr/local/bin/python -m pipx [-h] [--version]
                                     {install,inject,upgrade,upgrade-all,uninstall,uninstall-all,reinstall,reinstall-all,list,run,runpip,ensurepath,environment,completions}
                                     ...
```

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
$ /usr/local/bin/python -m pipx -h | grep "/usr/local/bin/python -m pipx"
```
