### PR TITLE
Remove extra trailing quote from exception message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Ship a [zipapp](https://docs.python.org/3/library/zipapp.html) of pipx
 
 - Change the program name to `path/to/python -m pipx` when running as `python -m pipx`
+- Remove extra trailing quote from exception message
 
 ## 1.1.0
 

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -380,7 +380,7 @@ def run_post_install_actions(
                 with '--include-deps' to include apps of dependent packages,
                 which are listed above. If you are attempting to install a
                 library, pipx should not be used. Consider using pip or a
-                similar tool instead."
+                similar tool instead.
                 """
             )
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

Remove an extra trailing quote in the exception raised when a package is installed which does not contain an application but has dependencies that do.

## Test plan

Tested by running `pipx install scikit-learn`.

Before:
```
% pipx install scikit-learn
Note: Dependent package 'numpy' contains 3 apps
  - f2py
  - f2py3
  - f2py3.10

No apps associated with package scikit-learn. Try again with '--include-deps' to include apps of dependent packages, which are listed above.
If you are attempting to install a library, pipx should not be used. Consider using pip or a similar tool instead."
```
After:
```
% pipx install scikit-learn
Note: Dependent package 'numpy' contains 3 apps
  - f2py
  - f2py3
  - f2py3.10

No apps associated with package scikit-learn. Try again with '--include-deps' to include apps of dependent packages, which are listed above.
If you are attempting to install a library, pipx should not be used. Consider using pip or a similar tool instead.
```
