### PR TITLE
Minor fixes for MkDocs configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ python pipx.pyz ensurepath
 
 ### Use with pre-commit
 
-pipx [has pre-commit support](docs/installation.md#pre-commit).
+pipx [has pre-commit support](installation.md#pre-commit).
 
 ### Shell completions
 

--- a/installation.md
+++ b/installation.md
@@ -1,0 +1,1 @@
+docs/installation.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,12 +3,14 @@ site_description: execute binaries from Python packages in isolated environments
 
 theme:
   name: "material"
-google_analytics:
-  - 'UA-90243909-2'
-  - 'auto'
 repo_name: pypa/pipx
 repo_url: https://github.com/pypa/pipx
 edit_uri: edit/main/docs/
+extra:
+  analytics:
+    provider: 'google'
+    property: 'UA-90243909-2'
+
 
 nav:
   - Home: "index.md"

--- a/noxfile.py
+++ b/noxfile.py
@@ -213,6 +213,7 @@ def publish_docs(session):
 @nox.session(python=PYTHON_DEFAULT_VERSION)
 def watch_docs(session):
     session.install(*DOC_DEPENDENCIES)
+    session.run("python", "scripts/generate_docs.py")
     session.run("mkdocs", "serve")
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -199,7 +199,7 @@ def build_docs(session):
         "PIPX__DOC_DEFAULT_PYTHON"
     ] = "typically the python used to execute pipx"
     session.run("python", "scripts/generate_docs.py")
-    session.run("mkdocs", "build")
+    session.run("mkdocs", "build", "--strict")
 
 
 @nox.session(python=PYTHON_DEFAULT_VERSION)
@@ -207,14 +207,14 @@ def publish_docs(session):
     session.run("python", "-m", "pip", "install", "--upgrade", "pip")
     session.install(*DOC_DEPENDENCIES)
     build_docs(session)
-    session.run("mkdocs", "gh-deploy")
+    session.run("mkdocs", "gh-deploy", "--strict")
 
 
 @nox.session(python=PYTHON_DEFAULT_VERSION)
 def watch_docs(session):
     session.install(*DOC_DEPENDENCIES)
     session.run("python", "scripts/generate_docs.py")
-    session.run("mkdocs", "serve")
+    session.run("mkdocs", "serve", "--strict")
 
 
 @nox.session(python=PYTHON_DEFAULT_VERSION)


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes

I removed the deprecated _google_analytics_ property and enabled generating _docs.md_ in the nox `watch_docs` session.
Also, I passed the `--strict` option to the MkDocs `build, serve` and `deploy` commands.
 
## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
