### PR TITLE
Return error when directory can't be added to PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Pass `--no-input` to pip when output is not piped to parent stdout
 - Fix program name in generated manual page
 - Print all environment variables in `pipx environment`
+- Return an error message when directory can't be added to PATH successfully
 
 ## 1.2.0
 

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -61,14 +61,22 @@ def ensure_path(location: Path, *, force: bool) -> Tuple[bool, bool]:
     in_current_path = userpath.in_current_path(location_str)
 
     if force or (not in_current_path and not need_shell_restart):
-        userpath.append(location_str, "pipx")
-        print(
-            pipx_wrap(
-                f"Success! Added {location_str} to the PATH environment variable.",
-                subsequent_indent=" " * 4,
+        path_added = userpath.append(location_str, "pipx")
+        if not path_added:
+            print(
+                pipx_wrap(
+                    f"{location_str} is not added to the PATH environment variable successfully. "
+                    f"You may need to add {location_str} to it manually.",
+                    subsequent_indent=" " * 4,
+                )
             )
-        )
-        path_added = True
+        else:
+            print(
+                pipx_wrap(
+                    f"Success! Added {location_str} to the PATH environment variable.",
+                    subsequent_indent=" " * 4,
+                )
+            )
         need_shell_restart = userpath.need_shell_restart(location_str)
     elif not in_current_path and need_shell_restart:
         print(

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -65,8 +65,8 @@ def ensure_path(location: Path, *, force: bool) -> Tuple[bool, bool]:
         if not path_added:
             print(
                 pipx_wrap(
-                    f"{location_str} is not added to the PATH environment variable successfully. "
-                    f"You may need to add {location_str} to it manually.",
+                    f"{hazard}  {location_str} is not added to the PATH environment variable successfully. "
+                    f"You may need to add it to PATH manually.",
                     subsequent_indent=" " * 4,
                 )
             )


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Return an error message when directory can't be added to PATH successfully.
Closes https://github.com/pypa/pipx/issues/1064

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
chmod 0444 ~/.zshrc
pipx ensurepath --force
```
