### PR TITLE
Warn users if '#egg' is detected in package

### DIFF
--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -182,6 +182,17 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:  # noqa: C901
     if "skip" in args:
         skip_list = [canonicalize_name(x) for x in args.skip]
 
+    if "package_spec" in args and "#egg" in args.package_spec:
+        logger.warning(
+            pipx_wrap(
+                f"""
+                '#egg' fragment in package ({args.package_spec})
+                This is obsolete but should not impact installation.
+                """,
+                subsequent_indent=" " * 4,
+            )
+        )
+
     if args.command == "run":
         package_or_url = (
             args.spec


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes
Displays a warning if '#egg' is in package_spec. Closes #875 

This is my first contribution here, let me know if there's any changes that should be made.

Thanks,
## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
