### PR TITLE
Add an example for installation from source with extras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## dev
 - Add `pipx uninject` command (#820)
+- [docs] Add an example for installation from source with extras
 
 ## 1.1.0
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,12 @@ pipx install git+https://github.com/psf/black.git@ce14fa8b497bae2b50ec48b3bd7022
 pipx install https://github.com/psf/black/archive/18.9b0.zip  # install a release
 ```
 
+The pip syntax with `egg` must be used when installing extras:
+
+```
+pipx install "git+https://github.com/psf/black.git#egg=black[jupyter]"
+```
+
 ### Walkthrough: Running an Application in a Temporary Virtual Environment
 
 This is an alternative to `pipx install`.


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

So far, the documentation makes no mention on how to specify an extra while installing from source, and this is a surprisingly hard information to find elsewhere. I added an example of this in the relevant section. I used quotes in the example to accommodate for `zsh`.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

The command I added in the example works on my computer:
```
❯ pipx install "git+https://github.com/psf/black.git#egg=black[jupyter]"
  installed package black 22.3.1.dev52+gfa6caa6, installed using Python 3.10.5
  These apps are now globally available
    - black
    - blackd
done! ✨ 🌟 ✨
```
