### PR TITLE
Fix encodingwarning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - Change the program name to `path/to/python -m pipx` when running as `python -m pipx`
 - Remove extra trailing quote from exception message
+- Fix EncodingWarning in `pipx_metadata_file`.
 
 ## 1.1.0
 

--- a/src/pipx/pipx_metadata_file.py
+++ b/src/pipx/pipx_metadata_file.py
@@ -123,7 +123,9 @@ class PipxMetadata:
     def write(self) -> None:
         self._validate_before_write()
         try:
-            with open(self.venv_dir / PIPX_INFO_FILENAME, "w") as pipx_metadata_fh:
+            with open(
+                self.venv_dir / PIPX_INFO_FILENAME, "w", encoding="utf-8"
+            ) as pipx_metadata_fh:
                 json.dump(
                     self.to_dict(),
                     pipx_metadata_fh,
@@ -146,7 +148,7 @@ class PipxMetadata:
 
     def read(self, verbose: bool = False) -> None:
         try:
-            with open(self.venv_dir / PIPX_INFO_FILENAME, "r") as pipx_metadata_fh:
+            with open(self.venv_dir / PIPX_INFO_FILENAME, "rb") as pipx_metadata_fh:
                 self.from_dict(
                     json.load(pipx_metadata_fh, object_hook=_json_decoder_object_hook)
                 )


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

Fix EncodingWarning like this.

```
  File "/opt/homebrew/Cellar/pipx/1.1.0/libexec/lib/python3.11/site-packages/pipx/pipx_metadata_file.py", line 126, in write
    with open(self.venv_dir / PIPX_INFO_FILENAME, "w") as pipx_metadata_fh:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
EncodingWarning: 'encoding' argument not specified
```

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
