### PR TITLE
pre-commit example needs to reference a commit that has .pre-commit-hooks.yaml available

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -49,7 +49,7 @@ Example configuration for use of the code linter [yapf](https://github.com/googl
 
 ```yaml
 - repo: https://github.com/pypa/pipx
-  rev: 1.2.0
+  rev: 53e7f27
   hooks:
   - id: pipx
     alias: yapf


### PR DESCRIPTION
As mentioned by [this comment](https://github.com/pypa/pipx/pull/981#discussion_r1202521749) .pre-commit-config.yaml needs to reference a commit that has .pre-commit-hooks.yaml available. Once version .NEXT is released to GA the commit hash can be replaced with a valid tag reference

<!-- add an 'x' in the brackets below -->
* [X] I have added an entry to `docs/changelog.md`

## Summary of changes
Update installation documentation to reference the latest commit that has a .pre-commit-hooks.yaml file.
