### PR TITLE
Pass --no-input

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,5 +30,5 @@ repos:
   rev: v1.1.1
   hooks:
   - id: mypy
-    args: ['--ignore-missing-imports', '--strict-equality','--no-implicit-optional']
+    args: ['--warn-unused-ignores', '--strict-equality','--no-implicit-optional']
     exclude: 'testdata/test_package_specifier/local_extras/setup.py'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [docs] Add more examples for `pipx run`
 - [docs] Add subsection to make README easier to read
 - Add `pipx install --preinstall` to support preinstalling build requirements
+- Pass `--no-input` to pip when output is not piped to parent stdout
 
 ## 1.2.0
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,7 +10,7 @@ DOC_DEPENDENCIES = [".", "jinja2", "mkdocs", "mkdocs-material"]
 MAN_DEPENDENCIES = [".", "argparse-manpage[setuptools]"]
 LINT_DEPENDENCIES = [
     "black==22.8.0",
-    "mypy==0.930",
+    "mypy==1.1.1",
     "packaging>=20.0",
     "ruff==0.0.254",
     "types-jinja2",

--- a/noxfile.py
+++ b/noxfile.py
@@ -103,7 +103,7 @@ def tests_with_options(session, net_pypiserver):
     if net_pypiserver:
         pypiserver_option = ["--net-pypiserver"]
     else:
-        session.install("pypiserver")
+        session.install("pypiserver[passlib]")
         refresh_packages_cache(session)
         pypiserver_option = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,3 +78,10 @@ max-complexity = 15
 
 [tool.pytest.ini_options]
 markers = ["all_packages: test install with maximum number of packages"]
+
+[[tool.mypy.overrides]]
+module = [
+  "packaging.*",
+  "platformdirs"
+]
+ignore_missing_imports = true

--- a/src/pipx/animate.py
+++ b/src/pipx/animate.py
@@ -101,11 +101,13 @@ def print_animation(
 # for Windows pre-ANSI-terminal-support (before Windows 10 TH2 (v1511))
 # https://stackoverflow.com/a/10455937
 def win_cursor(visible: bool) -> None:
+    if sys.platform != "win32":  # hello mypy
+        return
     ci = _CursorInfo()
-    handle = ctypes.windll.kernel32.GetStdHandle(-11)  # type: ignore[attr-defined]
-    ctypes.windll.kernel32.GetConsoleCursorInfo(handle, ctypes.byref(ci))  # type: ignore[attr-defined]
+    handle = ctypes.windll.kernel32.GetStdHandle(-11)
+    ctypes.windll.kernel32.GetConsoleCursorInfo(handle, ctypes.byref(ci))
     ci.visible = visible
-    ctypes.windll.kernel32.SetConsoleCursorInfo(handle, ctypes.byref(ci))  # type: ignore[attr-defined]
+    ctypes.windll.kernel32.SetConsoleCursorInfo(handle, ctypes.byref(ci))
 
 
 def hide_cursor() -> None:

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -101,6 +101,7 @@ class _SharedLibs:
                         self.python_path,
                         "-m",
                         "pip",
+                        "--no-input",
                         "--disable-pip-version-check",
                         "install",
                         *_pip_args,

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -240,11 +240,15 @@ class Venv:
         ):
             # do not use -q with `pip install` so subprocess_post_check_pip_errors
             #   has more information to analyze in case of failure.
-            cmd = (
-                [str(self.python_path), "-m", "pip", "--no-input", "install"]
-                + pip_args
-                + [package_or_url]
-            )
+            cmd = [
+                str(self.python_path),
+                "-m",
+                "pip",
+                "--no-input",
+                "install",
+                *pip_args,
+                package_or_url,
+            ]
             # no logging because any errors will be specially logged by
             #   subprocess_post_check_handle_pip_error()
             pip_process = run_subprocess(cmd, log_stdout=False, log_stderr=False)
@@ -284,11 +288,15 @@ class Venv:
         with animate(f"installing {', '.join(requirements)}", self.do_animation):
             # do not use -q with `pip install` so subprocess_post_check_pip_errors
             #   has more information to analyze in case of failure.
-            cmd = (
-                [str(self.python_path), "-m", "pip", "--no-input", "install"]
-                + pip_args
-                + requirements
-            )
+            cmd = [
+                str(self.python_path),
+                "-m",
+                "pip",
+                "--no-input",
+                "install",
+                *pip_args,
+                *requirements,
+            ]
             # no logging because any errors will be specially logged by
             #   subprocess_post_check_handle_pip_error()
             pip_process = run_subprocess(cmd, log_stdout=False, log_stderr=False)
@@ -301,11 +309,13 @@ class Venv:
             f"determining package name from {package_or_url!r}", self.do_animation
         ):
             old_package_set = self.list_installed_packages()
-            cmd = (
-                ["--no-input", "install", "--no-dependencies"]
-                + pip_args
-                + [package_or_url]
-            )
+            cmd = [
+                "--no-input",
+                "install",
+                "--no-dependencies",
+                *pip_args,
+                package_or_url,
+            ]
             pip_process = self._run_pip(cmd)
         subprocess_post_check(pip_process, raise_error=False)
         if pip_process.returncode:

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -241,7 +241,7 @@ class Venv:
             # do not use -q with `pip install` so subprocess_post_check_pip_errors
             #   has more information to analyze in case of failure.
             cmd = (
-                [str(self.python_path), "-m", "pip", "install"]
+                [str(self.python_path), "-m", "pip", "--no-input", "install"]
                 + pip_args
                 + [package_or_url]
             )
@@ -285,7 +285,7 @@ class Venv:
             # do not use -q with `pip install` so subprocess_post_check_pip_errors
             #   has more information to analyze in case of failure.
             cmd = (
-                [str(self.python_path), "-m", "pip", "install"]
+                [str(self.python_path), "-m", "pip", "--no-input", "install"]
                 + pip_args
                 + requirements
             )
@@ -301,7 +301,11 @@ class Venv:
             f"determining package name from {package_or_url!r}", self.do_animation
         ):
             old_package_set = self.list_installed_packages()
-            cmd = ["install"] + ["--no-dependencies"] + pip_args + [package_or_url]
+            cmd = (
+                ["--no-input", "install", "--no-dependencies"]
+                + pip_args
+                + [package_or_url]
+            )
             pip_process = self._run_pip(cmd)
         subprocess_post_check(pip_process, raise_error=False)
         if pip_process.returncode:
@@ -429,7 +433,7 @@ class Venv:
             self.do_animation,
         ):
             pip_process = self._run_pip(
-                ["install"] + pip_args + ["--upgrade", package_name]
+                ["--no-input", "install"] + pip_args + ["--upgrade", package_name]
             )
         subprocess_post_check(pip_process)
 
@@ -448,7 +452,7 @@ class Venv:
             self.do_animation,
         ):
             pip_process = self._run_pip(
-                ["install"] + pip_args + ["--upgrade", package_or_url]
+                ["--no-input", "install"] + pip_args + ["--upgrade", package_or_url]
             )
         subprocess_post_check(pip_process)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,7 +125,7 @@ def pipx_local_pypiserver(request):
             request.config.invocation_params.dir / PIPX_TESTS_DIR / "htpasswd"
         )
 
-        from passlib.apache import HtpasswdFile
+        from passlib.apache import HtpasswdFile  # type: ignore
 
         ht = HtpasswdFile(pypiserver_htpasswd, new=True)
         ht.set_password("username", "password")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -278,3 +278,9 @@ def test_force_install_changes(pipx_temp_env, capsys):
 def test_preinstall(pipx_temp_env, caplog):
     assert not run_pipx_cli(["install", "--preinstall", "black", "nox"])
     assert "black" in caplog.text
+
+
+@pytest.mark.xfail
+def test_do_not_wait_for_input(pipx_temp_env, pipx_session_shared_dir, monkeypatch):
+    monkeypatch.setenv("PIP_INDEX_URL", "http://127.0.0.1:8080/simple")
+    run_pipx_cli(["install", "pycowsay"])


### PR DESCRIPTION
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Pass `--no-input` to Pip.

Fixes #219 

This is a breaking change for keyring users. But was it ever properly supported anyway? As someone who needs the `artifacts-keyring` package to authenticate with our private repo I'm going with the answer being `no, you will have to apply hacks if this is important to you`. Failing fast is better then hanging forever because the user can't see the prompt asking for a username and password.

https://github.com/pypa/pip/pull/11698 which is released in Pip 23.1 added a section to the documentation how Pipx users who rely on the keyring library can set things up so keyring will be used again: https://pip.pypa.io/en/stable/topics/authentication/#using-keyring-as-a-command-line-application.

## Test plan
It should not have any impact when keyring is not required to authenticate with the repository.

Tested by running the test suite. 
```
pipx run --index https://pypi.org/simple/ cowsay no input
```
