### PR TITLE
Add detection logic for other mingw MSYS2 platforms 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## dev
+
 - Add test for pip module in `pipx reinstall` to fix an issue with `pipx reinstall-all` (#935)
 - Add `pipx uninject` command (#820)
 - [docs] Fix `pipx run` examples and update Python versions used by `pipx install` examples
@@ -7,7 +8,7 @@
 - Ship a [zipapp](https://docs.python.org/3/library/zipapp.html) of pipx
 
 - Change the program name to `path/to/python -m pipx` when running as `python -m pipx`
-- Improve the detection logic for MSYS2 to avoid entering infinite loop (#908)
+- Improve the detection logic for MSYS2 to avoid entering infinite loop (#908) (#938)
 - Remove extra trailing quote from exception message
 - Fix EncodingWarning in `pipx_metadata_file`.
 

--- a/src/pipx/constants.py
+++ b/src/pipx/constants.py
@@ -40,7 +40,7 @@ def is_windows() -> bool:
 
 
 def is_mingw() -> bool:
-    return sysconfig.get_platform() == "mingw"
+    return sysconfig.get_platform().startswith("mingw")
 
 
 WINDOWS: bool = is_windows()


### PR DESCRIPTION
The logic check if the platform begins with "mingw". This is also suggested on [MSYS2](https://www.msys2.org/docs/python/)

The previous logic did not work for the 'UCRT64' platform.

<!-- add an 'x' in the brackets below -->
* [X] I have added (updated) an entry to `docs/changelog.md`

## Summary of changes
Followed the suggestion on [MSYS2](https://www.msys2.org/docs/python/) for detecting the platform of MSYS2

check if the platform begins with "mingw"

closes #937 

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running

```
$ python src/pipx install pycowsay --verbose
```
# command(s) to exercise these changes
The result should be that pycowsay is installed

```
  installed package pycowsay 0.0.0.1, installed using Python 3.10.9
  These apps are now globally available
    - pycowsay.exe
done! 
```