### PR TITLE
fix(install): set v1.8.0 as upper-bound on userpath

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "importlib-metadata>=3.3.0; python_version < '3.8'",
   "packaging>=20.0",
   "platformdirs>=2.1.0",
-  "userpath>=1.6.0",
+  "userpath>=1.6.0, <=1.9.1, !=1.9.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
This fixes the functional regression introduced by userpath v1.9.0. For details see issue #1025.