### PR TITLE
Fix program name in generated manual page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [docs] Add subsection to make README easier to read
 - Add `pipx install --preinstall` to support preinstalling build requirements
 - Pass `--no-input` to pip when output is not piped to parent stdout
+- Fix program name in generated manual page
 
 ## 1.2.0
 

--- a/scripts/generate_man.py
+++ b/scripts/generate_man.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import os.path
+import sys
 import textwrap
 
 from build_manpages.manpage import Manpage  # type: ignore
@@ -10,6 +11,7 @@ from pipx.main import get_command_parser
 
 
 def main():
+    sys.argv[0] = "pipx"
     parser = get_command_parser()
     parser.man_short_description = parser.description.splitlines()[1]
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

243c631ceafc089e2485cd97655cb44d4690232c caused `python scripts/generate_man.py` (e.g. via `nox -s build_man`) to produce a manual page with `generate_man.py` as the program name. Fix this by changing `sys.argv[0]` to `pipx` before creating the parser.

## Test plan

AFAICT `scripts/generate_man.py` is not currently tested.