### PR TITLE
(🐞) Don't use `repr` for paths in console output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fallback to user's log path if the default log path (`$PIPX_HOME/logs`) is not writable to aid with pipx being used for multi-user (e.g. system-wide) installs of applications
 - Fix wrong interpreter usage when injecting local pip-installable dependencies into venvs
 - add pre-commit hook support
+- Don't show escaped backslashes for paths in console output 
 
 ## 1.2.0
 

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -409,7 +409,7 @@ def warn_if_not_on_path(local_bin_dir: Path) -> None:
         logger.warning(
             pipx_wrap(
                 f"""
-                {hazard}  Note: {str(local_bin_dir)!r} is not on your PATH
+                {hazard}  Note: '{local_bin_dir}' is not on your PATH
                 environment variable. These apps will not be globally
                 accessible until your PATH is updated. Run `pipx ensurepath` to
                 automatically add it, or manually modify your PATH in your

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -48,7 +48,7 @@ def install(
                 pipx_wrap(
                     f"""
                     {venv.name!r} already seems to be installed. Not modifying
-                    existing installation in {str(venv_dir)!r}. Pass '--force'
+                    existing installation in '{venv_dir}'. Pass '--force'
                     to force installation.
                     """
                 )

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -127,13 +127,13 @@ def run_package(
     pypackage_bin_path = get_pypackage_bin_path(app)
     if pypackage_bin_path.exists():
         logger.info(
-            f"Using app in local __pypackages__ directory at {str(pypackage_bin_path)}"
+            f"Using app in local __pypackages__ directory at '{pypackage_bin_path}'"
         )
         run_pypackage_bin(pypackage_bin_path, app_args)
     if pypackages:
         raise PipxError(
             f"""
-            '--pypackages' flag was passed, but {str(pypackage_bin_path)!r} was
+            '--pypackages' flag was passed, but '{pypackage_bin_path}' was
             not found. See https://github.com/cs01/pythonloc to learn how to
             install here, or omit the flag.
             """

--- a/src/pipx/interpreter.py
+++ b/src/pipx/interpreter.py
@@ -66,7 +66,7 @@ def _get_sys_executable() -> str:
 def _get_absolute_python_interpreter(env_python: str) -> str:
     which_python = shutil.which(env_python)
     if not which_python:
-        raise PipxError(f"Default python interpreter {repr(env_python)} is invalid.")
+        raise PipxError(f"Default python interpreter '{env_python}' is invalid.")
     return which_python
 
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -797,7 +797,7 @@ def setup(args: argparse.Namespace) -> None:
     logger.debug(f"{time.strftime('%Y-%m-%d %H:%M:%S')}")
     logger.debug(f"{' '.join(sys.argv)}")
     logger.info(f"pipx version is {__version__}")
-    logger.info(f"Default python interpreter is {repr(DEFAULT_PYTHON)}")
+    logger.info(f"Default python interpreter is '{DEFAULT_PYTHON}'")
 
     mkdir(constants.PIPX_LOCAL_VENVS)
     mkdir(constants.LOCAL_BIN_DIR)


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [🚀] I have added an entry to `docs/changelog.md`

## Summary of changes
Previously pipx would output things like `"File 'foo\\bar\\baz' not found."`, which isn't ideal.

- resolves #1003

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
> pipx install basedmypy
```
