### PR TITLE
Minor bug in installation instructions for windows

### DIFF
--- a/index.html
+++ b/index.html
@@ -790,7 +790,7 @@ python -m pip install --user pipx
 </code></pre>
 <p>If so, go to the mentioned folder, allowing you to run the pipx executable directly.
 Enter the following line (even if you did not get the warning):</p>
-<pre><code>pipx ensurepath
+<pre><code>.\pipx.exe ensurepath
 </code></pre>
 <p>This will add both the above mentioned path and the <code>%USERPROFILE%\.local\bin</code> folder to your search path.
 Restart your terminal session and verify <code>pipx</code> does run.</p>


### PR DESCRIPTION
## Summary of changes

This change will ensure that the command works on Windows, in both `console.exe` and `Powershell`.



Otherwise, in Powershell, if you run the command as currently stated, you will receive the error:

    pipx: The term 'pipx' is not recognized as a name of a cmdlet, function, script file, or executable program.
    Check the spelling of the name, or if a path was included, verify that the path is correct and try again.

Apologies if there is a source page from which this index.html is generated. I couldn't see it.


## Test plan

After making this change -- and running the updated command -- this is the output:

```
> .\pipx.exe ensurepath
Success! Added C:\Users\leonb\.local\bin to the PATH
    environment variable.
Success! Added
    C:\Users\leonb\AppData\Roaming\Python\Python39\Scrip
    ts to the PATH environment variable.

Consider adding shell completions for pipx. Run 'pipx
completions' for instructions.

You will need to open a new terminal or re-login for the
PATH changes to take effect.

Otherwise pipx is ready to go! ✨ 🌟 ✨
```

