### PR TITLE
Fix PIPX_HOME move instruction and improve text

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -122,18 +122,23 @@ rm -rf test_venv
 
 ## Pipx files not in expected locations according to documentation
 
-The default PIPX_HOME is `~/.local/pipx`, prior to the adoption of the XDG base
-directory specification after version 1.2.0. To maintain compatibility with older
-versions, pipx will automatically detect the old paths and use them accordingly.
-For a map of old and new paths, See [Installation](installation.md#installation-options)
+Pipx versions after 1.2.0 adopt the XDG base directory specification for
+the location of `PIPX_HOME` and the data, cache, and log directories.
+Version 1.2.0 and earlier use `PIPX_HOME=~/.local/pipx` and locate the
+data, cache, and log directories under that `PIPX_HOME`. To maintain
+compatibility with older versions, pipx will automatically use this old
+`PIPX_HOME` path if it exists. For a map of old and new paths, see
+[Installation](installation.md#installation-options).
 
-To migrate from the old path to the new path, you can remove the `~/.local/pipx` directory and
-reinstall all packages.
-
-For example, on Linux systems, you could read out `pipx`'s package information in JSON via `jq` (which you might need to install first):
+If you have a `pipx` version later than 1.2.0 and want to migrate from
+the old path to the new paths, you can move the `~/.local/pipx`
+directory to the new location and then reinstall all packages. For
+example, on Linux systems, `PIPX_HOME` moves from `~/.local/pipx` to
+`~/.local/share/pipx` so do this:
 
 ```
-packages=($(pipx list --json | jq '.venvs | keys[]' -r))
-rm -rf ~/.local/pipx
-for p in ${packages[@]}; do pipx install "$p"; done
+rm -rf ~/.local/pipx/{.cache,logs,trash}
+mkdir -p ~/.local/share
+mv ~/.local/pipx ~/.local/share/
+pipx reinstall-all
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -124,21 +124,21 @@ rm -rf test_venv
 
 Pipx versions after 1.2.0 adopt the XDG base directory specification for
 the location of `PIPX_HOME` and the data, cache, and log directories.
-Version 1.2.0 and earlier use `PIPX_HOME=~/.local/pipx` and locate the
-data, cache, and log directories under that `PIPX_HOME`. To maintain
+Version 1.2.0 and earlier use `~/.local/pipx` as the default `PIPX_HOME`
+and install the data, cache, and log directories under it. To maintain
 compatibility with older versions, pipx will automatically use this old
 `PIPX_HOME` path if it exists. For a map of old and new paths, see
 [Installation](installation.md#installation-options).
 
 If you have a `pipx` version later than 1.2.0 and want to migrate from
 the old path to the new paths, you can move the `~/.local/pipx`
-directory to the new location and then reinstall all packages. For
-example, on Linux systems, `PIPX_HOME` moves from `~/.local/pipx` to
-`~/.local/share/pipx` so do this:
+directory to the new location (after removing cache, log, and trash
+directories which will get recreated automatically) and then reinstall
+all packages. For example, on Linux systems, `PIPX_HOME` moves from
+`~/.local/pipx` to `~/.local/share/pipx` so you can do this:
 
 ```
 rm -rf ~/.local/pipx/{.cache,logs,trash}
-mkdir -p ~/.local/share
-mv ~/.local/pipx ~/.local/share/
+mkdir -p ~/.local/share && mv ~/.local/pipx ~/.local/share/
 pipx reinstall-all
 ```


### PR DESCRIPTION
The procedure previously documented in the section I changed here was incorrect because it assumes all packages were originally from PyPi, so does not work for packages installed from local source, or packages installed from VCS sources. I fixed the procedure to simply use `pipx reinstall`. I also found the section was a little confusing so I have rewritten t to hopefully make it clearer.
