### PR TITLE
Override shared libs directory when installing/running pip/wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## dev
 
+- Ignore shared libs directory on installing/running pip/wheel
 - Support including requirements in scripts run using `pipx run` (#916)
 - Pass `pip_args` to `shared_libs.upgrade()`
 - Fallback to user's log path if the default log path (`$PIPX_HOME/logs`) is not writable to aid with pipx being used for multi-user (e.g. system-wide) installs of applications

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -30,6 +30,12 @@ def install(
         package_name = package_name_from_spec(
             package_spec, python, pip_args=pip_args, verbose=verbose
         )
+
+    override_shared = False
+
+    if package_name in ["pip", "wheel"]:
+        override_shared = True
+
     if venv_dir is None:
         venv_container = VenvContainer(constants.PIPX_LOCAL_VENVS)
         venv_dir = venv_container.get_venv_dir(f"{package_name}{suffix}")
@@ -56,7 +62,7 @@ def install(
             return EXIT_CODE_INSTALL_VENV_EXISTS
 
     try:
-        venv.create_venv(venv_args, pip_args)
+        venv.create_venv(venv_args, pip_args, override_shared)
         venv.install_package(
             package_name=package_name,
             package_or_url=package_spec,

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -179,7 +179,6 @@ def run(
     """Installs venv to temporary dir (or reuses cache), then runs app from
     package
     """
-
     package_or_url = spec if spec is not None else app
     # For any package, we need to just use the name
     try:
@@ -223,7 +222,6 @@ def _download_and_run(
     verbose: bool,
 ) -> NoReturn:
     venv = Venv(venv_dir, python=python, verbose=verbose)
-    venv.create_venv(venv_args, pip_args)
 
     if venv.pipx_metadata.main_package.package is not None:
         package_name = venv.pipx_metadata.main_package.package
@@ -231,6 +229,13 @@ def _download_and_run(
         package_name = package_name_from_spec(
             package_or_url, python, pip_args=pip_args, verbose=verbose
         )
+
+    override_shared = False
+
+    if package_name in ["pip", "wheel"]:
+        override_shared = True
+
+    venv.create_venv(venv_args, pip_args, override_shared)
 
     venv.install_package(
         package_name=package_name,

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -156,24 +156,26 @@ class Venv:
         else:
             return self.pipx_metadata.main_package.package
 
-    def create_venv(self, venv_args: List[str], pip_args: List[str]) -> None:
+    def create_venv(self, venv_args: List[str], pip_args: List[str], override_shared: bool = False) -> None:
         with animate("creating virtual environment", self.do_animation):
-            cmd = [self.python, "-m", "venv", "--without-pip"]
+            cmd = [self.python, "-m", "venv"]
+            if not override_shared:
+                cmd.append("--without-pip")
             venv_process = run_subprocess(cmd + venv_args + [str(self.root)])
         subprocess_post_check(venv_process)
-
         shared_libs.create(self.verbose)
-        pipx_pth = get_site_packages(self.python_path) / PIPX_SHARED_PTH
-        # write path pointing to the shared libs site-packages directory
-        # example pipx_pth location:
-        #   ~/.local/pipx/venvs/black/lib/python3.8/site-packages/pipx_shared.pth
-        # example shared_libs.site_packages location:
-        #   ~/.local/pipx/shared/lib/python3.6/site-packages
-        #
-        # https://docs.python.org/3/library/site.html
-        # A path configuration file is a file whose name has the form 'name.pth'.
-        # its contents are additional items (one per line) to be added to sys.path
-        pipx_pth.write_text(f"{shared_libs.site_packages}\n", encoding="utf-8")
+        if not override_shared:
+            pipx_pth = get_site_packages(self.python_path) / PIPX_SHARED_PTH
+            # write path pointing to the shared libs site-packages directory
+            # example pipx_pth location:
+            #   ~/.local/pipx/venvs/black/lib/python3.8/site-packages/pipx_shared.pth
+            # example shared_libs.site_packages location:
+            #   ~/.local/pipx/shared/lib/python3.6/site-packages
+            #
+            # https://docs.python.org/3/library/site.html
+            # A path configuration file is a file whose name has the form 'name.pth'.
+            # its contents are additional items (one per line) to be added to sys.path
+            pipx_pth.write_text(f"{shared_libs.site_packages}\n", encoding="utf-8")
 
         self.pipx_metadata.venv_args = venv_args
         self.pipx_metadata.python_version = self.get_python_version()

--- a/src/pipx/venv_inspect.py
+++ b/src/pipx/venv_inspect.py
@@ -69,6 +69,7 @@ def get_apps(dist: metadata.Distribution, bin_path: Path) -> List[str]:
 
     sections = {"console_scripts", "gui_scripts"}
     # "entry_points" entry in setup.py are found here
+    # print([x for x in bin_path.iterdir()])
     for ep in dist.entry_points:
         if ep.group not in sections:
             continue

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -71,6 +71,16 @@ def test_install_tricky_packages(
     install_package(capsys, pipx_temp_env, caplog, package_spec, package_name)
 
 
+@pytest.mark.parametrize(
+    "package_name, package_spec",
+    [("wheel", "wheel")]
+)
+def test_run_shared_lib(
+    capsys, pipx_temp_env, caplog, package_name, package_spec
+):
+    install_package(capsys, pipx_temp_env, caplog, package_spec, package_name)
+
+
 # TODO: Add git+... spec when git is in binpath of tests (Issue #303)
 @pytest.mark.parametrize(
     "package_name, package_spec",

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -54,6 +54,16 @@ def test_simple_run(pipx_temp_env, monkeypatch, capsys, package_name):
     assert "Download the latest version of a package" not in captured.out
 
 
+@pytest.mark.parametrize(
+    "package_name", ["wheel"]
+)
+@mock.patch("os.execvpe", new=execvpe_mock)
+def test_run_shared_lib(pipx_temp_env, monkeypatch, capfd, package_name):
+    run_pipx_cli_exit(["run", package_name, "--help"])
+    captured = capfd.readouterr()
+    assert f"usage: {package_name}" in captured.out
+
+
 @mock.patch("os.execvpe", new=execvpe_mock)
 def test_cache(pipx_temp_env, monkeypatch, capsys, caplog):
     run_pipx_cli_exit(["run", "pycowsay", "cowsay", "args"])


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

Fixes #951 

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
python src/pipx run wheel
python src/pipx install wheel
nox -s tests-3.8
```
