### PR TITLE
feat(install): add support for pre-injected packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Move `pipx` paths to ensure compatibility with the platform-specific user directories
 - [docs] Add more examples for `pipx run`
 - [docs] Add subsection to make README easier to read
+- Add `pipx install --preinstall` to support preinstalling build requirements
 
 ## 1.2.0
 

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -20,6 +20,7 @@ def install(
     *,
     force: bool,
     include_dependencies: bool,
+    preinstall_packages: Optional[List[str]],
     suffix: str = "",
 ) -> ExitCode:
     """Returns pipx exit code."""
@@ -58,6 +59,11 @@ def install(
 
     try:
         venv.create_venv(venv_args, pip_args)
+        for dep in preinstall_packages or []:
+            dep_name = package_name_from_spec(
+                dep, python, pip_args=pip_args, verbose=verbose
+            )
+            venv.upgrade_package_no_metadata(dep_name, [])
         venv.install_package(
             package_name=package_name,
             package_or_url=package_spec,

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -70,6 +70,7 @@ def reinstall(
         verbose,
         force=True,
         include_dependencies=venv.pipx_metadata.main_package.include_dependencies,
+        preinstall_packages=[],
         suffix=venv.pipx_metadata.main_package.suffix,
     )
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -213,6 +213,7 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:  # noqa: C901
             verbose,
             force=args.force,
             include_dependencies=args.include_deps,
+            preinstall_packages=args.preinstall,
             suffix=args.suffix,
         )
     elif args.command == "inject":
@@ -348,6 +349,14 @@ def _add_install(subparsers: argparse._SubParsersAction) -> None:
             "Python to install with. Possible values can be the executable name (python3.11), "
             "the version to pass to py launcher (3.11), or the full path to the executable."
             f"Requires Python {MINIMUM_PYTHON_VERSION} or above."
+        ),
+    )
+    p.add_argument(
+        "--preinstall",
+        action="append",
+        help=(
+            "Optional packages to be installed into the Virtual Environment before "
+            "installing the main package."
         ),
     )
     add_pip_venv_args(p)

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -201,7 +201,7 @@ class Venv:
         else:
             # TODO: setuptools and wheel? Original code didn't bother
             # but shared libs code does.
-            self._upgrade_package_no_metadata("pip", pip_args)
+            self.upgrade_package_no_metadata("pip", pip_args)
 
     def uninstall_package(self, package: str, was_injected: bool = False):
         try:
@@ -421,7 +421,7 @@ class Venv:
             return True
         return (self.bin_path / filename).is_file()
 
-    def _upgrade_package_no_metadata(
+    def upgrade_package_no_metadata(
         self, package_name: str, pip_args: List[str]
     ) -> None:
         with animate(


### PR DESCRIPTION
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

Adds support for injecting packages before performing the main package installation. This allows for keyring support via the following, for example for using the Google Artifact Registry:

```
pipx install \
  --index-url=https://us-python.pkg.dev/my-project/my-index/simple \
  --inject=keyrings.google-artifactregistry-auth \
  my-private-package
```

This should allow users to install packages with arbitrary additional third-party requirements. This is important especially in cases where those third party requirements are not themselves build dependencies which could be specified via PEP 517: for example, at my company we have a private PyPI index hosted on Google's Artifact Registry which we must install from. The packages themselves should not specify the artifact registry credential helper as a build dependencies, as the packages themselves may be hosted on PyPI itself, this private index, or any other location. Rather, users fetching from that index must be able to specify "...and here's how to do it".

The current best approach I could find through `pipx` is to make use of `--system-site-packages` and to install these credential helpers globally. That has a few downsides I would like to avoid, though:

* requires global installations -- what if we want different versions of our credential helpers, or if their dependencies conflict with other global installs?
* requires giving projects access to site packages -- this can have plenty of other side-effects which we may not want!

Open question:

* the `--inject` flag here has somewhat different semantics than other uses of the "inject" term in pipx. Would renaming to, eg. `--pre-inject` be clearer?

## Test plan
Tested by running the following for several packages hosted on my company's private index. I don't have a great test path to offer folks who don't have access to a private index for testing against. I might be able to look into spinning up a test GCP project and giving a maintainer adhoc access via a Google account? Alternatively, this should support other private indexes such as AWS CodeArtifact, if anyone has access to it for testing!

```
venv/bin/pipx install \
    --extra-index-url=\https://us-python.pkg.dev/PACKAGE_INDEX/simple\ \
    --inject='keyrings.google-artifactregistry-auth' \
    PACKAGE_NAME

venv/bin/pipx install \
    --pip-args='--extra-index-url=https://us-python.pkg.dev/PACKAGE_INDEX/simple' \
    --inject='keyrings.google-artifactregistry-auth' \
    PACKAGE_NAME
```
