### PR TITLE
Fix argparse-manpage dependency for Python 3.12+

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -7,7 +7,7 @@ import nox  # type: ignore
 PYTHON_ALL_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 PYTHON_DEFAULT_VERSION = "3.11"
 DOC_DEPENDENCIES = [".", "jinja2", "mkdocs", "mkdocs-material"]
-MAN_DEPENDENCIES = [".", "argparse-manpage"]
+MAN_DEPENDENCIES = [".", "argparse-manpage[setuptools]"]
 LINT_DEPENDENCIES = [
     "black==22.8.0",
     "flake8==4.0.1",


### PR DESCRIPTION
To use the build_manpages tool on Python 3.12+, argparse-manpage needs setuptools; depend on argparse-manpage[setuptools] to ensure this keeps working.

See: https://github.com/praiskup/argparse-manpage/issues/63

<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```

I haven’t had much luck demonstrating the problem via `nox`—I guess something is already pulling in `setuptools`—but the linked issue shows why this is technically necessary, and you can easily confirm that `nox -s build_man` still works after this PR, so it hasn’t broken anything.

See also the downstream Fedora bug: https://bugzilla.redhat.com/show_bug.cgi?id=2175193