### PR TITLE
`pipx run`: reinstall the package if exceptions are raised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [docs] Add an example for installation from source with extras
 
 - Change the program name to `path/to/python -m pipx` when running as `python -m pipx`
+- `pipx run` will now reinstall the package if exceptions are raised when trying to run the app (such as missing Python interpreter symlink)
 
 ## 1.1.0
 

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -101,7 +101,24 @@ def run(
 
     if venv.has_app(app, app_filename):
         logger.info(f"Reusing cached venv {venv_dir}")
-        venv.run_app(app, app_filename, app_args)
+        try:
+            venv.run_app(app, app_filename, app_args)
+        except Exception as e:
+            logger.warning(f"Exception found when trying to run {app}: {e}")
+            logger.warning(f"Reinstalling {app}...")
+            rmdir(venv_dir)
+            _download_and_run(
+                Path(venv_dir),
+                package_or_url,
+                app,
+                app_filename,
+                app_args,
+                python,
+                pip_args,
+                venv_args,
+                use_cache,
+                verbose,
+            )
     else:
         logger.info(f"venv location is {venv_dir}")
         _download_and_run(

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -122,7 +122,7 @@ def run(
                     verbose,
                 )
             else:
-                logger.error(str(e))
+                raise PipxError(str(e))
     else:
         logger.info(f"venv location is {venv_dir}")
         _download_and_run(

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -43,6 +43,7 @@ def run(
     pypackages: bool,
     verbose: bool,
     use_cache: bool,
+    auto_reinstall: bool,
 ) -> NoReturn:
     """Installs venv to temporary dir (or reuses cache), then runs app from
     package
@@ -104,21 +105,24 @@ def run(
         try:
             venv.run_app(app, app_filename, app_args)
         except Exception as e:
-            logger.warning(f"Exception found when trying to run {app}: {e}")
-            logger.warning(f"Reinstalling {app}...")
-            rmdir(venv_dir)
-            _download_and_run(
-                Path(venv_dir),
-                package_or_url,
-                app,
-                app_filename,
-                app_args,
-                python,
-                pip_args,
-                venv_args,
-                use_cache,
-                verbose,
-            )
+            if auto_reinstall:
+                logger.warning(f"Exception found when trying to run {app}: {str(e)}")
+                logger.warning(f"Reinstalling {app}...")
+                rmdir(venv_dir)
+                _download_and_run(
+                    Path(venv_dir),
+                    package_or_url,
+                    app,
+                    app_filename,
+                    app_args,
+                    python,
+                    pip_args,
+                    venv_args,
+                    use_cache,
+                    verbose,
+                )
+            else:
+                logger.error(str(e))
     else:
         logger.info(f"venv location is {venv_dir}")
         _download_and_run(

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -197,6 +197,7 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:  # noqa: C901
             package_name = args.app_with_args[0]
 
         use_cache = not args.no_cache
+        auto_reinstall = not args.no_auto_reinstall
         commands.run(
             package_name,
             package_or_url,
@@ -207,6 +208,7 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:  # noqa: C901
             args.pypackages,
             verbose,
             use_cache,
+            auto_reinstall,
         )
         # We should never reach here because run() is NoReturn.
         return ExitCode(1)
@@ -580,6 +582,11 @@ def _add_run(subparsers: argparse._SubParsersAction) -> None:
         "--no-cache",
         action="store_true",
         help="Do not re-use cached virtual environment if it exists",
+    )
+    p.add_argument(
+        "--no-auto-reinstall",
+        action="store_true",
+        help="Do not reinstall the package automatically even if execptions are raised",
     )
     p.add_argument(
         "app_with_args",

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -189,7 +189,7 @@ def test_invalid_venv(capsys, pipx_temp_env):
     run_pipx_cli_exit(["run", "pycowsay"])
     bin_path = _get_temporary_venv_path("pycowsay", sys.executable, [], []) / "bin"
     if sys.platform.startswith("win"):
-        (bin_path / "python.exe").unlink()
+        pipx.util.safe_unlink(bin_path / "python.exe")
     else:
         (bin_path / "python").unlink()
     run_pipx_cli_exit(["run", "pycowsay"])

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -186,17 +186,14 @@ def test_package_determination(
 
 @mock.patch("os.execvpe", new=execvpe_mock)
 def test_invalid_venv(capsys, pipx_temp_env, assert_exit=None):
+    if sys.platform.startswith("win"):
+        pytest.skip()
+
     run_pipx_cli_exit(["run", "pycowsay"])
     tmp_venv_path = _get_temporary_venv_path("pycowsay", sys.executable, [], [])
-    if sys.platform.startswith("win"):
-        (tmp_venv_path / "Scripts" / "python.exe").unlink()
-    else:
-        (tmp_venv_path / "bin" / "python").unlink()
+    (tmp_venv_path / "bin" / "python").unlink()
 
-    if sys.platform.startswith("win"):
-        run_pipx_cli_exit(["run", "--no-auto-reinstall", "pycowsay"], assert_exit=1)
-    else:
-        assert run_pipx_cli(["run", "--no-auto-reinstall", "pycowsay"])
+    assert run_pipx_cli(["run", "--no-auto-reinstall", "pycowsay"])
 
     run_pipx_cli_exit(["run", "pycowsay"], assert_exit=0)
     captured = capsys.readouterr()

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -186,10 +186,14 @@ def test_package_determination(
 
 @mock.patch("os.execvpe", new=execvpe_mock)
 def test_invalid_venv(capsys, pipx_temp_env):
-    run_pipx_cli_exit(["run", "pycowsay"])
+    run_pipx_cli_exit(["run", "pycowsay", "moo"])
     bin_path = _get_temporary_venv_path("pycowsay", sys.executable, [], []) / "bin"
-    (bin_path / "python").unlink()
-    run_pipx_cli_exit(["run", "pycowsay"])
+    if sys.platform.startswith("win"):
+        (bin_path / "python.exe").unlink()
+    else:
+        (bin_path / "python").unlink()
+    run_pipx_cli_exit(["run", "pycowsay", "moo"])
     captured = capsys.readouterr()
     assert "Exception found when trying to run pycowsay" in captured.err
     assert "Reinstalling pycowsay" in captured.err
+    assert "moo" in captured.out

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -187,11 +187,16 @@ def test_package_determination(
 @mock.patch("os.execvpe", new=execvpe_mock)
 def test_invalid_venv(capsys, pipx_temp_env):
     run_pipx_cli_exit(["run", "pycowsay"])
-    bin_path = _get_temporary_venv_path("pycowsay", sys.executable, [], []) / "bin"
+    tmp_venv_path = _get_temporary_venv_path("pycowsay", sys.executable, [], [])
     if sys.platform.startswith("win"):
-        pipx.util.safe_unlink(bin_path / "python.exe")
+        (tmp_venv_path/ "Scripts" / "python.exe").unlink()
     else:
-        (bin_path / "python").unlink()
+        (tmp_venv_path / "bin" / "python").unlink()
+
+    run_pipx_cli(["run", "--no-auto-reinstall", "pycowsay"])
+    captured = capsys.readouterr()
+    assert "No such file or directory" in captured.err
+
     run_pipx_cli_exit(["run", "pycowsay"])
     captured = capsys.readouterr()
     assert "Exception found when trying to run pycowsay" in captured.err

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -185,7 +185,7 @@ def test_package_determination(
 
 
 @mock.patch("os.execvpe", new=execvpe_mock)
-def test_invalid_venv(capsys, pipx_temp_env):
+def test_invalid_venv(capsys, pipx_temp_env, assert_exit=None):
     run_pipx_cli_exit(["run", "pycowsay"])
     tmp_venv_path = _get_temporary_venv_path("pycowsay", sys.executable, [], [])
     if sys.platform.startswith("win"):
@@ -193,11 +193,9 @@ def test_invalid_venv(capsys, pipx_temp_env):
     else:
         (tmp_venv_path / "bin" / "python").unlink()
 
-    run_pipx_cli(["run", "--no-auto-reinstall", "pycowsay"])
-    captured = capsys.readouterr()
-    assert "No such file or directory" in captured.err
+    assert run_pipx_cli(["run", "--no-auto-reinstall", "pycowsay"])
 
-    run_pipx_cli_exit(["run", "pycowsay"])
+    run_pipx_cli_exit(["run", "pycowsay"], assert_exit=0)
     captured = capsys.readouterr()
     assert "Exception found when trying to run pycowsay" in captured.err
     assert "Reinstalling pycowsay" in captured.err

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -193,7 +193,10 @@ def test_invalid_venv(capsys, pipx_temp_env, assert_exit=None):
     else:
         (tmp_venv_path / "bin" / "python").unlink()
 
-    assert run_pipx_cli(["run", "--no-auto-reinstall", "pycowsay"])
+    if sys.platform.startswith("win"):
+        run_pipx_cli_exit(["run", "--no-auto-reinstall", "pycowsay"], assert_exit=1)
+    else:
+        assert run_pipx_cli(["run", "--no-auto-reinstall", "pycowsay"])
 
     run_pipx_cli_exit(["run", "pycowsay"], assert_exit=0)
     captured = capsys.readouterr()

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -186,14 +186,13 @@ def test_package_determination(
 
 @mock.patch("os.execvpe", new=execvpe_mock)
 def test_invalid_venv(capsys, pipx_temp_env):
-    run_pipx_cli_exit(["run", "pycowsay", "moo"])
+    run_pipx_cli_exit(["run", "pycowsay"])
     bin_path = _get_temporary_venv_path("pycowsay", sys.executable, [], []) / "bin"
     if sys.platform.startswith("win"):
         (bin_path / "python.exe").unlink()
     else:
         (bin_path / "python").unlink()
-    run_pipx_cli_exit(["run", "pycowsay", "moo"])
+    run_pipx_cli_exit(["run", "pycowsay"])
     captured = capsys.readouterr()
     assert "Exception found when trying to run pycowsay" in captured.err
     assert "Reinstalling pycowsay" in captured.err
-    assert "moo" in captured.out

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -189,7 +189,7 @@ def test_invalid_venv(capsys, pipx_temp_env):
     run_pipx_cli_exit(["run", "pycowsay"])
     tmp_venv_path = _get_temporary_venv_path("pycowsay", sys.executable, [], [])
     if sys.platform.startswith("win"):
-        (tmp_venv_path/ "Scripts" / "python.exe").unlink()
+        (tmp_venv_path / "Scripts" / "python.exe").unlink()
     else:
         (tmp_venv_path / "bin" / "python").unlink()
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -185,7 +185,7 @@ def test_package_determination(
 
 
 @mock.patch("os.execvpe", new=execvpe_mock)
-def test_invalid_venv(capsys, pipx_temp_env, assert_exit=None):
+def test_invalid_venv(capsys, pipx_temp_env):
     if sys.platform.startswith("win"):
         pytest.skip()
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

`pipx run` will now reinstall the package if exceptions are raised when trying to run the app (such as missing Python interpreter symlink).

Closes #449 

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
pipx run pycowsay
```

Then remove the symlink to the Python interpreter in the temporary venv of pycowsay.

And run `pipx run pycowsay` again. It will now fix the venv instead of raising error.
