### PR TITLE
chore: ruff moved to astral-sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
   - id: check-added-large-files
   - id: trailing-whitespace
   - id: check-yaml
-- repo: https://github.com/charliermarsh/ruff-pre-commit
+- repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.0.254
   hooks:
     - id: ruff


### PR DESCRIPTION
See https://github.com/scientific-python/cookie/pull/200.