### PR TITLE
Update README.md - Windows instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If so, go to the mentioned folder, allowing you to run the pipx executable direc
 Enter the following line (even if you did not get the warning):
 
 ```
-pipx ensurepath
+.\pipx.exe ensurepath
 ```
 
 This will add both the above mentioned path and the `%USERPROFILE%\.local\bin` folder to your search path.


### PR DESCRIPTION
## Summary of changes

In windows, to ensure that you can run local instance of pipx.exe when it is not yet on your path you need to use “.\pipx.exe” (if on Powershell, as a power Windows user may often be)


## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
.\pipx.exe
```
