### PR TITLE
Relax VenvInspectInformation attribute typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## dev
 
+- Use `Iterable[metadata.Distribution]` instead of `List[metadata.Distribution]` in `venv_inspect.py` (#629)
 - Make usage message in `pipx run` show `package_or_url`, so extra will be printed out as well
 - Add `--force-reinstall` to pip arguments when `--force` was passed
 - Use the py launcher, if available, to select Python version with the `--python` option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## dev
 
-- Use `Iterable[metadata.Distribution]` instead of `List[metadata.Distribution]` in `venv_inspect.py` (#629)
 - Make usage message in `pipx run` show `package_or_url`, so extra will be printed out as well
 - Add `--force-reinstall` to pip arguments when `--force` was passed
 - Use the py launcher, if available, to select Python version with the `--python` option

--- a/src/pipx/venv_inspect.py
+++ b/src/pipx/venv_inspect.py
@@ -1,9 +1,14 @@
 import json
 import logging
+import sys
 import textwrap
-from collections.abc import Collection
 from pathlib import Path
 from typing import Dict, List, NamedTuple, Optional, Set, Tuple
+
+if sys.version_info >= (3, 9):
+    from collections.abc import Collection
+else:
+    from typing import Collection
 
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name

--- a/src/pipx/venv_inspect.py
+++ b/src/pipx/venv_inspect.py
@@ -1,14 +1,8 @@
 import json
 import logging
-import sys
 import textwrap
 from pathlib import Path
-from typing import Dict, List, NamedTuple, Optional, Set, Tuple
-
-if sys.version_info >= (3, 9):
-    from collections.abc import Collection
-else:
-    from typing import Collection
+from typing import Collection, Dict, List, NamedTuple, Optional, Set, Tuple
 
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name

--- a/src/pipx/venv_inspect.py
+++ b/src/pipx/venv_inspect.py
@@ -1,8 +1,9 @@
 import json
 import logging
 import textwrap
+from collections.abc import Collection
 from pathlib import Path
-from typing import Dict, Iterable, List, NamedTuple, Optional, Set, Tuple
+from typing import Dict, List, NamedTuple, Optional, Set, Tuple
 
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
@@ -19,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 class VenvInspectInformation(NamedTuple):
-    distributions: Iterable[metadata.Distribution]
+    distributions: Collection[metadata.Distribution]
     env: Dict[str, str]
     bin_path: Path
 
@@ -34,7 +35,7 @@ class VenvMetadata(NamedTuple):
 
 
 def get_dist(
-    package: str, distributions: Iterable[metadata.Distribution]
+    package: str, distributions: Collection[metadata.Distribution]
 ) -> Optional[metadata.Distribution]:
     """Find matching distribution in the canonicalized sense."""
     for dist in distributions:


### PR DESCRIPTION

## Description

This PR aims to remove the explicit call to `list()` made in `venv_inspect.py` by using the type that `importlib.metadata.distributions()` returns (an `Iterator` from `itertools.chain.from_iterable`, [see](https://github.com/python/cpython/blob/3.11/Lib/importlib/metadata/__init__.py#L581)) from wrapping `Distribution.discover(**kwargs)`.

However, the code logic would be flawed if we used an `Iterator` (in this case skipping the explicit `list()` call) because we could only iterate on it once and need to do it multiple times in `_dfs_package_apps` to retrieve the dependencies for a given package correctly. 

Therefore, an `Iterable` was used as a more generic type hint for more flexibility, and `tuple` was used instead of `list` since we are not modifying `VenvInspectInformation.distributions`.

* [X] I have added an entry to `docs/changelog.md`

## Summary of changes

* Import Iterable from typing
* Replace all the corresponding type hints
* Swap the explicit list() call to a tuple() call

## Test plan
Tested by running
```
nox -s lint
nox -s tests-3.11
```
Resolves: #629