### PR TITLE
Add support for virtualenv

### DIFF
--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -41,12 +41,27 @@ class _SharedLibs:
 
     def create(self, verbose: bool = False) -> None:
         if not self.is_valid:
-            with animate("creating shared libraries", not verbose):
-                create_process = run_subprocess(
-                    [DEFAULT_PYTHON, "-m", "venv", "--clear", self.root]
-                )
-            subprocess_post_check(create_process)
-
+            try:
+                with animate("creating shared libraries using venv", not verbose):
+                    create_process = run_subprocess(
+                        [DEFAULT_PYTHON, "-m", "venv", "--clear", self.root]
+                    )
+                subprocess_post_check(create_process)
+            except Exception:
+                # try to create shared libs using virtualenv if venv is not available
+                with animate("creating shared libraries using virtualenv", not verbose):
+                    create_process = run_subprocess(
+                        [
+                            DEFAULT_PYTHON,
+                            "-m",
+                            "virtualenv",
+                            "--clear",
+                            "--creator",
+                            "venv",
+                            self.root,
+                        ]
+                    )
+                subprocess_post_check(create_process)
             # ignore installed packages to ensure no unexpected patches from the OS vendor
             # are used
             self.upgrade(pip_args=["--force-reinstall"], verbose=verbose)

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -161,7 +161,7 @@ class Venv:
         try:
             with animate("creating virtual environment using venv", self.do_animation):
                 venv_process = run_subprocess(cmd + venv_args + [str(self.root)])
-                subprocess_post_check(venv_process)
+            subprocess_post_check(venv_process)
         except Exception:
             with animate(
                 "creating virtual environment using virtualenv", self.do_animation
@@ -175,7 +175,7 @@ class Venv:
                     "--without-pip",
                 ]
                 virtualenv_process = run_subprocess(cmd + venv_args + [str(self.root)])
-                subprocess_post_check(virtualenv_process)
+            subprocess_post_check(virtualenv_process)
 
         shared_libs.create(self.verbose)
         pipx_pth = get_site_packages(self.python_path) / PIPX_SHARED_PTH
@@ -422,7 +422,7 @@ class Venv:
             self.do_animation,
         ):
             pip_process = self._run_pip(
-                ["install"] + pip_args + ["--upgrade", package_name]
+                ["instal"] + pip_args + ["--upgrade", package_name]
             )
         subprocess_post_check(pip_process)
 

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -422,7 +422,7 @@ class Venv:
             self.do_animation,
         ):
             pip_process = self._run_pip(
-                ["instal"] + pip_args + ["--upgrade", package_name]
+                ["install"] + pip_args + ["--upgrade", package_name]
             )
         subprocess_post_check(pip_process)
 

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -157,7 +157,7 @@ class Venv:
             return self.pipx_metadata.main_package.package
 
     def create_venv(self, venv_args: List[str], pip_args: List[str]) -> None:
-        with animate("creating virtual environment using venv", self.do_animation):
+        with animate("creating virtual environment", self.do_animation):
             cmd = [self.python, "-m", "venv", "--without-pip"]
             try:
                 venv_process = run_subprocess(cmd + venv_args + [str(self.root)])

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -157,13 +157,14 @@ class Venv:
             return self.pipx_metadata.main_package.package
 
     def create_venv(self, venv_args: List[str], pip_args: List[str]) -> None:
-        with animate("creating virtual environment", self.do_animation):
-            cmd = [self.python, "-m", "venv", "--without-pip"]
-            try:
+        cmd = [self.python, "-m", "venv", "--without-pip"]
+        try:
+            with animate("creating virtual environment using venv", self.do_animation):
                 venv_process = run_subprocess(cmd + venv_args + [str(self.root)])
                 subprocess_post_check(venv_process)
-            except Exception:
-                cmd = [self.python, "-m", "virtualenv", "--without-pip"]
+        except Exception:
+            with animate("creating virtual environment using virtualenv", self.do_animation):
+                cmd = [self.python, "-m", "virtualenv", "--creator", "venv", "--without-pip"]
                 virtualenv_process = run_subprocess(cmd + venv_args + [str(self.root)])
                 subprocess_post_check(virtualenv_process)
 

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -163,8 +163,17 @@ class Venv:
                 venv_process = run_subprocess(cmd + venv_args + [str(self.root)])
                 subprocess_post_check(venv_process)
         except Exception:
-            with animate("creating virtual environment using virtualenv", self.do_animation):
-                cmd = [self.python, "-m", "virtualenv", "--creator", "venv", "--without-pip"]
+            with animate(
+                "creating virtual environment using virtualenv", self.do_animation
+            ):
+                cmd = [
+                    self.python,
+                    "-m",
+                    "virtualenv",
+                    "--creator",
+                    "venv",
+                    "--without-pip",
+                ]
                 virtualenv_process = run_subprocess(cmd + venv_args + [str(self.root)])
                 subprocess_post_check(virtualenv_process)
 

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -157,10 +157,15 @@ class Venv:
             return self.pipx_metadata.main_package.package
 
     def create_venv(self, venv_args: List[str], pip_args: List[str]) -> None:
-        with animate("creating virtual environment", self.do_animation):
+        with animate("creating virtual environment using venv", self.do_animation):
             cmd = [self.python, "-m", "venv", "--without-pip"]
-            venv_process = run_subprocess(cmd + venv_args + [str(self.root)])
-        subprocess_post_check(venv_process)
+            try:
+                venv_process = run_subprocess(cmd + venv_args + [str(self.root)])
+                subprocess_post_check(venv_process)
+            except Exception:
+                cmd = [self.python, "-m", "virtualenv", "--without-pip"]
+                virtualenv_process = run_subprocess(cmd + venv_args + [str(self.root)])
+                subprocess_post_check(virtualenv_process)
 
         shared_libs.create(self.verbose)
         pipx_pth = get_site_packages(self.python_path) / PIPX_SHARED_PTH


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes

Use virtualenv to create virtual environment when venv is not available.

Closes #853

TODO:

* [ ] Allow users to pass a flag (`--use-virtualenv`) for using virtualenv to create the virtual environment.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
pipx install black --verbose
```
