### PR TITLE
Recommend windows users use the PEP 397 python launcher

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,8 +18,8 @@ pipx ensurepath
 Otherwise, install via pip (requires pip 19.0 or later):
 
 ```
-python3 -m pip install --user pipx
-python3 -m pipx ensurepath
+py -3 -m pip install --user pipx
+py -3 -m pipx ensurepath
 ```
 
 ### Installation Options


### PR DESCRIPTION
This is a doc-only change, fixing issue #705.

The current windows install instructions won't work for windows users using python.org installed versions of python below recent versions of 3.9 and 3.10, due to https://github.com/python/cpython/issues/87915 .  According to [this discussion](https://discuss.python.org/t/microsoft-store-package-does-not-add-the-py-exe-launcher/538/11),

> Right now, approx 95% of the downloads go through [python.org](http://python.org/).

Thus, most Windows users will have access to the [PEP 397](https://peps.python.org/pep-0397/) `py` launcher tool, and will _not_ have access to `python3`.  So `py` is probably a better choice for installation instructions.