### PR TITLE
fix: same interpreter from venv to get pkg name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## dev
 
 - Fallback to user's log path if the default log path (`$PIPX_HOME/logs`) is not writable to aid with pipx being used for multi-user (e.g. system-wide) installs of applications
+- Fix wrong interpreter usage when injecting local pip-installable dependencies into venvs
 
 ## 1.2.0
 

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 from typing import List, Optional
@@ -47,7 +48,10 @@ def inject_dep(
     #   zip file, or tar.gz file.
     if package_name is None:
         package_name = package_name_from_spec(
-            package_spec, str(venv.python_path), pip_args=pip_args, verbose=verbose
+            package_spec,
+            os.fspath(venv.python_path),
+            pip_args=pip_args,
+            verbose=verbose,
         )
 
     venv.install_package(

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -47,7 +47,7 @@ def inject_dep(
     #   zip file, or tar.gz file.
     if package_name is None:
         package_name = package_name_from_spec(
-            package_spec, venv.python_path, pip_args=pip_args, verbose=verbose
+            package_spec, str(venv.python_path), pip_args=pip_args, verbose=verbose
         )
 
     venv.install_package(

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -47,7 +47,7 @@ def inject_dep(
     #   zip file, or tar.gz file.
     if package_name is None:
         package_name = package_name_from_spec(
-            package_spec, venv.python, pip_args=pip_args, verbose=verbose
+            package_spec, venv.python_path, pip_args=pip_args, verbose=verbose
         )
 
     venv.install_package(


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Fixes #956 
- Use venv-specific interpreter for package name extraction when injecting local "pip-installable" packages

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running the following locally
```shell
pipx install jupyterlab --python python3.8

# The package must be any wheel with interpreter constraints
# that are compatible with the venv's in which it's going to be injected
# but doesn't match pipx's default interpreter
pipx inject jupyterlab package-1.0.0-py3-none-any.whl
```
