### PR TITLE
Make usage message in `pipx run` show `package_or_url`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## dev
 
+- Make usage message in `pipx run` show `package_or_url`, so extra will be printed out as well
 - Use the py launcher, if available, to select Python version with the `--python` option
 - Support including requirements in scripts run using `pipx run` (#916)
 - Pass `pip_args` to `shared_libs.upgrade()`

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -250,7 +250,7 @@ def _download_and_run(
                 app_filename = app
         else:
             all_apps = (
-                f"{a} - usage: 'pipx run --spec {package_name} {a} [arguments?]'"
+                f"{a} - usage: 'pipx run --spec {package_or_url} {a} [arguments?]'"
                 for a in apps
             )
             raise PipxError(


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Make usage message in `pipx run` show `package_or_url` instead of `package_name`

Before:
```
$ pipx run pymodbus[repl]
'pymodbus' executable script not found in package 'pymodbus'.
Available executable scripts:
    pymodbus.console - usage: 'pipx run --spec pymodbus pymodbus.console [arguments?]'
    pymodbus.server - usage: 'pipx run --spec pymodbus pymodbus.server [arguments?]'
    pymodbus.simulator - usage: 'pipx run --spec pymodbus pymodbus.simulator [arguments?]'
```

After:
```
$ pipx run pymodbus[repl]
'pymodbus' executable script not found in package 'pymodbus'.
Available executable scripts:
    pymodbus.console - usage: 'pipx run --spec pymodbus[repl] pymodbus.console [arguments?]'
    pymodbus.server - usage: 'pipx run --spec pymodbus[repl] pymodbus.server [arguments?]'
    pymodbus.simulator - usage: 'pipx run --spec pymodbus[repl] pymodbus.simulator [arguments?]'
```
