### PR TITLE
`pipx install`: emit a warning when `--force` and `--python` were passed at the same time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [docs] Add an example for installation from source with extras
 
 - Change the program name to `path/to/python -m pipx` when running as `python -m pipx`
+- `pipx install`: emit a warning when `--force` and `--python` were passed at the same time
 
 ## 1.1.0
 

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 from pipx import constants
 from pipx.commands.common import package_name_from_spec, run_post_install_actions
 from pipx.constants import EXIT_CODE_INSTALL_VENV_EXISTS, EXIT_CODE_OK, ExitCode
+from pipx.interpreter import DEFAULT_PYTHON
 from pipx.util import pipx_wrap
 from pipx.venv import Venv, VenvContainer
 
@@ -13,18 +14,32 @@ def install(
     package_name: Optional[str],
     package_spec: str,
     local_bin_dir: Path,
-    python: str,
+    python: Optional[str],
     pip_args: List[str],
     venv_args: List[str],
     verbose: bool,
     *,
     force: bool,
+    reinstall: bool,
     include_dependencies: bool,
     suffix: str = "",
 ) -> ExitCode:
     """Returns pipx exit code."""
     # package_spec is anything pip-installable, including package_name, vcs spec,
     #   zip file, or tar.gz file.
+
+    if not reinstall and force and python is not None:
+        print(
+            pipx_wrap(
+                f"""
+                --python is ignored when --force is passed.
+                If you want to reinstall {package_spec} with {python},
+                run `pipx reinstall {package_spec} --python {python}` instead.
+                """
+            )
+        )
+
+    python = python or DEFAULT_PYTHON
 
     if package_name is None:
         package_name = package_name_from_spec(

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -61,6 +61,7 @@ def reinstall(
         venv.pipx_metadata.venv_args,
         verbose,
         force=True,
+        reinstall=True,
         include_dependencies=venv.pipx_metadata.main_package.include_dependencies,
         suffix=venv.pipx_metadata.main_package.suffix,
     )

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -221,6 +221,7 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:  # noqa: C901
             venv_args,
             verbose,
             force=args.force,
+            reinstall=False,
             include_dependencies=args.include_deps,
             suffix=args.suffix,
         )
@@ -352,7 +353,7 @@ def _add_install(subparsers: argparse._SubParsersAction) -> None:
     )
     p.add_argument(
         "--python",
-        default=DEFAULT_PYTHON,
+        # Don't pass a default Python here so we know whether --python and --force were passed at the same time
         help=(
             "The Python executable used to create the Virtual Environment and run the "
             "associated app/apps. Must be v3.6+."

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -252,3 +252,13 @@ def test_install_pip_failure(pipx_temp_env, capsys):
     assert Path(pip_log_file_match.group(1)).exists()
 
     assert re.search(r"pip (failed|seemed to fail) to build package", captured.err)
+
+
+def test_passed_python_and_force_flag_warning(pipx_temp_env, capsys):
+    assert not run_pipx_cli(["install", "--python", sys.executable, "--force", "black"])
+    captured = capsys.readouterr()
+    assert "--python is ignored when --force is passed." in captured.out
+
+    assert not run_pipx_cli(["install", "pycowsay", "--force"])
+    captured = capsys.readouterr()
+    assert "--python is ignored when --force is passed." not in captured.out


### PR DESCRIPTION

<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

For `pipx install`, emit a warning when `--force` and `--python` were passed at the same time.
Closes #447 

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
pipx install black --force --python python3.10
```
