### PR TITLE
Use venv API to get venv paths

### DIFF
--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -24,7 +24,7 @@ SHARED_LIBS_MAX_AGE_SEC = datetime.timedelta(days=30).total_seconds()
 class _SharedLibs:
     def __init__(self) -> None:
         self.root = constants.PIPX_SHARED_LIBS
-        self.bin_path, self.python_path = get_venv_paths(self.root)
+        self.bin_path, self.python_path = get_venv_paths(DEFAULT_PYTHON, self.root)
         self.pip_path = self.bin_path / ("pip" if not WINDOWS else "pip.exe")
         # i.e. bin_path is ~/.local/pipx/shared/bin
         # i.e. python_path is ~/.local/pipx/shared/python

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -116,7 +116,7 @@ def get_venv_paths(python: str, root: Path) -> Tuple[Path, Path]:
     command_str = textwrap.dedent(
         f"""
         import venv
-        root_paths = venv.EnvBuilder().ensure_directories("{str(root)}")
+        root_paths = venv.EnvBuilder().ensure_directories(r"{str(root)}")
         print(root_paths.bin_path + ";" + root_paths.env_exe)
         """
     )

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -116,8 +116,7 @@ def get_venv_paths(python: str, root: Path) -> Tuple[Path, Path]:
     command_str = textwrap.dedent(
         f"""
         import venv
-
-        root_paths = venv.EnvBuilder().ensure_directories("{root}")
+        root_paths = venv.EnvBuilder().ensure_directories("{str(root)}")
         print(root_paths.bin_path + ";" + root_paths.env_exe)
         """
     )

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -112,7 +112,7 @@ def run_pypackage_bin(bin_path: Path, args: List[str]) -> NoReturn:
     )
 
 
-def get_venv_paths(python: Path, root: Path) -> Tuple[Path, Path]:
+def get_venv_paths(python: str, root: Path) -> Tuple[Path, Path]:
     command_str = textwrap.dedent(
         f"""
         import venv
@@ -130,20 +130,9 @@ def get_venv_paths(python: Path, root: Path) -> Tuple[Path, Path]:
         .stdout.strip()
         .split(";")
     )
-    # venv is not installed, so we can't use the above command to get the paths.
-    if "No module named" in output:
-        if WINDOWS:
-            bin_path = root / "Scripts"
-            python_path = bin_path / "python.exe"
-            return bin_path, python_path
-        else:
-            bin_path = root / "bin"
-            python_path = bin_path / "python"
-            return bin_path, python_path
-    else:
-        bin_path = Path(output[0])
-        python_path = Path(output[1])
-        return bin_path, python_path
+    bin_path = Path(output[0])
+    python_path = Path(output[1])
+    return bin_path, python_path
 
 
 def get_site_packages(python: Path) -> Path:

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -89,7 +89,7 @@ class Venv:
     ) -> None:
         self.root = path
         self.python = python
-        self.bin_path, self.python_path = get_venv_paths(self.root)
+        self.bin_path, self.python_path = get_venv_paths(python, self.root)
         self.pipx_metadata = PipxMetadata(venv_dir=path)
         self.verbose = verbose
         self.do_animation = not verbose

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -9,7 +9,7 @@ from unittest import mock
 from packaging.utils import canonicalize_name
 
 from package_info import PKG
-from pipx import constants, main, pipx_metadata_file, util
+from pipx import constants, main, pipx_metadata_file, util, interpreter
 
 WIN = sys.platform.startswith("win")
 
@@ -168,7 +168,9 @@ def assert_package_metadata(test_metadata, ref_metadata):
 
 
 def remove_venv_interpreter(venv_name):
-    _, venv_python_path = util.get_venv_paths(constants.PIPX_LOCAL_VENVS / venv_name)
+    _, venv_python_path = util.get_venv_paths(
+        interpreter.DEFAULT_PYTHON, constants.PIPX_LOCAL_VENVS / venv_name
+    )
     assert venv_python_path.is_file()
     venv_python_path.unlink()
     assert not venv_python_path.is_file()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -9,7 +9,7 @@ from unittest import mock
 from packaging.utils import canonicalize_name
 
 from package_info import PKG
-from pipx import constants, main, pipx_metadata_file, util, interpreter
+from pipx import constants, interpreter, main, pipx_metadata_file, util
 
 WIN = sys.platform.startswith("win")
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes

Use venv API to get venv paths.

Closes #701 

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
pipx install black --verbose
```
