### PR TITLE
Support pre-commit to run arbitrary entrypoints even if they don't have native pre-commit support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist
 activate
 __pypackages__
 venv
+.venv
 .DS_Store
 .tox
 __pycache__

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+-   id: pipx
+    name: pipx
+    entry: pipx
+    require_serial: true
+    language: python
+    minimum_pre_commit_version: '2.9.2'

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 -   id: pipx
     name: pipx
-    entry: pipx
+    entry: pipx run
     require_serial: true
     language: python
     minimum_pre_commit_version: '2.9.2'

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,11 +1,6 @@
 -   id: pipx
     name: pipx
     entry: pipx run
-    language: python
-    minimum_pre_commit_version: '2.9.2'
--   id: pipx-serial
-    name: pipx-serial
-    entry: pipx run
     require_serial: true
     language: python
     minimum_pre_commit_version: '2.9.2'

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,11 @@
 -   id: pipx
     name: pipx
     entry: pipx run
+    language: python
+    minimum_pre_commit_version: '2.9.2'
+-   id: pipx-serial
+    name: pipx-serial
+    entry: pipx run
     require_serial: true
     language: python
     minimum_pre_commit_version: '2.9.2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Pass `pip_args` to `shared_libs.upgrade()`
 - Fallback to user's log path if the default log path (`$PIPX_HOME/logs`) is not writable to aid with pipx being used for multi-user (e.g. system-wide) installs of applications
 - Fix wrong interpreter usage when injecting local pip-installable dependencies into venvs
+- add pre-commit hook support
 
 ## 1.2.0
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ python pipx.pyz ensurepath
 
 ### Use with pre-commit
 
-Pipx [has pre-commit support](docs/installation.md#pre-commit).
+pipx [has pre-commit support](docs/installation.md#pre-commit).
 
 ### Shell completions
 

--- a/README.md
+++ b/README.md
@@ -80,18 +80,10 @@ python pipx.pyz ensurepath
 
 ### Use with pre-commit
 
-Pipx has pre-commit support. This allows for running any package that can be installed with pipx even if it doesn't support pre-commit natively, or to install the package as a wheel from pypi instead of building from source control.
-
-```yaml
-- repo: https://github.com/pypa/pipx
-  rev: 1.3.0
-  hooks:
-  - id: pipx
-    alias: yapf
-    name: yapf
-    args: ['run', 'yapf', '-i']
-    types: ['python']
-```
+Pipx [has pre-commit support](docs/installation.md#pre-commit). This lets you:
+* Run any package that can be installed with `pipx run` even it the application doesn't support pre-commit natively.
+* Install an application's prebuilt wheel instead of building it from source.
+* Install an application from an arbitrary pypi repository (e.g. artifactory)
 
 ### Shell completions
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,21 @@ The zipapp can be downloaded from [Github releases](https://github.com/pypa/pipx
 python pipx.pyz ensurepath
 ```
 
+### Use with pre-commit
+
+Pipx has pre-commit support. This allows for running any package that can be installed with pipx even if it doesn't support pre-commit natively, or to install the package as a wheel from pypi instead of building from source control.
+
+```yaml
+- repo: https://github.com/pypa/pipx
+  rev: 1.3.0
+  hooks:
+  - id: pipx
+    alias: yapf
+    name: yapf
+    args: ['run', 'yapf', '-i']
+    types: ['python']
+```
+
 ### Shell completions
 
 Shell completions are available by following the instructions printed with this command:

--- a/README.md
+++ b/README.md
@@ -80,10 +80,7 @@ python pipx.pyz ensurepath
 
 ### Use with pre-commit
 
-Pipx [has pre-commit support](docs/installation.md#pre-commit). This lets you:
-* Run any package that can be installed with `pipx run` even it the application doesn't support pre-commit natively.
-* Install an application's prebuilt wheel instead of building it from source.
-* Install an application from an arbitrary pypi repository (e.g. artifactory)
+Pipx [has pre-commit support](docs/installation.md#pre-commit).
 
 ### Shell completions
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,10 +40,10 @@ python pipx.pyz ensurepath
 
 <a name="pre-commit"></a>Or use with pre-commit:
 
-Pipx has pre-commit support. This lets you:
-* Run any package that can be installed with `pipx run` even it the application doesn't support pre-commit natively.
-* Install an application's prebuilt wheel instead of building it from source.
-* Use pipx's `--spec` and `--index-url` flags.
+Pipx has pre-commit support. This lets you run applications:
+* That can be installed with `pipx run` but don't have native pre-commit support.
+* Using the prebuilt wheel instead of building it from source.
+* Using pipx's `--spec` and `--index-url` flags.
 
 ```yaml
 - repo: https://github.com/pypa/pipx

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -49,7 +49,7 @@ Example configuration for use of the code linter [yapf](https://github.com/googl
 
 ```yaml
 - repo: https://github.com/pypa/pipx
-  rev: 1.3.0
+  rev: 1.2.0
   hooks:
   - id: pipx
     alias: yapf

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -41,7 +41,7 @@ python pipx.pyz ensurepath
 <a name="pre-commit"></a>Or use with pre-commit:
 
 Pipx has pre-commit support. This lets you run applications:
-* That can be installed with `pipx run` but don't have native pre-commit support.
+* That can be run using `pipx run` but don't have native pre-commit support.
 * Using the prebuilt wheel instead of building it from source.
 * Using pipx's `--spec` and `--index-url` flags.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,7 +40,10 @@ python pipx.pyz ensurepath
 
 <a name="pre-commit"></a>Or use with pre-commit:
 
-Pipx has pre-commit support. This allows for running any package that can be installed with pipx even if it doesn't support pre-commit natively, or to install the package as a wheel from pypi instead of building from source control.
+Pipx has pre-commit support. This lets you:
+* Run any package that can be installed with `pipx run` even it the application doesn't support pre-commit natively.
+* Install an application's prebuilt wheel instead of building it from source.
+* Use pipx's `--spec` and `--index-url` flags.
 
 ```yaml
 - repo: https://github.com/pypa/pipx

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -38,6 +38,21 @@ The zipapp can be downloaded from [Github releases](https://github.com/pypa/pipx
 python pipx.pyz ensurepath
 ```
 
+Or use with pre-commit
+
+Pipx has pre-commit support. This allows for running any package that can be installed with pipx even if it doesn't support pre-commit natively, or to install the package as a wheel from pypi instead of building from source control.
+
+```yaml
+- repo: https://github.com/pypa/pipx
+  rev: 1.3.0
+  hooks:
+  - id: pipx
+    alias: yapf
+    name: yapf
+    args: ['run', 'yapf', '-i']
+    types: ['python']
+```
+
 ### Installation Options
 
 The default binary location for pipx-installed apps is `~/.local/bin`. This can be overridden with the environment variable `PIPX_BIN_DIR`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,7 +40,7 @@ python pipx.pyz ensurepath
 
 <a name="pre-commit"></a>Or use with pre-commit:
 
-Pipx has <a href="https://pre-commit.com/">pre-commit</a> support. This lets you run applications:
+Pipx has [pre-commit](https://pre-commit.com/) support. This lets you run applications:
 * That can be run using `pipx run` but don't have native pre-commit support.
 * Using its prebuilt wheel from pypi.org instead of building it from source.
 * Using pipx's `--spec` and `--index-url` flags.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -45,6 +45,8 @@ Pipx has pre-commit support. This lets you run applications:
 * Using the prebuilt wheel instead of building it from source.
 * Using pipx's `--spec` and `--index-url` flags.
 
+Example configuration for use of the code linter [yapf](https://github.com/google/yapf/). This is to be added to your `.pre-commit-config.yaml`. 
+
 ```yaml
 - repo: https://github.com/pypa/pipx
   rev: 1.3.0

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -54,7 +54,7 @@ Example configuration for use of the code linter [yapf](https://github.com/googl
   - id: pipx
     alias: yapf
     name: yapf
-    args: ['run', 'yapf', '-i']
+    args: ['yapf', '-i']
     types: ['python']
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -45,7 +45,7 @@ Pipx has [pre-commit](https://pre-commit.com/) support. This lets you run applic
 * Using its prebuilt wheel from pypi.org instead of building it from source.
 * Using pipx's `--spec` and `--index-url` flags.
 
-Example configuration for use of the code linter [yapf](https://github.com/google/yapf/). This is to be added to your `.pre-commit-config.yaml`. 
+Example configuration for use of the code linter [yapf](https://github.com/google/yapf/). This is to be added to your `.pre-commit-config.yaml`.
 
 ```yaml
 - repo: https://github.com/pypa/pipx
@@ -56,9 +56,7 @@ Example configuration for use of the code linter [yapf](https://github.com/googl
     name: yapf
     args: ['yapf', '-i']
     types: ['python']
-``````
-
-There are two ids available: `pipx` which uses the default value for [require_serial](https://pre-commit.com/#hooks-require_serial) and `pipx-serial` when has this setting set to `true`.
+```
 
 ### Installation Options
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,9 +40,9 @@ python pipx.pyz ensurepath
 
 <a name="pre-commit"></a>Or use with pre-commit:
 
-Pipx has pre-commit support. This lets you run applications:
+Pipx has <a href="https://pre-commit.com/">pre-commit</a> support. This lets you run applications:
 * That can be run using `pipx run` but don't have native pre-commit support.
-* Using the prebuilt wheel instead of building it from source.
+* Using its prebuilt wheel from pypi.org instead of building it from source.
 * Using pipx's `--spec` and `--index-url` flags.
 
 Example configuration for use of the code linter [yapf](https://github.com/google/yapf/). This is to be added to your `.pre-commit-config.yaml`. 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -38,7 +38,7 @@ The zipapp can be downloaded from [Github releases](https://github.com/pypa/pipx
 python pipx.pyz ensurepath
 ```
 
-Or use with pre-commit
+<a name="pre-commit"></a>Or use with pre-commit:
 
 Pipx has pre-commit support. This allows for running any package that can be installed with pipx even if it doesn't support pre-commit natively, or to install the package as a wheel from pypi instead of building from source control.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -56,7 +56,9 @@ Example configuration for use of the code linter [yapf](https://github.com/googl
     name: yapf
     args: ['yapf', '-i']
     types: ['python']
-```
+``````
+
+There are two ids available: `pipx` which uses the default value for [require_serial](https://pre-commit.com/#hooks-require_serial) and `pipx-serial` when has this setting set to `true`.
 
 ### Installation Options
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [X] I have added an entry to `docs/changelog.md`

## Summary of changes
Add support for using pipx as a pre-commit hook for arbitrary python packages that do not have a pre-commit hook configured.
Some package utilities I'd like to use even but they don't have a pre-commit hook configured for them.

This allows configuration like the following to be added to a project `.pre-commit-config.yaml` file to run the script.

```yaml
- repo: https://github.com/Spitfire1900/pipx
  rev: 9e59f26
  hooks:
  - id: pipx
    alias: yapf
    name: yapf
    args: ['yapf', '-i']
    types: ['python']
```
With the previous config the following command runs yapf against pipx's `get-pipx.py` as an example:
>`pre-commit run pipx --files .\get-pipx.py`

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running the configuration from "Summary of changes" against my local pipx repo.
