### PR TITLE
Drop Python 3.7

### DIFF
--- a/.github/workflows/create_tests_package_lists.yml
+++ b/.github/workflows/create_tests_package_lists.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/exhaustive_package_test.yml
+++ b/.github/workflows/exhaustive_package_test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         include:
           - os: windows-latest
             python-version: "3.11"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## dev
 
+- Drop support for Python 3.7
 - Make usage message in `pipx run` show `package_or_url`, so extra will be printed out as well
 - Add `--force-reinstall` to pip arguments when `--force` was passed
 - Use the py launcher, if available, to select Python version with the `--python` option

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import nox  # type: ignore
 
-PYTHON_ALL_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11"]
+PYTHON_ALL_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]
 PYTHON_DEFAULT_VERSION = "3.11"
 DOC_DEPENDENCIES = [".", "jinja2", "mkdocs", "mkdocs-material"]
 MAN_DEPENDENCIES = [".", "argparse-manpage[setuptools]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pipx"
 description = "Install and Run Python Applications in Isolated Environments"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 keywords = ["pip", "install", "cli", "workflow", "Virtual Environment"]
 authors = [{ name = "Chad Smith", email = "chadsmith.software@gmail.com" }]
 classifiers = [
@@ -15,7 +15,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
 dependencies = [
   "argcomplete>=1.9.4",
   "colorama>=0.4.4; sys_platform == 'win32'",
-  "importlib-metadata>=3.3.0; python_version < '3.8'",
   "packaging>=20.0",
   "platformdirs>=2.1.0",
   "userpath>=1.6.0,!=1.9.0",

--- a/src/pipx/__init__.py
+++ b/src/pipx/__init__.py
@@ -1,9 +1,8 @@
 import sys
-from constants import MINIMUM_PYTHON_VERSION
 
-if sys.version_info < tuple(int(number) for number in MINIMUM_PYTHON_VERSION.split(".")):
+if sys.version_info < (3, 8, 0):
     sys.exit(
-       f"Python {MINIMUM_PYTHON_VERSION} or later is required. "
+        "Python 3.8 or later is required. "
         "See https://github.com/pypa/pipx "
         "for installation instructions."
     )

--- a/src/pipx/__init__.py
+++ b/src/pipx/__init__.py
@@ -1,8 +1,8 @@
 import sys
 
-if sys.version_info < (3, 6, 0):
+if sys.version_info < (3, 8, 0):
     sys.exit(
-        "Python 3.6 or later is required. "
+        "Python 3.8 or later is required. "
         "See https://github.com/pypa/pipx "
         "for installation instructions."
     )

--- a/src/pipx/__init__.py
+++ b/src/pipx/__init__.py
@@ -1,8 +1,9 @@
 import sys
+from constants import MINIMUM_PYTHON_VERSION
 
-if sys.version_info < (3, 8, 0):
+if sys.version_info < tuple(int(number) for number in MINIMUM_PYTHON_VERSION.split(".")):
     sys.exit(
-        "Python 3.8 or later is required. "
+       f"Python {MINIMUM_PYTHON_VERSION} or later is required. "
         "See https://github.com/pypa/pipx "
         "for installation instructions."
     )

--- a/tests/test_package_specifier.py
+++ b/tests/test_package_specifier.py
@@ -96,7 +96,7 @@ def test_fix_package_name(package_spec_in, package_name, package_spec_out):
             True,
         ),
         (
-            'my-project[cli] @ git+ssh://git@bitbucket.org/my-company/myproject.git ; python_version<"3.7"',
+            'my-project[cli] @ git+ssh://git@bitbucket.org/my-company/myproject.git ; python_version<"3.8"',
             "my-project[cli]@ git+ssh://git@bitbucket.org/my-company/myproject.git",
             True,
         ),
@@ -165,7 +165,7 @@ def test_parse_specifier_for_metadata(
             True,
         ),
         (
-            'my-project[cli] @ git+ssh://git@bitbucket.org/my-company/myproject.git ; python_version<"3.7"',
+            'my-project[cli] @ git+ssh://git@bitbucket.org/my-company/myproject.git ; python_version<"3.8"',
             "my-project[cli]@ git+ssh://git@bitbucket.org/my-company/myproject.git",
             True,
         ),


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

Dropped support for Python 3.7 which is EOL on June 26, 2023.

Closes #1040 

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
