### PR TITLE
Use py launcher to select Python interpreter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## dev
 
+- Windows: use the py launcher to select Python version with `--python` option
 - Support including requirements in scripts run using `pipx run` (#916)
 - Pass `pip_args` to `shared_libs.upgrade()`
 - Fallback to user's log path if the default log path (`$PIPX_HOME/logs`) is not writable to aid with pipx being used for multi-user (e.g. system-wide) installs of applications

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## dev
 
-- Windows: use the py launcher to select Python version with `--python` option
+- Use the py launcher, if available, to select Python version with the `--python` option
 - Support including requirements in scripts run using `pipx run` (#916)
 - Pass `pip_args` to `shared_libs.upgrade()`
 - Fallback to user's log path if the default log path (`$PIPX_HOME/logs`) is not writable to aid with pipx being used for multi-user (e.g. system-wide) installs of applications

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -2,8 +2,8 @@
 
 ```
 pipx install pycowsay
-pipx install --python python3.7 pycowsay
-pipx install --python python3.8 pycowsay
+pipx install --python python3.10 pycowsay
+pipx install --python 3.11 pycowsay
 pipx install git+https://github.com/psf/black
 pipx install git+https://github.com/psf/black.git@branch-name
 pipx install git+https://github.com/psf/black.git@git-hash

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 from pipx import constants
 from pipx.commands.common import package_name_from_spec, run_post_install_actions
 from pipx.constants import EXIT_CODE_INSTALL_VENV_EXISTS, EXIT_CODE_OK, ExitCode
+from pipx.interpreter import find_py_launcher_python
 from pipx.util import pipx_wrap
 from pipx.venv import Venv, VenvContainer
 
@@ -25,6 +26,11 @@ def install(
     """Returns pipx exit code."""
     # package_spec is anything pip-installable, including package_name, vcs spec,
     #   zip file, or tar.gz file.
+
+    if constants.WINDOWS and python and not Path(python).is_file():
+        py_launcher = find_py_launcher_python(python)
+        if py_launcher:
+            python = py_launcher
 
     if package_name is None:
         package_name = package_name_from_spec(

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -4,7 +4,6 @@ from typing import List, Optional
 from pipx import constants
 from pipx.commands.common import package_name_from_spec, run_post_install_actions
 from pipx.constants import EXIT_CODE_INSTALL_VENV_EXISTS, EXIT_CODE_OK, ExitCode
-from pipx.interpreter import find_py_launcher_python
 from pipx.util import pipx_wrap
 from pipx.venv import Venv, VenvContainer
 
@@ -26,11 +25,6 @@ def install(
     """Returns pipx exit code."""
     # package_spec is anything pip-installable, including package_name, vcs spec,
     #   zip file, or tar.gz file.
-
-    if constants.WINDOWS and python and not Path(python).is_file():
-        py_launcher = find_py_launcher_python(python)
-        if py_launcher:
-            python = py_launcher
 
     if package_name is None:
         package_name = package_name_from_spec(

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -188,7 +188,7 @@ def run(
         # we can't parse this as a package
         package_name = app
 
-    if constants.WINDOWS and python and not Path(python).is_file():
+    if python and not Path(python).is_file():
         py_launcher = find_py_launcher_python(python)
         if py_launcher:
             python = py_launcher

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -288,7 +288,7 @@ def _get_temporary_venv_path(
     m.update(python.encode())
     m.update("".join(pip_args).encode())
     m.update("".join(venv_args).encode())
-    venv_folder_name = m.hexdigest()[0:15]  # 15 chosen arbitrarily
+    venv_folder_name = m.hexdigest()[:15]  # 15 chosen arbitrarily
     return Path(constants.PIPX_VENV_CACHEDIR) / venv_folder_name
 
 

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -180,7 +180,6 @@ def run(
     package
     """
 
-    package_or_url = spec if spec is not None else app
     # For any package, we need to just use the name
     try:
         package_name = Requirement(app).name
@@ -198,6 +197,7 @@ def run(
     if content is not None:
         run_script(content, app_args, python, pip_args, venv_args, verbose, use_cache)
     else:
+        package_or_url = spec if spec is not None else app
         run_package(
             package_name,
             package_or_url,

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -322,7 +322,7 @@ def _http_get_request(url: str) -> str:
         return res.read().decode(charset)
     except Exception as e:
         logger.debug("Uncaught Exception:", exc_info=True)
-        raise PipxError(str(e))
+        raise PipxError(str(e)) from e
 
 
 def _get_requirements_from_script(content: str) -> Optional[List[str]]:
@@ -356,7 +356,7 @@ def _get_requirements_from_script(content: str) -> Optional[List[str]]:
         try:
             req = Requirement(line_content)
         except InvalidRequirement as e:
-            raise PipxError(f"Invalid requirement {line_content}: {str(e)}")
+            raise PipxError(f"Invalid requirement {line_content}: {str(e)}") from e
 
         # Use the normalised form of the requirement,
         # not the original line.

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -75,7 +75,7 @@ def run_script(
 ) -> NoReturn:
     requirements = _get_requirements_from_script(content)
     if requirements is None:
-        exec_app([str(python), "-c", content, *app_args])
+        exec_app([python, "-c", content, *app_args])
     else:
         # Note that the environment name is based on the identified
         # requirements, and *not* on the script name. This is deliberate, as

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -14,7 +14,6 @@ from pipx import constants
 from pipx.commands.common import package_name_from_spec
 from pipx.constants import TEMP_VENV_EXPIRATION_THRESHOLD_DAYS, WINDOWS
 from pipx.emojis import hazard
-from pipx.interpreter import find_py_launcher_python
 from pipx.util import (
     PipxError,
     exec_app,
@@ -187,11 +186,6 @@ def run(
         # Raw URLs to scripts are supported, too, so continue if
         # we can't parse this as a package
         package_name = app
-
-    if python and not Path(python).is_file():
-        py_launcher_python = find_py_launcher_python(python)
-        if py_launcher_python:
-            python = py_launcher_python
 
     content = None if spec is not None else maybe_script_content(app, is_path)
     if content is not None:

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -194,11 +194,7 @@ def run(
         if py_launcher:
             python = py_launcher
 
-    if spec is not None:
-        content = None
-    else:
-        content = maybe_script_content(app, is_path)
-
+    content = None if spec is not None else maybe_script_content(app, is_path)
     if content is not None:
         run_script(content, app_args, python, pip_args, venv_args, verbose, use_cache)
     else:

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -14,6 +14,7 @@ from pipx import constants
 from pipx.commands.common import package_name_from_spec
 from pipx.constants import TEMP_VENV_EXPIRATION_THRESHOLD_DAYS, WINDOWS
 from pipx.emojis import hazard
+from pipx.interpreter import find_py_launcher_python
 from pipx.util import (
     PipxError,
     exec_app,
@@ -106,7 +107,6 @@ def run_package(
     verbose: bool,
     use_cache: bool,
 ) -> NoReturn:
-
     if which(app):
         logger.warning(
             pipx_wrap(
@@ -188,6 +188,11 @@ def run(
         # Raw URLs to scripts are supported, too, so continue if
         # we can't parse this as a package
         package_name = app
+
+    if constants.WINDOWS and python and not Path(python).is_file():
+        py_launcher = find_py_launcher_python(python)
+        if py_launcher:
+            python = py_launcher
 
     if spec is not None:
         content = None
@@ -325,7 +330,6 @@ def _http_get_request(url: str) -> str:
 
 
 def _get_requirements_from_script(content: str) -> Optional[List[str]]:
-
     # An iterator over the lines in the script. We will
     # read through this in sections, so it needs to be an
     # iterator, not just a list.

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -189,9 +189,9 @@ def run(
         package_name = app
 
     if python and not Path(python).is_file():
-        py_launcher = find_py_launcher_python(python)
-        if py_launcher:
-            python = py_launcher
+        py_launcher_python = find_py_launcher_python(python)
+        if py_launcher_python:
+            python = py_launcher_python
 
     content = None if spec is not None else maybe_script_content(app, is_path)
     if content is not None:

--- a/src/pipx/constants.py
+++ b/src/pipx/constants.py
@@ -19,6 +19,7 @@ PIPX_SHARED_PTH = "pipx_shared.pth"
 LOCAL_BIN_DIR = Path(os.environ.get("PIPX_BIN_DIR", DEFAULT_PIPX_BIN_DIR)).resolve()
 PIPX_VENV_CACHEDIR = PIPX_HOME / ".cache"
 TEMP_VENV_EXPIRATION_THRESHOLD_DAYS = 14
+MINIMUM_PYTHON_VERSION = "3.8"
 
 ExitCode = NewType("ExitCode", int)
 # pipx shell exit codes

--- a/src/pipx/interpreter.py
+++ b/src/pipx/interpreter.py
@@ -31,7 +31,7 @@ def find_py_launcher_python(python_version: Optional[str] = None) -> Optional[st
     py = shutil.which("py")
     if py and python_version:
         py = subprocess.run(
-            ["py", f"-{python_version}", "-c", "import sys; print(sys.executable)"],
+            [py, f"-{python_version}", "-c", "import sys; print(sys.executable)"],
             capture_output=True,
             text=True,
         ).stdout.strip()

--- a/src/pipx/interpreter.py
+++ b/src/pipx/interpreter.py
@@ -30,7 +30,11 @@ def has_venv() -> bool:
 def find_py_launcher_python(python_version: Optional[str] = None) -> Optional[str]:
     py = shutil.which("py")
     if py and python_version:
-        os.environ["PY_PYTHON"] = python_version
+        py = subprocess.run(
+            ["py", f"-{python_version}", "-c", "import sys; print(sys.executable)"],
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
     return py
 
 

--- a/src/pipx/interpreter.py
+++ b/src/pipx/interpreter.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import subprocess
 import sys
+from typing import Optional
 
 from pipx.constants import WINDOWS
 from pipx.util import PipxError
@@ -26,14 +27,18 @@ def has_venv() -> bool:
 # so we try to locate the system Python and use that instead.
 
 
+def find_py_launcher_python(python_version: Optional[str] = None) -> Optional[str]:
+    py = shutil.which("py")
+    if py and python_version:
+        os.environ["PY_PYTHON"] = python_version
+    return py
+
+
 def _find_default_windows_python() -> str:
     if has_venv():
         return sys.executable
+    python = find_py_launcher_python() or shutil.which("python")
 
-    py = shutil.which("py")
-    if py:
-        return py
-    python = shutil.which("python")
     if python is None:
         raise PipxError("No suitable Python found")
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -345,9 +345,8 @@ def _add_install(subparsers: argparse._SubParsersAction) -> None:
         "--python",
         default=DEFAULT_PYTHON,
         help=(
-            "The Python executable used to create the Virtual Environment and run the "
-            "associated app/apps. The Python version for the Python Launcher. "
-            "Must be v3.6+."
+            "Python to install with. Possible values can be the executable name (python3.11), "
+            "the version to pass to py launcher (3.11), or the full path to the executable."
         ),
     )
     add_pip_venv_args(p)
@@ -489,9 +488,8 @@ def _add_reinstall(subparsers, venv_completer: VenvCompleter) -> None:
         "--python",
         default=DEFAULT_PYTHON,
         help=(
-            "The Python executable used to create the Virtual Environment and run the "
-            "associated app/apps. The Python version for the Python Launcher. "
-            "Must be v3.6+."
+            "Python to reinstall with. Possible values can be the executable name (python3.11), "
+            "the version to pass to py launcher (3.11), or the full path to the executable."
         ),
     )
     p.add_argument("--verbose", action="store_true")
@@ -518,9 +516,8 @@ def _add_reinstall_all(subparsers: argparse._SubParsersAction) -> None:
         "--python",
         default=DEFAULT_PYTHON,
         help=(
-            "The Python executable used to create the Virtual Environment and run the "
-            "associated app/apps. The Python version for the Python Launcher. "
-            "Must be v3.6+."
+            "Python to reinstall with. Possible values can be the executable name (python3.11), "
+            "the version to pass to py launcher (3.11), or the full path to the executable."
         ),
     )
     p.add_argument("--skip", nargs="+", default=[], help="skip these packages")
@@ -596,9 +593,8 @@ def _add_run(subparsers: argparse._SubParsersAction) -> None:
         "--python",
         default=DEFAULT_PYTHON,
         help=(
-            "The Python executable used to create the Virtual Environment and run the "
-            "associated app/apps. The Python version for the Python Launcher. "
-            "Must be v3.6+."
+            "Python to run with. Possible values can be the executable name (python3.11), "
+            "the version to pass to py launcher (3.11), or the full path to the executable."
         ),
     )
     add_pip_venv_args(p)

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -181,7 +181,7 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:  # noqa: C901
         logger.info(f"Virtual Environment location is {venv_dir}")
     if "skip" in args:
         skip_list = [canonicalize_name(x) for x in args.skip]
-    if "python" in args and WINDOWS and not Path(args.python).is_file():
+    if "python" in args and not Path(args.python).is_file():
         py_launcher_python = find_py_launcher_python(args.python)
         if py_launcher_python:
             args.python = py_launcher_python

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -25,7 +25,7 @@ from pipx.animate import hide_cursor, show_cursor
 from pipx.colors import bold, green
 from pipx.constants import WINDOWS, ExitCode
 from pipx.emojis import hazard
-from pipx.interpreter import DEFAULT_PYTHON
+from pipx.interpreter import DEFAULT_PYTHON, find_py_launcher_python
 from pipx.util import PipxError, mkdir, pipx_wrap, rmdir
 from pipx.venv import VenvContainer
 from pipx.version import __version__
@@ -181,6 +181,10 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:  # noqa: C901
         logger.info(f"Virtual Environment location is {venv_dir}")
     if "skip" in args:
         skip_list = [canonicalize_name(x) for x in args.skip]
+    if "python" in args and WINDOWS and not Path(args.python).is_file():
+        py_launcher = find_py_launcher_python(args.python)
+        if py_launcher:
+            args.python = py_launcher
 
     if args.command == "run":
         commands.run(

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -346,7 +346,7 @@ def _add_install(subparsers: argparse._SubParsersAction) -> None:
         default=DEFAULT_PYTHON,
         help=(
             "The Python executable used to create the Virtual Environment and run the "
-            "associated app/apps. The Python version for the Python Launcher for Windows. "
+            "associated app/apps. The Python version for the Python Launcher. "
             "Must be v3.6+."
         ),
     )
@@ -490,7 +490,7 @@ def _add_reinstall(subparsers, venv_completer: VenvCompleter) -> None:
         default=DEFAULT_PYTHON,
         help=(
             "The Python executable used to create the Virtual Environment and run the "
-            "associated app/apps. The Python version for the Python Launcher for Windows. "
+            "associated app/apps. The Python version for the Python Launcher. "
             "Must be v3.6+."
         ),
     )
@@ -519,7 +519,7 @@ def _add_reinstall_all(subparsers: argparse._SubParsersAction) -> None:
         default=DEFAULT_PYTHON,
         help=(
             "The Python executable used to create the Virtual Environment and run the "
-            "associated app/apps. The Python version for the Python Launcher for Windows. "
+            "associated app/apps. The Python version for the Python Launcher. "
             "Must be v3.6+."
         ),
     )
@@ -597,7 +597,7 @@ def _add_run(subparsers: argparse._SubParsersAction) -> None:
         default=DEFAULT_PYTHON,
         help=(
             "The Python executable used to create the Virtual Environment and run the "
-            "associated app/apps. The Python version for the Python Launcher for Windows. "
+            "associated app/apps. The Python version for the Python Launcher. "
             "Must be v3.6+."
         ),
     )

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -23,7 +23,7 @@ import pipx.constants
 from pipx import commands, constants
 from pipx.animate import hide_cursor, show_cursor
 from pipx.colors import bold, green
-from pipx.constants import WINDOWS, ExitCode
+from pipx.constants import MINIMUM_PYTHON_VERSION, WINDOWS, ExitCode
 from pipx.emojis import hazard
 from pipx.interpreter import DEFAULT_PYTHON, find_py_launcher_python
 from pipx.util import PipxError, mkdir, pipx_wrap, rmdir
@@ -347,6 +347,7 @@ def _add_install(subparsers: argparse._SubParsersAction) -> None:
         help=(
             "Python to install with. Possible values can be the executable name (python3.11), "
             "the version to pass to py launcher (3.11), or the full path to the executable."
+            f"Requires Python {MINIMUM_PYTHON_VERSION} or above."
         ),
     )
     add_pip_venv_args(p)
@@ -490,6 +491,7 @@ def _add_reinstall(subparsers, venv_completer: VenvCompleter) -> None:
         help=(
             "Python to reinstall with. Possible values can be the executable name (python3.11), "
             "the version to pass to py launcher (3.11), or the full path to the executable."
+            f"Requires Python {MINIMUM_PYTHON_VERSION} or above."
         ),
     )
     p.add_argument("--verbose", action="store_true")
@@ -518,6 +520,7 @@ def _add_reinstall_all(subparsers: argparse._SubParsersAction) -> None:
         help=(
             "Python to reinstall with. Possible values can be the executable name (python3.11), "
             "the version to pass to py launcher (3.11), or the full path to the executable."
+            f"Requires Python {MINIMUM_PYTHON_VERSION} or above."
         ),
     )
     p.add_argument("--skip", nargs="+", default=[], help="skip these packages")
@@ -594,7 +597,8 @@ def _add_run(subparsers: argparse._SubParsersAction) -> None:
         default=DEFAULT_PYTHON,
         help=(
             "Python to run with. Possible values can be the executable name (python3.11), "
-            "the version to pass to py launcher (3.11), or the full path to the executable."
+            "the version to pass to py launcher (3.11), or the full path to the executable. "
+            f"Requires Python {MINIMUM_PYTHON_VERSION} or above."
         ),
     )
     add_pip_venv_args(p)

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -342,7 +342,8 @@ def _add_install(subparsers: argparse._SubParsersAction) -> None:
         default=DEFAULT_PYTHON,
         help=(
             "The Python executable used to create the Virtual Environment and run the "
-            "associated app/apps. Must be v3.6+."
+            "associated app/apps. The Python version for the Python Launcher for Windows. "
+            "Must be v3.6+."
         ),
     )
     add_pip_venv_args(p)
@@ -484,8 +485,9 @@ def _add_reinstall(subparsers, venv_completer: VenvCompleter) -> None:
         "--python",
         default=DEFAULT_PYTHON,
         help=(
-            "The Python executable used to recreate the Virtual Environment "
-            "and run the associated app/apps. Must be v3.6+."
+            "The Python executable used to create the Virtual Environment and run the "
+            "associated app/apps. The Python version for the Python Launcher for Windows. "
+            "Must be v3.6+."
         ),
     )
     p.add_argument("--verbose", action="store_true")
@@ -512,8 +514,9 @@ def _add_reinstall_all(subparsers: argparse._SubParsersAction) -> None:
         "--python",
         default=DEFAULT_PYTHON,
         help=(
-            "The Python executable used to recreate the Virtual Environment "
-            "and run the associated app/apps. Must be v3.6+."
+            "The Python executable used to create the Virtual Environment and run the "
+            "associated app/apps. The Python version for the Python Launcher for Windows. "
+            "Must be v3.6+."
         ),
     )
     p.add_argument("--skip", nargs="+", default=[], help="skip these packages")
@@ -588,7 +591,11 @@ def _add_run(subparsers: argparse._SubParsersAction) -> None:
     p.add_argument(
         "--python",
         default=DEFAULT_PYTHON,
-        help="The Python version to run package's CLI app with. Must be v3.6+.",
+        help=(
+            "The Python executable used to create the Virtual Environment and run the "
+            "associated app/apps. The Python version for the Python Launcher for Windows. "
+            "Must be v3.6+."
+        ),
     )
     add_pip_venv_args(p)
     p.set_defaults(subparser=p)

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -182,9 +182,9 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:  # noqa: C901
     if "skip" in args:
         skip_list = [canonicalize_name(x) for x in args.skip]
     if "python" in args and WINDOWS and not Path(args.python).is_file():
-        py_launcher = find_py_launcher_python(args.python)
-        if py_launcher:
-            args.python = py_launcher
+        py_launcher_python = find_py_launcher_python(args.python)
+        if py_launcher_python:
+            args.python = py_launcher_python
 
     if args.command == "run":
         commands.run(

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -250,7 +250,7 @@ def test_install_pip_failure(pipx_temp_env, capsys):
         r"Full pip output in file:\s+(\S.+)$", captured.err, re.MULTILINE
     )
     assert pip_log_file_match
-    assert Path(pip_log_file_match.group(1)).exists()
+    assert Path(pip_log_file_match[1]).exists()
 
     assert re.search(r"pip (failed|seemed to fail) to build package", captured.err)
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -262,12 +262,3 @@ def test_install_local_archive(pipx_temp_env, monkeypatch, capsys):
     assert not run_pipx_cli(["install", "repeatme-0.1-py3-none-any.whl"])
     captured = capsys.readouterr()
     assert f"- {app_name('repeatme')}\n" in captured.out
-
-
-@pytest.mark.skipif(
-    not sys.platform.startswith("win"), reason="uses windows version format"
-)
-def test_install_with_python_windows(capsys, pipx_temp_env):
-    run_pipx_cli(["install", "pycowsay", "--python", "3.11"])
-    captured = capsys.readouterr()
-    assert "Python 3.11" in captured.out

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -262,3 +262,12 @@ def test_install_local_archive(pipx_temp_env, monkeypatch, capsys):
     assert not run_pipx_cli(["install", "repeatme-0.1-py3-none-any.whl"])
     captured = capsys.readouterr()
     assert f"- {app_name('repeatme')}\n" in captured.out
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("win"), reason="uses windows version format"
+)
+def test_install_with_python_windows(capsys, pipx_temp_env):
+    run_pipx_cli(["install", "pycowsay", "--python", "3.11"])
+    captured = capsys.readouterr()
+    assert "Python 3.11" in captured.out

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -144,7 +144,7 @@ def test_extra(pipx_temp_env, capsys):
 
 def test_install_local_extra(pipx_temp_env, capsys):
     assert not run_pipx_cli(
-        ["install", TEST_DATA_PATH + "/local_extras[cow]", "--include-deps"]
+        ["install", f"{TEST_DATA_PATH}/local_extras[cow]", "--include-deps"]
     )
     captured = capsys.readouterr()
     assert f"- {app_name('pycowsay')}\n" in captured.out

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -23,9 +23,9 @@ def test_windows_python_with_version(monkeypatch, venv):
     minor = sys.version_info.minor
     monkeypatch.setattr(pipx.interpreter, "has_venv", lambda: venv)
     monkeypatch.setattr(shutil, "which", which)
-    assert find_py_launcher_python(f"{major}.{minor}").endswith(
-        f"Python{major}{minor}\\python.exe"
-    )
+    python_path = find_py_launcher_python(f"{major}.{minor}")
+    assert f"{major}.{minor}" in python_path or f"{major}{minor}" in python_path
+    assert python_path.endswith("python.exe")
 
 
 def test_windows_python_no_version_with_venv(monkeypatch):

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 import subprocess
 import sys
@@ -14,23 +13,18 @@ from pipx.interpreter import (
 from pipx.util import PipxError
 
 
-def py_which(name):
-    if name == "py":
+@pytest.mark.parametrize("venv", [True, False])
+def test_windows_python_with_version(monkeypatch, venv):
+    def which(name):
         return "py"
 
-
-def test_windows_python_with_version_no_venv(monkeypatch):
-    monkeypatch.setattr(pipx.interpreter, "has_venv", lambda: False)
-    monkeypatch.setattr(shutil, "which", py_which)
-    assert find_py_launcher_python("3.9") == "py"
-    assert os.environ.get("PY_PYTHON") == "3.9"
-
-
-def test_windows_python_with_version_with_venv(monkeypatch):
-    monkeypatch.setattr(pipx.interpreter, "has_venv", lambda: True)
-    monkeypatch.setattr(shutil, "which", py_which)
-    assert find_py_launcher_python("3.9") == "py"
-    assert os.environ.get("PY_PYTHON") == "3.9"
+    major = sys.version_info.major
+    minor = sys.version_info.minor
+    monkeypatch.setattr(pipx.interpreter, "has_venv", lambda: venv)
+    monkeypatch.setattr(shutil, "which", which)
+    assert find_py_launcher_python(f"{major}.{minor}").endswith(
+        f"Python{major}{minor}\\python.exe"
+    )
 
 
 def test_windows_python_no_version_with_venv(monkeypatch):
@@ -39,8 +33,11 @@ def test_windows_python_no_version_with_venv(monkeypatch):
 
 
 def test_windows_python_no_version_no_venv_with_py(monkeypatch):
+    def which(name):
+        return "py"
+
     monkeypatch.setattr(pipx.interpreter, "has_venv", lambda: False)
-    monkeypatch.setattr(shutil, "which", py_which)
+    monkeypatch.setattr(shutil, "which", which)
     assert _find_default_windows_python() == "py"
 
 

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -13,6 +13,7 @@ from pipx.interpreter import (
 from pipx.util import PipxError
 
 
+@pytest.mark.skipif(not sys.platform.startswith("win"), reason="Looks for Python.exe")
 @pytest.mark.parametrize("venv", [True, False])
 def test_windows_python_with_version(monkeypatch, venv):
     def which(name):

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -316,3 +316,23 @@ def test_run_script_by_relative_name(caplog, pipx_temp_env, monkeypatch, tmp_pat
         m.chdir(tmp_path)
         run_pipx_cli_exit(["run", "test.py"])
     assert out.read_text() == test_str
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("win"), reason="uses windows version format"
+)
+@mock.patch("os.execvpe", new=execvpe_mock)
+def test_run_with_windows_python_version(caplog, pipx_temp_env, tmp_path):
+    script = tmp_path / "test.py"
+    out = tmp_path / "output.txt"
+    script.write_text(
+        textwrap.dedent(
+            f"""
+                import sys
+                from pathlib import Path
+                Path({repr(str(out))}).write_text(sys.version)
+            """
+        ).strip()
+    )
+    run_pipx_cli_exit(["run", script.as_uri(), "--python", "3.11"])
+    assert "3.11" in out.read_text()


### PR DESCRIPTION
* [X] I have added an entry to `docs/changelog.md`

## Summary of changes

This PR closes #940 by adding support to use the py launcher to select the Python interpreter when the `--python` option is provided.

The feature is used like `pipx install --python 3.10 cowsay` to install using the Python 3.10 interpreter. The only way to do this right now is by passing in the full path to the interpreter.

I also did some refactoring in nearby code to leave the codebase in better shape than I found it.

## Test plan

Tested by running
```
> pipx install --python 3.10 cowsay`
> pipx reinstall --python 3.11 cowsay`
> pipx uninstall cowsay`
> pipx run --python 3.9 cowsay hi`
```
`pipx install --python 3.100 cowsay` raises a FileNotFound error, which is similar to the behavior in Linux if you run `pipx install --python python3.100 cowsay`.