### PR TITLE
Added --global option to perform actions for all users (#754)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fix program name in generated manual page
 - Print all environment variables in `pipx environment`
 - Return an error message when directory can't be added to PATH successfully
+- Added `--global` option to perform actions system-wide, for all users (#754).
 
 ## 1.2.0
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -15,6 +15,7 @@ pipx install --suffix @branch-name 'black[d] @ git+https://github.com/psf/black.
 pipx install --include-deps jupyter
 pipx install --pip-args='--pre' poetry
 pipx install --pip-args='--index-url=<private-repo-host>:<private-repo-port> --trusted-host=<private-repo-host>:<private-repo-port>' private-repo-package
+pipx --global install pycowsay
 ```
 
 ## `pipx run` examples

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -12,7 +12,7 @@ from typing import Dict, List, Optional, Set, Tuple
 import userpath  # type: ignore
 from packaging.utils import canonicalize_name
 
-from pipx import constants
+from pipx import paths
 from pipx.colors import bold, red
 from pipx.constants import WINDOWS
 from pipx.emojis import hazard, stars
@@ -214,7 +214,7 @@ def get_venv_summary(
 
     exposed_app_paths = get_exposed_app_paths_for_package(
         venv.bin_path,
-        constants.PIPX_DIRS.BIN_DIR,
+        paths.ctx.bin_dir,
         [add_suffix(app, package_metadata.suffix) for app in apps],
     )
     exposed_binary_names = sorted(p.name for p in exposed_app_paths)

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -214,7 +214,7 @@ def get_venv_summary(
 
     exposed_app_paths = get_exposed_app_paths_for_package(
         venv.bin_path,
-        constants.LOCAL_BIN_DIR,
+        constants.PIPX_DIRS.BIN_DIR,
         [add_suffix(app, package_metadata.suffix) for app in apps],
     )
     exposed_binary_names = sorted(p.name for p in exposed_app_paths)

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -99,7 +99,7 @@ def ensure_path(location: Path, *, force: bool) -> Tuple[bool, bool]:
 
 def ensure_pipx_paths(force: bool) -> ExitCode:
     """Returns pipx exit code."""
-    bin_paths = {constants.LOCAL_BIN_DIR}
+    bin_paths = {constants.PIPX_DIRS.BIN_DIR}
 
     pipx_user_bin_path = get_pipx_user_bin_path()
     if pipx_user_bin_path is not None:

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -6,7 +6,7 @@ from typing import Optional, Tuple
 
 import userpath  # type: ignore
 
-from pipx import constants
+from pipx import paths
 from pipx.constants import EXIT_CODE_OK, ExitCode
 from pipx.emojis import hazard, stars
 from pipx.util import pipx_wrap
@@ -99,7 +99,7 @@ def ensure_path(location: Path, *, force: bool) -> Tuple[bool, bool]:
 
 def ensure_pipx_paths(force: bool) -> ExitCode:
     """Returns pipx exit code."""
-    bin_paths = {constants.PIPX_DIRS.BIN_DIR}
+    bin_paths = {paths.ctx.bin_dir}
 
     pipx_user_bin_path = get_pipx_user_bin_path()
     if pipx_user_bin_path is not None:

--- a/src/pipx/commands/environment.py
+++ b/src/pipx/commands/environment.py
@@ -1,6 +1,7 @@
 import os
 
-from pipx.constants import EXIT_CODE_OK, PIPX_DIRS, ExitCode
+from pipx import paths
+from pipx.constants import EXIT_CODE_OK, ExitCode
 from pipx.emojis import EMOJI_SUPPORT
 from pipx.interpreter import DEFAULT_PYTHON
 from pipx.util import PipxError
@@ -16,13 +17,13 @@ def environment(value: str) -> ExitCode:
         "USE_EMOJI",
     ]
     derived_values = {
-        "PIPX_HOME": PIPX_DIRS.HOME,
-        "PIPX_BIN_DIR": PIPX_DIRS.BIN_DIR,
-        "PIPX_SHARED_LIBS": PIPX_DIRS.SHARED_LIBS,
-        "PIPX_LOCAL_VENVS": PIPX_DIRS.LOCAL_VENVS,
-        "PIPX_LOG_DIR": PIPX_DIRS.LOG_DIR,
-        "PIPX_TRASH_DIR": PIPX_DIRS.TRASH_DIR,
-        "PIPX_VENV_CACHEDIR": PIPX_DIRS.VENV_CACHEDIR,
+        "PIPX_HOME": paths.ctx.home,
+        "PIPX_BIN_DIR": paths.ctx.bin_dir,
+        "PIPX_SHARED_LIBS": paths.ctx.shared_libs,
+        "PIPX_LOCAL_VENVS": paths.ctx.venvs,
+        "PIPX_LOG_DIR": paths.ctx.logs,
+        "PIPX_TRASH_DIR": paths.ctx.trash,
+        "PIPX_VENV_CACHEDIR": paths.ctx.venv_cache,
         "PIPX_DEFAULT_PYTHON": DEFAULT_PYTHON,
         "USE_EMOJI": str(EMOJI_SUPPORT).lower(),
     }

--- a/src/pipx/commands/environment.py
+++ b/src/pipx/commands/environment.py
@@ -1,16 +1,6 @@
 import os
 
-from pipx.constants import (
-    EXIT_CODE_OK,
-    LOCAL_BIN_DIR,
-    PIPX_HOME,
-    PIPX_LOCAL_VENVS,
-    PIPX_LOG_DIR,
-    PIPX_SHARED_LIBS,
-    PIPX_TRASH_DIR,
-    PIPX_VENV_CACHEDIR,
-    ExitCode,
-)
+from pipx.constants import EXIT_CODE_OK, PIPX_DIRS, ExitCode
 from pipx.emojis import EMOJI_SUPPORT
 from pipx.interpreter import DEFAULT_PYTHON
 from pipx.util import PipxError
@@ -26,13 +16,13 @@ def environment(value: str) -> ExitCode:
         "USE_EMOJI",
     ]
     derived_values = {
-        "PIPX_HOME": PIPX_HOME,
-        "PIPX_BIN_DIR": LOCAL_BIN_DIR,
-        "PIPX_SHARED_LIBS": PIPX_SHARED_LIBS,
-        "PIPX_LOCAL_VENVS": PIPX_LOCAL_VENVS,
-        "PIPX_LOG_DIR": PIPX_LOG_DIR,
-        "PIPX_TRASH_DIR": PIPX_TRASH_DIR,
-        "PIPX_VENV_CACHEDIR": PIPX_VENV_CACHEDIR,
+        "PIPX_HOME": PIPX_DIRS.HOME,
+        "PIPX_BIN_DIR": PIPX_DIRS.BIN_DIR,
+        "PIPX_SHARED_LIBS": PIPX_DIRS.SHARED_LIBS,
+        "PIPX_LOCAL_VENVS": PIPX_DIRS.LOCAL_VENVS,
+        "PIPX_LOG_DIR": PIPX_DIRS.LOG_DIR,
+        "PIPX_TRASH_DIR": PIPX_DIRS.TRASH_DIR,
+        "PIPX_VENV_CACHEDIR": PIPX_DIRS.VENV_CACHEDIR,
         "PIPX_DEFAULT_PYTHON": DEFAULT_PYTHON,
         "USE_EMOJI": str(EMOJI_SUPPORT).lower(),
     }

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 from typing import List, Optional
 
-from pipx import constants
+from pipx import paths
 from pipx.colors import bold
 from pipx.commands.common import package_name_from_spec, run_post_install_actions
 from pipx.constants import EXIT_CODE_INJECT_ERROR, EXIT_CODE_OK, ExitCode
@@ -66,7 +66,7 @@ def inject_dep(
         run_post_install_actions(
             venv,
             package_name,
-            constants.PIPX_DIRS.BIN_DIR,
+            paths.ctx.bin_dir,
             venv_dir,
             include_dependencies,
             force=force,

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -66,7 +66,7 @@ def inject_dep(
         run_post_install_actions(
             venv,
             package_name,
-            constants.LOCAL_BIN_DIR,
+            constants.PIPX_DIRS.BIN_DIR,
             venv_dir,
             include_dependencies,
             force=force,

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -32,7 +32,7 @@ def install(
             package_spec, python, pip_args=pip_args, verbose=verbose
         )
     if venv_dir is None:
-        venv_container = VenvContainer(constants.PIPX_LOCAL_VENVS)
+        venv_container = VenvContainer(constants.PIPX_DIRS.LOCAL_VENVS)
         venv_dir = venv_container.get_venv_dir(f"{package_name}{suffix}")
 
     try:

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import List, Optional
 
-from pipx import constants
+from pipx import paths
 from pipx.commands.common import package_name_from_spec, run_post_install_actions
 from pipx.constants import EXIT_CODE_INSTALL_VENV_EXISTS, EXIT_CODE_OK, ExitCode
 from pipx.util import pipx_wrap
@@ -32,7 +32,7 @@ def install(
             package_spec, python, pip_args=pip_args, verbose=verbose
         )
     if venv_dir is None:
-        venv_container = VenvContainer(constants.PIPX_DIRS.LOCAL_VENVS)
+        venv_container = VenvContainer(paths.ctx.venvs)
         venv_dir = venv_container.get_venv_dir(f"{package_name}{suffix}")
 
     try:

--- a/src/pipx/commands/list_packages.py
+++ b/src/pipx/commands/list_packages.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 from typing import Any, Collection, Dict, Tuple
 
-from pipx import constants
+from pipx import paths
 from pipx.colors import bold
 from pipx.commands.common import VenvProblems, get_venv_summary, venv_health_check
 from pipx.constants import EXIT_CODE_LIST_PROBLEM, EXIT_CODE_OK, ExitCode
@@ -47,7 +47,7 @@ def list_text(
     venv_dirs: Collection[Path], include_injected: bool, venv_root_dir: str
 ) -> VenvProblems:
     print(f"venvs are in {bold(venv_root_dir)}")
-    print(f"apps are exposed on your $PATH at {bold(str(constants.PIPX_DIRS.BIN_DIR))}")
+    print(f"apps are exposed on your $PATH at {bold(str(paths.ctx.bin_dir))}")
 
     all_venv_problems = VenvProblems()
     for venv_dir in venv_dirs:

--- a/src/pipx/commands/list_packages.py
+++ b/src/pipx/commands/list_packages.py
@@ -47,7 +47,7 @@ def list_text(
     venv_dirs: Collection[Path], include_injected: bool, venv_root_dir: str
 ) -> VenvProblems:
     print(f"venvs are in {bold(venv_root_dir)}")
-    print(f"apps are exposed on your $PATH at {bold(str(constants.LOCAL_BIN_DIR))}")
+    print(f"apps are exposed on your $PATH at {bold(str(constants.PIPX_DIRS.BIN_DIR))}")
 
     all_venv_problems = VenvProblems()
     for venv_dir in venv_dirs:

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -6,6 +6,7 @@ from typing import List, Sequence
 from packaging.utils import canonicalize_name
 
 import pipx.shared_libs  # import instead of from so mockable in tests
+from pipx import paths
 from pipx.commands.inject import inject_dep
 from pipx.commands.install import install
 from pipx.commands.uninstall import uninstall
@@ -13,7 +14,6 @@ from pipx.constants import (
     EXIT_CODE_OK,
     EXIT_CODE_REINSTALL_INVALID_PYTHON,
     EXIT_CODE_REINSTALL_VENV_NONEXISTENT,
-    PIPX_DIRS,
     ExitCode,
 )
 from pipx.emojis import error, sleep
@@ -50,7 +50,7 @@ def reinstall(
     if importlib.util.find_spec("pip") is None:
         raise PipxError(
             f"Can not find pip. You may encounter issues uninstalling packages. "
-            f"Remove {PIPX_DIRS.SHARED_LIBS} and run 'pipx reinstall-all' to fix them."
+            f"Remove {paths.ctx.shared_libs} and run 'pipx reinstall-all' to fix them."
         )
 
     uninstall(venv_dir, local_bin_dir, verbose)

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -13,7 +13,7 @@ from pipx.constants import (
     EXIT_CODE_OK,
     EXIT_CODE_REINSTALL_INVALID_PYTHON,
     EXIT_CODE_REINSTALL_VENV_NONEXISTENT,
-    PIPX_SHARED_LIBS,
+    PIPX_DIRS,
     ExitCode,
 )
 from pipx.emojis import error, sleep
@@ -50,7 +50,7 @@ def reinstall(
     if importlib.util.find_spec("pip") is None:
         raise PipxError(
             f"Can not find pip. You may encounter issues uninstalling packages. "
-            f"Remove {PIPX_SHARED_LIBS} and run 'pipx reinstall-all' to fix them."
+            f"Remove {PIPX_DIRS.SHARED_LIBS} and run 'pipx reinstall-all' to fix them."
         )
 
     uninstall(venv_dir, local_bin_dir, verbose)

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -283,7 +283,7 @@ def _get_temporary_venv_path(
     m.update("".join(pip_args).encode())
     m.update("".join(venv_args).encode())
     venv_folder_name = m.hexdigest()[:15]  # 15 chosen arbitrarily
-    return Path(constants.PIPX_VENV_CACHEDIR) / venv_folder_name
+    return Path(constants.PIPX_DIRS.VENV_CACHEDIR) / venv_folder_name
 
 
 def _is_temporary_venv_expired(venv_dir: Path) -> bool:
@@ -303,7 +303,7 @@ def _prepare_venv_cache(venv: Venv, bin_path: Optional[Path], use_cache: bool) -
 
 
 def _remove_all_expired_venvs() -> None:
-    for venv_dir in Path(constants.PIPX_VENV_CACHEDIR).iterdir():
+    for venv_dir in Path(constants.PIPX_DIRS.VENV_CACHEDIR).iterdir():
         if _is_temporary_venv_expired(venv_dir):
             logger.info(f"Removing expired venv {str(venv_dir)}")
             rmdir(venv_dir)

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -10,7 +10,7 @@ from typing import List, NoReturn, Optional
 
 from packaging.requirements import InvalidRequirement, Requirement
 
-from pipx import constants
+from pipx import paths
 from pipx.commands.common import package_name_from_spec
 from pipx.constants import TEMP_VENV_EXPIRATION_THRESHOLD_DAYS, WINDOWS
 from pipx.emojis import hazard
@@ -283,7 +283,7 @@ def _get_temporary_venv_path(
     m.update("".join(pip_args).encode())
     m.update("".join(venv_args).encode())
     venv_folder_name = m.hexdigest()[:15]  # 15 chosen arbitrarily
-    return Path(constants.PIPX_DIRS.VENV_CACHEDIR) / venv_folder_name
+    return Path(paths.ctx.venv_cache) / venv_folder_name
 
 
 def _is_temporary_venv_expired(venv_dir: Path) -> bool:
@@ -303,7 +303,7 @@ def _prepare_venv_cache(venv: Venv, bin_path: Optional[Path], use_cache: bool) -
 
 
 def _remove_all_expired_venvs() -> None:
-    for venv_dir in Path(constants.PIPX_DIRS.VENV_CACHEDIR).iterdir():
+    for venv_dir in Path(paths.ctx.venv_cache).iterdir():
         if _is_temporary_venv_expired(venv_dir):
             logger.info(f"Removing expired venv {str(venv_dir)}")
             rmdir(venv_dir)

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 from typing import List, Sequence
 
-from pipx import constants
+from pipx import paths
 from pipx.colors import bold, red
 from pipx.commands.common import expose_apps_globally
 from pipx.constants import EXIT_CODE_OK, ExitCode
@@ -50,7 +50,7 @@ def _upgrade_package(
 
     if package_metadata.include_apps:
         expose_apps_globally(
-            constants.PIPX_DIRS.BIN_DIR,
+            paths.ctx.bin_dir,
             package_metadata.app_paths,
             force=force,
             suffix=package_metadata.suffix,
@@ -59,7 +59,7 @@ def _upgrade_package(
     if package_metadata.include_dependencies:
         for _, app_paths in package_metadata.app_paths_of_dependencies.items():
             expose_apps_globally(
-                constants.PIPX_DIRS.BIN_DIR,
+                paths.ctx.bin_dir,
                 app_paths,
                 force=force,
                 suffix=package_metadata.suffix,

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -50,7 +50,7 @@ def _upgrade_package(
 
     if package_metadata.include_apps:
         expose_apps_globally(
-            constants.LOCAL_BIN_DIR,
+            constants.PIPX_DIRS.BIN_DIR,
             package_metadata.app_paths,
             force=force,
             suffix=package_metadata.suffix,
@@ -59,7 +59,7 @@ def _upgrade_package(
     if package_metadata.include_dependencies:
         for _, app_paths in package_metadata.app_paths_of_dependencies.items():
             expose_apps_globally(
-                constants.LOCAL_BIN_DIR,
+                constants.PIPX_DIRS.BIN_DIR,
                 app_paths,
                 force=force,
                 suffix=package_metadata.suffix,

--- a/src/pipx/constants.py
+++ b/src/pipx/constants.py
@@ -1,17 +1,7 @@
-import os
 import sys
 import sysconfig
-from pathlib import Path
 from textwrap import dedent
-from typing import NewType, Optional
-
-from platformdirs import user_cache_path, user_data_path, user_log_path
-
-DEFAULT_PIPX_HOME = user_data_path("pipx")
-FALLBACK_PIPX_HOME = Path.home() / ".local/pipx"
-DEFAULT_PIPX_BIN_DIR = Path.home() / ".local/bin"
-DEFAULT_PIPX_GLOBAL_BIN_DIR = "/usr/local/bin"
-DEFAULT_PIPX_GLOBAL_HOME = "/opt/pipx"
+from typing import NewType
 
 PIPX_SHARED_PTH = "pipx_shared.pth"
 TEMP_VENV_EXPIRATION_THRESHOLD_DAYS = 14
@@ -28,67 +18,6 @@ EXIT_CODE_UNINSTALL_VENV_NONEXISTENT = ExitCode(1)
 EXIT_CODE_UNINSTALL_ERROR = ExitCode(1)
 EXIT_CODE_REINSTALL_VENV_NONEXISTENT = ExitCode(1)
 EXIT_CODE_REINSTALL_INVALID_PYTHON = ExitCode(1)
-
-pipx_log_file: Optional[Path] = None
-
-
-class PIPXDirs:
-    _base_home = os.environ.get("PIPX_HOME")
-    _base_bin = os.environ.get("PIPX_BIN_DIR")
-    _base_shared_libs = os.environ.get("PIPX_SHARED_LIBS")
-    _fallback_home = Path.home() / ".local/pipx"
-    _in_home = _base_home is not None or _fallback_home.exists()
-
-    @property
-    def LOCAL_VENVS(self) -> Path:
-        return self.HOME / "venvs"
-
-    @property
-    def LOG_DIR(self) -> Path:
-        if self._in_home:
-            return self.HOME / "logs"
-        return user_log_path("pipx")
-
-    @property
-    def TRASH_DIR(self) -> Path:
-        if self._in_home:
-            return self.HOME / ".trash"
-        return self.HOME / "trash"
-
-    @property
-    def VENV_CACHEDIR(self) -> Path:
-        if self._in_home:
-            return self.HOME / ".cache"
-        return user_cache_path("pipx")
-
-    @property
-    def BIN_DIR(self) -> Path:
-        return Path(self._base_bin or DEFAULT_PIPX_BIN_DIR).resolve()
-
-    @property
-    def HOME(self) -> Path:
-        if self._base_home:
-            home = Path(self._base_home)
-        elif self._fallback_home.exists():
-            home = self._fallback_home
-        else:
-            home = Path(DEFAULT_PIPX_HOME)
-        return home.resolve()
-
-    @property
-    def DEFAULT_SHARED_LIBS(self) -> Path:
-        return self.HOME / "shared"
-
-    @property
-    def SHARED_LIBS(self) -> Path:
-        return Path(self._base_shared_libs or self.DEFAULT_SHARED_LIBS).resolve()
-
-    def make_global(self) -> None:
-        self._base_home = DEFAULT_PIPX_GLOBAL_HOME
-        self._base_bin = DEFAULT_PIPX_GLOBAL_BIN_DIR
-
-
-PIPX_DIRS = PIPXDirs()
 
 
 def is_windows() -> bool:

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -162,7 +162,7 @@ def get_venv_args(parsed_args: Dict[str, str]) -> List[str]:
 
 def run_pipx_command(args: argparse.Namespace) -> ExitCode:  # noqa: C901
     verbose = args.verbose if "verbose" in args else False
-    if args.is_global:
+    if not constants.WINDOWS and args.is_global:
         constants.PIPX_DIRS.make_global()
     pip_args = get_pip_args(vars(args))
     venv_args = get_venv_args(vars(args))
@@ -721,12 +721,13 @@ def get_command_parser() -> argparse.ArgumentParser:
     _add_ensurepath(subparsers)
     _add_environment(subparsers)
 
-    parser.add_argument(
-        "--global",
-        action="store_true",
-        dest="is_global",
-        help="Preform action globally for all users.",
-    )
+    if not constants.WINDOWS:
+        parser.add_argument(
+            "--global",
+            action="store_true",
+            dest="is_global",
+            help="Preform action globally for all users.",
+        )
     parser.add_argument("--version", action="store_true", help="Print version and exit")
     subparsers.add_parser(
         "completions",

--- a/src/pipx/paths.py
+++ b/src/pipx/paths.py
@@ -1,0 +1,67 @@
+import os
+from pathlib import Path
+from typing import Optional, Union
+
+from platformdirs import user_cache_path, user_data_path, user_log_path
+
+DEFAULT_PIPX_HOME = user_data_path("pipx")
+FALLBACK_PIPX_HOME = Path.home() / ".local/pipx"
+DEFAULT_PIPX_BIN_DIR = Path.home() / ".local/bin"
+DEFAULT_PIPX_GLOBAL_BIN_DIR = "/usr/local/bin"
+DEFAULT_PIPX_GLOBAL_HOME = "/opt/pipx"
+
+
+class _PathContext:
+    _base_home: Optional[Union[Path, str]] = os.environ.get("PIPX_HOME")
+    _base_bin: Optional[Union[Path, str]] = os.environ.get("PIPX_BIN_DIR")
+    _base_shared_libs: Optional[Union[Path, str]] = os.environ.get("PIPX_SHARED_LIBS")
+    _fallback_home: Path = Path.home() / ".local/pipx"
+    _in_home: bool = _base_home is not None or _fallback_home.exists()
+    log_file: Optional[Path] = None
+
+    @property
+    def venvs(self) -> Path:
+        return self.home / "venvs"
+
+    @property
+    def logs(self) -> Path:
+        if self._in_home:
+            return self.home / "logs"
+        return user_log_path("pipx")
+
+    @property
+    def trash(self) -> Path:
+        if self._in_home:
+            return self.home / ".trash"
+        return self.home / "trash"
+
+    @property
+    def venv_cache(self) -> Path:
+        if self._in_home:
+            return self.home / ".cache"
+        return user_cache_path("pipx")
+
+    @property
+    def bin_dir(self) -> Path:
+        return Path(self._base_bin or DEFAULT_PIPX_BIN_DIR).resolve()
+
+    @property
+    def home(self) -> Path:
+        if self._base_home:
+            home = Path(self._base_home)
+        elif self._fallback_home.exists():
+            home = self._fallback_home
+        else:
+            home = Path(DEFAULT_PIPX_HOME)
+        return home.resolve()
+
+    @property
+    def shared_libs(self) -> Path:
+        return Path(self._base_shared_libs or self.home / "shared").resolve()
+
+    def make_global(self) -> None:
+        self._base_home = DEFAULT_PIPX_GLOBAL_HOME
+        self._base_bin = DEFAULT_PIPX_GLOBAL_BIN_DIR
+
+
+ctx = _PathContext()

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -23,7 +23,7 @@ SHARED_LIBS_MAX_AGE_SEC = datetime.timedelta(days=30).total_seconds()
 
 class _SharedLibs:
     def __init__(self) -> None:
-        self.root = constants.PIPX_SHARED_LIBS
+        self.root = constants.PIPX_DIRS.SHARED_LIBS
         self.bin_path, self.python_path = get_venv_paths(self.root)
         self.pip_path = self.bin_path / ("pip" if not WINDOWS else "pip.exe")
         # i.e. bin_path is ~/.local/pipx/shared/bin

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -4,7 +4,7 @@ import time
 from pathlib import Path
 from typing import List, Optional
 
-from pipx import constants
+from pipx import paths
 from pipx.animate import animate
 from pipx.constants import WINDOWS
 from pipx.interpreter import DEFAULT_PYTHON
@@ -23,7 +23,7 @@ SHARED_LIBS_MAX_AGE_SEC = datetime.timedelta(days=30).total_seconds()
 
 class _SharedLibs:
     def __init__(self) -> None:
-        self.root = constants.PIPX_DIRS.SHARED_LIBS
+        self.root = paths.ctx.shared_libs
         self.bin_path, self.python_path = get_venv_paths(self.root)
         self.pip_path = self.bin_path / ("pip" if not WINDOWS else "pip.exe")
         # i.e. bin_path is ~/.local/pipx/shared/bin

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -21,7 +21,7 @@ from typing import (
     Union,
 )
 
-import pipx.constants
+from pipx import paths
 from pipx.animate import show_cursor
 from pipx.constants import MINGW, WINDOWS
 
@@ -42,10 +42,10 @@ class RelevantSearch(NamedTuple):
 
 
 def _get_trash_file(path: Path) -> Path:
-    if not pipx.constants.PIPX_DIRS.TRASH_DIR.is_dir():
-        pipx.constants.PIPX_DIRS.TRASH_DIR.mkdir()
+    if not paths.ctx.trash.is_dir():
+        paths.ctx.trash.mkdir()
     prefix = "".join(random.choices(string.ascii_lowercase, k=8))
-    return pipx.constants.PIPX_DIRS.TRASH_DIR / f"{prefix}.{path.name}"
+    return paths.ctx.trash / f"{prefix}.{path.name}"
 
 
 def rmdir(path: Path, safe_rm: bool = True) -> None:
@@ -334,10 +334,10 @@ def subprocess_post_check_handle_pip_error(
     if completed_process.returncode:
         logger.info(f"{' '.join(completed_process.args)!r} failed")
         # Save STDOUT and STDERR to file in pipx/logs/
-        if pipx.constants.pipx_log_file is None:
+        if paths.ctx.log_file is None:
             raise PipxError("Pipx internal error: No log_file present.")
-        pip_error_file = pipx.constants.pipx_log_file.parent / (
-            pipx.constants.pipx_log_file.stem + "_pip_errors.log"
+        pip_error_file = paths.ctx.log_file.parent / (
+            paths.ctx.log_file.stem + "_pip_errors.log"
         )
         with pip_error_file.open("w", encoding="utf-8") as pip_error_fh:
             print("PIP STDOUT", file=pip_error_fh)

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -23,7 +23,7 @@ from typing import (
 
 import pipx.constants
 from pipx.animate import show_cursor
-from pipx.constants import MINGW, PIPX_TRASH_DIR, WINDOWS
+from pipx.constants import MINGW, WINDOWS
 
 logger = logging.getLogger(__name__)
 
@@ -42,10 +42,10 @@ class RelevantSearch(NamedTuple):
 
 
 def _get_trash_file(path: Path) -> Path:
-    if not PIPX_TRASH_DIR.is_dir():
-        PIPX_TRASH_DIR.mkdir()
+    if not pipx.constants.PIPX_DIRS.TRASH_DIR.is_dir():
+        pipx.constants.PIPX_DIRS.TRASH_DIR.mkdir()
     prefix = "".join(random.choices(string.ascii_lowercase, k=8))
-    return PIPX_TRASH_DIR / f"{prefix}.{path.name}"
+    return pipx.constants.PIPX_DIRS.TRASH_DIR / f"{prefix}.{path.name}"
 
 
 def rmdir(path: Path, safe_rm: bool = True) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest  # type: ignore
 
 from helpers import WIN
-from pipx import commands, constants, interpreter, shared_libs, venv
+from pipx import commands, interpreter, paths, shared_libs, venv
 
 PIPX_TESTS_DIR = Path(".pipx_tests")
 PIPX_TESTS_PACKAGE_LIST_DIR = Path("testdata/tests_packages")
@@ -50,12 +50,12 @@ def pipx_temp_env_helper(
     global_home_dir = Path(tmp_path) / "global" / "pipxhome"
 
     # Patch in test specific base paths
-    monkeypatch.setattr(constants.PIPX_DIRS, "_base_shared_libs", pipx_shared_dir)
-    monkeypatch.setattr(constants.PIPX_DIRS, "_base_home", home_dir)
-    monkeypatch.setattr(constants.PIPX_DIRS, "_base_bin", bin_dir)
+    monkeypatch.setattr(paths.ctx, "_base_shared_libs", pipx_shared_dir)
+    monkeypatch.setattr(paths.ctx, "_base_home", home_dir)
+    monkeypatch.setattr(paths.ctx, "_base_bin", bin_dir)
     # Patch the default global paths so developers don't contaminate their own systems
-    monkeypatch.setattr(constants, "DEFAULT_PIPX_GLOBAL_BIN_DIR", global_bin_dir)
-    monkeypatch.setattr(constants, "DEFAULT_PIPX_GLOBAL_HOME", global_home_dir)
+    monkeypatch.setattr(paths, "DEFAULT_PIPX_GLOBAL_BIN_DIR", global_bin_dir)
+    monkeypatch.setattr(paths, "DEFAULT_PIPX_GLOBAL_HOME", global_home_dir)
     monkeypatch.setattr(shared_libs, "shared_libs", shared_libs._SharedLibs())
     monkeypatch.setattr(venv, "shared_libs", shared_libs.shared_libs)
     monkeypatch.setattr(interpreter, "DEFAULT_PYTHON", sys.executable)
@@ -67,18 +67,18 @@ def pipx_temp_env_helper(
     #   applications in /usr/bin cause test_install.py tests to raise warnings
     #   which make tests fail (e.g. on Github ansible apps exist in /usr/bin)
     monkeypatch.setenv(
-        "PATH_ORIG", str(constants.PIPX_DIRS.BIN_DIR) + os.pathsep + os.getenv("PATH")
+        "PATH_ORIG", str(paths.ctx.bin_dir) + os.pathsep + os.getenv("PATH")
     )
-    monkeypatch.setenv("PATH_TEST", str(constants.PIPX_DIRS.BIN_DIR))
+    monkeypatch.setenv("PATH_TEST", str(paths.ctx.bin_dir))
     monkeypatch.setenv(
-        "PATH", str(constants.PIPX_DIRS.BIN_DIR) + os.pathsep + str(utils_temp_dir)
+        "PATH", str(paths.ctx.bin_dir) + os.pathsep + str(utils_temp_dir)
     )
     # On Windows, monkeypatch pipx.commands.common._can_symlink_cache to
-    #   indicate that constants.PIPX_DIRS.BIN_DIR cannot use symlinks, even if
+    #   indicate that paths.ctx.bin_dir cannot use symlinks, even if
     #   we're running as administrator and symlinks are actually possible.
     if WIN:
         monkeypatch.setitem(
-            commands.common._can_symlink_cache, constants.PIPX_DIRS.BIN_DIR, False
+            commands.common._can_symlink_cache, paths.ctx.bin_dir, False
         )
     if not request.config.option.net_pypiserver:
         # IMPORTANT: use 127.0.0.1 not localhost

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -9,7 +9,7 @@ from unittest import mock
 from packaging.utils import canonicalize_name
 
 from package_info import PKG
-from pipx import constants, main, pipx_metadata_file, util
+from pipx import constants, main, paths, pipx_metadata_file, util
 
 WIN = sys.platform.startswith("win")
 
@@ -76,7 +76,7 @@ def mock_legacy_venv(venv_name: str, metadata_version: Optional[str] = None) -> 
     one with a previous metadata version.
     metadata_version=None refers to no metadata file (pipx pre-0.15.0.0)
     """
-    venv_dir = Path(constants.PIPX_DIRS.LOCAL_VENVS) / canonicalize_name(venv_name)
+    venv_dir = Path(paths.ctx.venvs) / canonicalize_name(venv_name)
 
     if metadata_version == "0.2":
         # Current metadata version, do nothing
@@ -168,9 +168,7 @@ def assert_package_metadata(test_metadata, ref_metadata):
 
 
 def remove_venv_interpreter(venv_name):
-    _, venv_python_path = util.get_venv_paths(
-        constants.PIPX_DIRS.LOCAL_VENVS / venv_name
-    )
+    _, venv_python_path = util.get_venv_paths(paths.ctx.venvs / venv_name)
     assert venv_python_path.is_file()
     venv_python_path.unlink()
     assert not venv_python_path.is_file()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -76,7 +76,7 @@ def mock_legacy_venv(venv_name: str, metadata_version: Optional[str] = None) -> 
     one with a previous metadata version.
     metadata_version=None refers to no metadata file (pipx pre-0.15.0.0)
     """
-    venv_dir = Path(constants.PIPX_LOCAL_VENVS) / canonicalize_name(venv_name)
+    venv_dir = Path(constants.PIPX_DIRS.LOCAL_VENVS) / canonicalize_name(venv_name)
 
     if metadata_version == "0.2":
         # Current metadata version, do nothing
@@ -168,7 +168,9 @@ def assert_package_metadata(test_metadata, ref_metadata):
 
 
 def remove_venv_interpreter(venv_name):
-    _, venv_python_path = util.get_venv_paths(constants.PIPX_LOCAL_VENVS / venv_name)
+    _, venv_python_path = util.get_venv_paths(
+        constants.PIPX_DIRS.LOCAL_VENVS / venv_name
+    )
     assert venv_python_path.is_file()
     venv_python_path.unlink()
     assert not venv_python_path.is_file()

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,3 +1,7 @@
+import sys
+
+import pytest  # type: ignore
+
 from helpers import run_pipx_cli
 
 
@@ -33,6 +37,8 @@ def test_cli_with_args(monkeypatch, capsys):
 
 
 def test_cli_global(monkeypatch, capsys):
+    if sys.platform.startswith("win"):
+        pytest.skip("This behavior is undefined on Windows")
     assert not run_pipx_cli(["--global", "environment"])
     captured = capsys.readouterr()
     assert "PIPX_HOME=/opt/pipx" in captured.out

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -30,3 +30,18 @@ def test_cli_with_args(monkeypatch, capsys):
     assert run_pipx_cli(["environment", "--value", "SSS"])
     captured = capsys.readouterr()
     assert "Variable not found." in captured.err
+
+
+def test_cli_global(monkeypatch, capsys):
+    assert not run_pipx_cli(["--global", "environment"])
+    captured = capsys.readouterr()
+    assert "PIPX_HOME=/opt/pipx" in captured.out
+    assert "PIPX_BIN_DIR=/usr/local/bin" in captured.out
+    assert "PIPX_SHARED_LIBS=/opt/pipx/shared" in captured.out
+    assert "PIPX_LOCAL_VENVS=/opt/pipx/venvs" in captured.out
+    assert "PIPX_LOG_DIR=/opt/pipx/logs" in captured.out
+    assert "PIPX_TRASH_DIR=/opt/pipx/.trash" in captured.out
+    assert "PIPX_VENV_CACHEDIR=/opt/pipx/.cache" in captured.out
+    # Checking just for the sake of completeness
+    assert "PIPX_DEFAULT_PYTHON" in captured.out
+    assert "USE_EMOJI" in captured.out

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -9,6 +9,11 @@ def test_inject_simple(pipx_temp_env, capsys):
     assert not run_pipx_cli(["inject", "pycowsay", PKG["black"]["spec"]])
 
 
+def test_inject_simple_global(pipx_temp_env, capsys):
+    assert not run_pipx_cli(["--global", "install", "pycowsay"])
+    assert not run_pipx_cli(["--global", "inject", "pycowsay", PKG["black"]["spec"]])
+
+
 @pytest.mark.parametrize("metadata_version", [None, "0.1"])
 def test_inject_simple_legacy_venv(pipx_temp_env, capsys, metadata_version):
     assert not run_pipx_cli(["install", "pycowsay"])

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest  # type: ignore
 
 from helpers import mock_legacy_venv, run_pipx_cli
@@ -10,6 +12,8 @@ def test_inject_simple(pipx_temp_env, capsys):
 
 
 def test_inject_simple_global(pipx_temp_env, capsys):
+    if sys.platform.startswith("win"):
+        pytest.skip("This behavior is undefined on Windows")
     assert not run_pipx_cli(["--global", "install", "pycowsay"])
     assert not run_pipx_cli(["--global", "inject", "pycowsay", PKG["black"]["spec"]])
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -53,6 +53,16 @@ def test_install_easy_packages(
 
 @pytest.mark.parametrize(
     "package_name, package_spec",
+    [("pycowsay", "pycowsay"), ("black", PKG["black"]["spec"])],
+)
+def test_install_easy_packages_globally(
+    capsys, pipx_temp_env, caplog, package_name, package_spec
+):
+    install_package(capsys, pipx_temp_env, caplog, package_spec, package_name)
+
+
+@pytest.mark.parametrize(
+    "package_name, package_spec",
     [
         ("cloudtoken", PKG["cloudtoken"]["spec"]),
         ("awscli", PKG["awscli"]["spec"]),
@@ -83,6 +93,12 @@ def test_install_package_specs(
     capsys, pipx_temp_env, caplog, package_name, package_spec
 ):
     install_package(capsys, pipx_temp_env, caplog, package_spec, package_name)
+
+
+def test_global_install(pipx_temp_env, capsys):
+    run_pipx_cli(["--global", "install", "pycowsay"])
+    captured = capsys.readouterr()
+    assert "installed package" in captured.out
 
 
 def test_force_install(pipx_temp_env, capsys):
@@ -166,8 +182,8 @@ def test_existing_symlink_points_to_existing_wrong_location_warning(
     if sys.platform.startswith("win"):
         pytest.skip("pipx does not use symlinks on Windows")
 
-    constants.LOCAL_BIN_DIR.mkdir(exist_ok=True, parents=True)
-    (constants.LOCAL_BIN_DIR / "pycowsay").symlink_to(os.devnull)
+    constants.PIPX_DIRS.BIN_DIR.mkdir(exist_ok=True, parents=True)
+    (constants.PIPX_DIRS.BIN_DIR / "pycowsay").symlink_to(os.devnull)
     assert not run_pipx_cli(["install", "pycowsay"])
     captured = capsys.readouterr()
     assert "File exists at" in unwrap_log_text(caplog.text)
@@ -181,8 +197,8 @@ def test_existing_symlink_points_to_nothing(pipx_temp_env, capsys):
     if sys.platform.startswith("win"):
         pytest.skip("pipx does not use symlinks on Windows")
 
-    constants.LOCAL_BIN_DIR.mkdir(exist_ok=True, parents=True)
-    (constants.LOCAL_BIN_DIR / "pycowsay").symlink_to("/asdf/jkl")
+    constants.PIPX_DIRS.BIN_DIR.mkdir(exist_ok=True, parents=True)
+    (constants.PIPX_DIRS.BIN_DIR / "pycowsay").symlink_to("/asdf/jkl")
     assert not run_pipx_cli(["install", "pycowsay"])
     captured = capsys.readouterr()
     # pipx should realize the symlink points to nothing and replace it,
@@ -235,8 +251,8 @@ def test_install_suffix(pipx_temp_env, capsys):
     name_b = app_name(f"{name}{suffix}")
     assert f"- {name_b}" in captured.out
 
-    assert (constants.LOCAL_BIN_DIR / name_a).exists()
-    assert (constants.LOCAL_BIN_DIR / name_b).exists()
+    assert (constants.PIPX_DIRS.BIN_DIR / name_a).exists()
+    assert (constants.PIPX_DIRS.BIN_DIR / name_b).exists()
 
 
 def test_install_pip_failure(pipx_temp_env, capsys):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -9,7 +9,7 @@ import pytest  # type: ignore
 
 from helpers import app_name, run_pipx_cli, unwrap_log_text
 from package_info import PKG
-from pipx import constants
+from pipx import paths
 
 TEST_DATA_PATH = "./testdata/test_package_specifier"
 
@@ -97,12 +97,6 @@ def test_install_package_specs(
     install_package(capsys, pipx_temp_env, caplog, package_spec, package_name)
 
 
-def test_global_install(pipx_temp_env, capsys):
-    run_pipx_cli(["--global", "install", "pycowsay"])
-    captured = capsys.readouterr()
-    assert "installed package" in captured.out
-
-
 def test_force_install(pipx_temp_env, capsys):
     run_pipx_cli(["install", "pycowsay"])
     captured = capsys.readouterr()
@@ -184,8 +178,8 @@ def test_existing_symlink_points_to_existing_wrong_location_warning(
     if sys.platform.startswith("win"):
         pytest.skip("pipx does not use symlinks on Windows")
 
-    constants.PIPX_DIRS.BIN_DIR.mkdir(exist_ok=True, parents=True)
-    (constants.PIPX_DIRS.BIN_DIR / "pycowsay").symlink_to(os.devnull)
+    paths.ctx.bin_dir.mkdir(exist_ok=True, parents=True)
+    (paths.ctx.bin_dir / "pycowsay").symlink_to(os.devnull)
     assert not run_pipx_cli(["install", "pycowsay"])
     captured = capsys.readouterr()
     assert "File exists at" in unwrap_log_text(caplog.text)
@@ -199,8 +193,8 @@ def test_existing_symlink_points_to_nothing(pipx_temp_env, capsys):
     if sys.platform.startswith("win"):
         pytest.skip("pipx does not use symlinks on Windows")
 
-    constants.PIPX_DIRS.BIN_DIR.mkdir(exist_ok=True, parents=True)
-    (constants.PIPX_DIRS.BIN_DIR / "pycowsay").symlink_to("/asdf/jkl")
+    paths.ctx.bin_dir.mkdir(exist_ok=True, parents=True)
+    (paths.ctx.bin_dir / "pycowsay").symlink_to("/asdf/jkl")
     assert not run_pipx_cli(["install", "pycowsay"])
     captured = capsys.readouterr()
     # pipx should realize the symlink points to nothing and replace it,
@@ -253,8 +247,8 @@ def test_install_suffix(pipx_temp_env, capsys):
     name_b = app_name(f"{name}{suffix}")
     assert f"- {name_b}" in captured.out
 
-    assert (constants.PIPX_DIRS.BIN_DIR / name_a).exists()
-    assert (constants.PIPX_DIRS.BIN_DIR / name_b).exists()
+    assert (paths.ctx.bin_dir / name_a).exists()
+    assert (paths.ctx.bin_dir / name_b).exists()
 
 
 def test_install_pip_failure(pipx_temp_env, capsys):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -58,6 +58,8 @@ def test_install_easy_packages(
 def test_install_easy_packages_globally(
     capsys, pipx_temp_env, caplog, package_name, package_spec
 ):
+    if sys.platform.startswith("win"):
+        pytest.skip("This behavior is undefined on Windows")
     install_package(capsys, pipx_temp_env, caplog, package_spec, package_name)
 
 

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,5 +1,6 @@
 import json
 import re
+import sys
 
 import pytest  # type: ignore
 
@@ -23,6 +24,8 @@ def test_cli(pipx_temp_env, monkeypatch, capsys):
 
 
 def test_cli_global(pipx_temp_env, monkeypatch, capsys):
+    if sys.platform.startswith("win"):
+        pytest.skip("This behavior is undefined on Windows")
     assert not run_pipx_cli(["--global", "list"])
     captured = capsys.readouterr()
     assert "nothing has been installed with pipx" in captured.err

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -13,7 +13,7 @@ from helpers import (
     run_pipx_cli,
 )
 from package_info import PKG
-from pipx import constants
+from pipx import constants, paths
 from pipx.pipx_metadata_file import PackageInfo, _json_decoder_object_hook
 
 
@@ -81,7 +81,7 @@ def test_list_suffix_legacy_venv(pipx_temp_env, monkeypatch, capsys, metadata_ve
 
 
 def test_list_json(pipx_temp_env, capsys):
-    pipx_venvs_dir = constants.PIPX_DIRS.HOME / "venvs"
+    pipx_venvs_dir = paths.ctx.home / "venvs"
     venv_bin_dir = "Scripts" if constants.WINDOWS else "bin"
 
     assert not run_pipx_cli(["install", PKG["pycowsay"]["spec"]])

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -22,6 +22,12 @@ def test_cli(pipx_temp_env, monkeypatch, capsys):
     assert "nothing has been installed with pipx" in captured.err
 
 
+def test_cli_global(pipx_temp_env, monkeypatch, capsys):
+    assert not run_pipx_cli(["--global", "list"])
+    captured = capsys.readouterr()
+    assert "nothing has been installed with pipx" in captured.err
+
+
 def test_missing_interpreter(pipx_temp_env, monkeypatch, capsys):
     assert not run_pipx_cli(["install", "pycowsay"])
 
@@ -72,7 +78,7 @@ def test_list_suffix_legacy_venv(pipx_temp_env, monkeypatch, capsys, metadata_ve
 
 
 def test_list_json(pipx_temp_env, capsys):
-    pipx_venvs_dir = constants.PIPX_HOME / "venvs"
+    pipx_venvs_dir = constants.PIPX_DIRS.HOME / "venvs"
     venv_bin_dir = "Scripts" if constants.WINDOWS else "bin"
 
     assert not run_pipx_cli(["install", PKG["pycowsay"]["spec"]])

--- a/tests/test_pipx_metadata_file.py
+++ b/tests/test_pipx_metadata_file.py
@@ -80,7 +80,7 @@ def test_pipx_metadata_file_validation(tmp_path, test_package):
 
 
 def test_package_install(monkeypatch, tmp_path, pipx_temp_env):
-    pipx_venvs_dir = pipx.constants.PIPX_HOME / "venvs"
+    pipx_venvs_dir = pipx.constants.PIPX_DIRS.HOME / "venvs"
 
     run_pipx_cli(["install", PKG["pycowsay"]["spec"]])
     assert (pipx_venvs_dir / "pycowsay" / "pipx_metadata.json").is_file()
@@ -94,7 +94,7 @@ def test_package_install(monkeypatch, tmp_path, pipx_temp_env):
 
 
 def test_package_inject(monkeypatch, tmp_path, pipx_temp_env):
-    pipx_venvs_dir = pipx.constants.PIPX_HOME / "venvs"
+    pipx_venvs_dir = pipx.constants.PIPX_DIRS.HOME / "venvs"
 
     run_pipx_cli(["install", PKG["pycowsay"]["spec"]])
     run_pipx_cli(["inject", "pycowsay", PKG["black"]["spec"]])

--- a/tests/test_pipx_metadata_file.py
+++ b/tests/test_pipx_metadata_file.py
@@ -2,9 +2,9 @@ from pathlib import Path
 
 import pytest  # type: ignore
 
-import pipx.constants
 from helpers import assert_package_metadata, create_package_info_ref, run_pipx_cli
 from package_info import PKG
+from pipx import paths
 from pipx.pipx_metadata_file import PackageInfo, PipxMetadata
 from pipx.util import PipxError
 
@@ -80,7 +80,7 @@ def test_pipx_metadata_file_validation(tmp_path, test_package):
 
 
 def test_package_install(monkeypatch, tmp_path, pipx_temp_env):
-    pipx_venvs_dir = pipx.constants.PIPX_DIRS.HOME / "venvs"
+    pipx_venvs_dir = paths.ctx.home / "venvs"
 
     run_pipx_cli(["install", PKG["pycowsay"]["spec"]])
     assert (pipx_venvs_dir / "pycowsay" / "pipx_metadata.json").is_file()
@@ -94,7 +94,7 @@ def test_package_install(monkeypatch, tmp_path, pipx_temp_env):
 
 
 def test_package_inject(monkeypatch, tmp_path, pipx_temp_env):
-    pipx_venvs_dir = pipx.constants.PIPX_DIRS.HOME / "venvs"
+    pipx_venvs_dir = paths.ctx.home / "venvs"
 
     run_pipx_cli(["install", PKG["pycowsay"]["spec"]])
     run_pipx_cli(["inject", "pycowsay", PKG["black"]["spec"]])

--- a/tests/test_reinstall.py
+++ b/tests/test_reinstall.py
@@ -11,6 +11,8 @@ def test_reinstall(pipx_temp_env, capsys):
 
 
 def test_reinstall_global(pipx_temp_env, capsys):
+    if sys.platform.startswith("win"):
+        pytest.skip("This behavior is undefined on Windows")
     assert not run_pipx_cli(["--global", "install", "pycowsay"])
     assert not run_pipx_cli(
         ["--global", "reinstall", "--python", sys.executable, "pycowsay"]

--- a/tests/test_reinstall.py
+++ b/tests/test_reinstall.py
@@ -10,6 +10,13 @@ def test_reinstall(pipx_temp_env, capsys):
     assert not run_pipx_cli(["reinstall", "--python", sys.executable, "pycowsay"])
 
 
+def test_reinstall_global(pipx_temp_env, capsys):
+    assert not run_pipx_cli(["--global", "install", "pycowsay"])
+    assert not run_pipx_cli(
+        ["--global", "reinstall", "--python", sys.executable, "pycowsay"]
+    )
+
+
 def test_reinstall_nonexistent(pipx_temp_env, capsys):
     assert run_pipx_cli(["reinstall", "--python", sys.executable, "nonexistent"])
     assert "Nothing to reinstall for nonexistent" in capsys.readouterr().out

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -11,7 +11,7 @@ import pipx.main
 import pipx.util
 from helpers import run_pipx_cli
 from package_info import PKG
-from pipx import constants
+from pipx import paths
 
 
 def test_help_text(pipx_temp_env, monkeypatch, capsys):
@@ -66,7 +66,7 @@ def test_cache(pipx_temp_env, monkeypatch, capsys, caplog):
 
 @mock.patch("os.execvpe", new=execvpe_mock)
 def test_cachedir_tag(pipx_ultra_temp_env, monkeypatch, capsys, caplog):
-    tag_path = constants.PIPX_DIRS.VENV_CACHEDIR / "CACHEDIR.TAG"
+    tag_path = paths.ctx.venv_cache / "CACHEDIR.TAG"
     assert not tag_path.exists()
 
     # Run pipx to create tag

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -66,7 +66,7 @@ def test_cache(pipx_temp_env, monkeypatch, capsys, caplog):
 
 @mock.patch("os.execvpe", new=execvpe_mock)
 def test_cachedir_tag(pipx_ultra_temp_env, monkeypatch, capsys, caplog):
-    tag_path = constants.PIPX_VENV_CACHEDIR / "CACHEDIR.TAG"
+    tag_path = constants.PIPX_DIRS.VENV_CACHEDIR / "CACHEDIR.TAG"
     assert not tag_path.exists()
 
     # Run pipx to create tag

--- a/tests/test_runpip.py
+++ b/tests/test_runpip.py
@@ -4,3 +4,8 @@ from helpers import run_pipx_cli
 def test_runpip(pipx_temp_env, monkeypatch, capsys):
     assert not run_pipx_cli(["install", "pycowsay"])
     assert not run_pipx_cli(["runpip", "pycowsay", "list"])
+
+
+def test_runpip_global(pipx_temp_env, monkeypatch, capsys):
+    assert not run_pipx_cli(["--global", "install", "pycowsay"])
+    assert not run_pipx_cli(["--global", "runpip", "pycowsay", "list"])

--- a/tests/test_runpip.py
+++ b/tests/test_runpip.py
@@ -1,3 +1,7 @@
+import sys
+
+import pytest  # type: ignore
+
 from helpers import run_pipx_cli
 
 
@@ -7,5 +11,7 @@ def test_runpip(pipx_temp_env, monkeypatch, capsys):
 
 
 def test_runpip_global(pipx_temp_env, monkeypatch, capsys):
+    if sys.platform.startswith("win"):
+        pytest.skip("This behavior is undefined on Windows")
     assert not run_pipx_cli(["--global", "install", "pycowsay"])
     assert not run_pipx_cli(["--global", "runpip", "pycowsay", "list"])

--- a/tests/test_uninject.py
+++ b/tests/test_uninject.py
@@ -1,3 +1,7 @@
+import sys
+
+import pytest  # type: ignore
+
 from helpers import run_pipx_cli
 from package_info import PKG
 
@@ -9,6 +13,19 @@ def test_uninject_simple(pipx_temp_env, capsys):
     captured = capsys.readouterr()
     assert "Uninjected package black" in captured.out
     assert not run_pipx_cli(["list", "--include-injected"])
+    captured = capsys.readouterr()
+    assert "black" not in captured.out
+
+
+def test_uninject_simple_global(pipx_temp_env, capsys):
+    if sys.platform.startswith("win"):
+        pytest.skip("This behavior is undefined on Windows")
+    assert not run_pipx_cli(["--global", "install", "pycowsay"])
+    assert not run_pipx_cli(["--global", "inject", "pycowsay", PKG["black"]["spec"]])
+    assert not run_pipx_cli(["--global", "uninject", "pycowsay", "black"])
+    captured = capsys.readouterr()
+    assert "Uninjected package black" in captured.out
+    assert not run_pipx_cli(["--global", "list", "--include-injected"])
     captured = capsys.readouterr()
     assert "black" not in captured.out
 

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -22,6 +22,11 @@ def test_uninstall(pipx_temp_env):
     assert not run_pipx_cli(["uninstall", "pycowsay"])
 
 
+def test_uninstall_global(pipx_temp_env):
+    assert not run_pipx_cli(["--global", "install", "pycowsay"])
+    assert not run_pipx_cli(["--global", "uninstall", "pycowsay"])
+
+
 def test_uninstall_circular_deps(pipx_temp_env):
     assert not run_pipx_cli(["install", PKG["cloudtoken"]["spec"]])
     assert not run_pipx_cli(["uninstall", "cloudtoken"])
@@ -29,7 +34,7 @@ def test_uninstall_circular_deps(pipx_temp_env):
 
 @pytest.mark.parametrize("metadata_version", [None, "0.1"])
 def test_uninstall_legacy_venv(pipx_temp_env, metadata_version):
-    executable_path = constants.LOCAL_BIN_DIR / app_name("pycowsay")
+    executable_path = constants.PIPX_DIRS.BIN_DIR / app_name("pycowsay")
 
     assert not run_pipx_cli(["install", "pycowsay"])
     assert executable_path.exists()
@@ -42,7 +47,7 @@ def test_uninstall_legacy_venv(pipx_temp_env, metadata_version):
 def test_uninstall_suffix(pipx_temp_env):
     name = "pbr"
     suffix = "_a"
-    executable_path = constants.LOCAL_BIN_DIR / app_name(f"{name}{suffix}")
+    executable_path = constants.PIPX_DIRS.BIN_DIR / app_name(f"{name}{suffix}")
 
     assert not run_pipx_cli(["install", PKG[name]["spec"], f"--suffix={suffix}"])
     assert executable_path.exists()
@@ -53,9 +58,11 @@ def test_uninstall_suffix(pipx_temp_env):
 
 def test_uninstall_injected(pipx_temp_env):
     pycowsay_app_paths = [
-        constants.LOCAL_BIN_DIR / app for app in PKG["pycowsay"]["apps"]
+        constants.PIPX_DIRS.BIN_DIR / app for app in PKG["pycowsay"]["apps"]
     ]
-    pylint_app_paths = [constants.LOCAL_BIN_DIR / app for app in PKG["pylint"]["apps"]]
+    pylint_app_paths = [
+        constants.PIPX_DIRS.BIN_DIR / app for app in PKG["pylint"]["apps"]
+    ]
     app_paths = pycowsay_app_paths + pylint_app_paths
 
     assert not run_pipx_cli(["install", PKG["pycowsay"]["spec"]])
@@ -78,7 +85,7 @@ def test_uninstall_suffix_legacy_venv(pipx_temp_env, metadata_version):
     # legacy uninstall on Windows only works with "canonical name characters"
     #   in suffix
     suffix = "-a"
-    executable_path = constants.LOCAL_BIN_DIR / app_name(f"{name}{suffix}")
+    executable_path = constants.PIPX_DIRS.BIN_DIR / app_name(f"{name}{suffix}")
 
     assert not run_pipx_cli(["install", PKG[name]["spec"], f"--suffix={suffix}"])
     mock_legacy_venv(f"{name}{suffix}", metadata_version=metadata_version)
@@ -90,7 +97,7 @@ def test_uninstall_suffix_legacy_venv(pipx_temp_env, metadata_version):
 
 @pytest.mark.parametrize("metadata_version", [None, "0.1", "0.2"])
 def test_uninstall_with_missing_interpreter(pipx_temp_env, metadata_version):
-    executable_path = constants.LOCAL_BIN_DIR / app_name("pycowsay")
+    executable_path = constants.PIPX_DIRS.BIN_DIR / app_name("pycowsay")
 
     assert not run_pipx_cli(["install", "pycowsay"])
     assert executable_path.exists()
@@ -108,8 +115,12 @@ def test_uninstall_with_missing_interpreter(pipx_temp_env, metadata_version):
 def test_uninstall_proper_dep_behavior(pipx_temp_env, metadata_version):
     # isort is a dependency of pylint.  Make sure that uninstalling pylint
     #   does not also uninstall isort app in LOCAL_BIN_DIR
-    isort_app_paths = [constants.LOCAL_BIN_DIR / app for app in PKG["isort"]["apps"]]
-    pylint_app_paths = [constants.LOCAL_BIN_DIR / app for app in PKG["pylint"]["apps"]]
+    isort_app_paths = [
+        constants.PIPX_DIRS.BIN_DIR / app for app in PKG["isort"]["apps"]
+    ]
+    pylint_app_paths = [
+        constants.PIPX_DIRS.BIN_DIR / app for app in PKG["pylint"]["apps"]
+    ]
 
     assert not run_pipx_cli(["install", PKG["pylint"]["spec"]])
     assert not run_pipx_cli(["install", PKG["isort"]["spec"]])
@@ -135,8 +146,12 @@ def test_uninstall_proper_dep_behavior_missing_interpreter(
 ):
     # isort is a dependency of pylint.  Make sure that uninstalling pylint
     #   does not also uninstall isort app in LOCAL_BIN_DIR
-    isort_app_paths = [constants.LOCAL_BIN_DIR / app for app in PKG["isort"]["apps"]]
-    pylint_app_paths = [constants.LOCAL_BIN_DIR / app for app in PKG["pylint"]["apps"]]
+    isort_app_paths = [
+        constants.PIPX_DIRS.BIN_DIR / app for app in PKG["isort"]["apps"]
+    ]
+    pylint_app_paths = [
+        constants.PIPX_DIRS.BIN_DIR / app for app in PKG["pylint"]["apps"]
+    ]
 
     assert not run_pipx_cli(["install", PKG["pylint"]["spec"]])
     assert not run_pipx_cli(["install", PKG["isort"]["spec"]])

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -4,7 +4,7 @@ import pytest  # type: ignore
 
 from helpers import app_name, mock_legacy_venv, remove_venv_interpreter, run_pipx_cli
 from package_info import PKG
-from pipx import constants
+from pipx import paths
 
 
 def file_or_symlink(filepath):
@@ -36,7 +36,7 @@ def test_uninstall_circular_deps(pipx_temp_env):
 
 @pytest.mark.parametrize("metadata_version", [None, "0.1"])
 def test_uninstall_legacy_venv(pipx_temp_env, metadata_version):
-    executable_path = constants.PIPX_DIRS.BIN_DIR / app_name("pycowsay")
+    executable_path = paths.ctx.bin_dir / app_name("pycowsay")
 
     assert not run_pipx_cli(["install", "pycowsay"])
     assert executable_path.exists()
@@ -49,7 +49,7 @@ def test_uninstall_legacy_venv(pipx_temp_env, metadata_version):
 def test_uninstall_suffix(pipx_temp_env):
     name = "pbr"
     suffix = "_a"
-    executable_path = constants.PIPX_DIRS.BIN_DIR / app_name(f"{name}{suffix}")
+    executable_path = paths.ctx.bin_dir / app_name(f"{name}{suffix}")
 
     assert not run_pipx_cli(["install", PKG[name]["spec"], f"--suffix={suffix}"])
     assert executable_path.exists()
@@ -59,12 +59,8 @@ def test_uninstall_suffix(pipx_temp_env):
 
 
 def test_uninstall_injected(pipx_temp_env):
-    pycowsay_app_paths = [
-        constants.PIPX_DIRS.BIN_DIR / app for app in PKG["pycowsay"]["apps"]
-    ]
-    pylint_app_paths = [
-        constants.PIPX_DIRS.BIN_DIR / app for app in PKG["pylint"]["apps"]
-    ]
+    pycowsay_app_paths = [paths.ctx.bin_dir / app for app in PKG["pycowsay"]["apps"]]
+    pylint_app_paths = [paths.ctx.bin_dir / app for app in PKG["pylint"]["apps"]]
     app_paths = pycowsay_app_paths + pylint_app_paths
 
     assert not run_pipx_cli(["install", PKG["pycowsay"]["spec"]])
@@ -87,7 +83,7 @@ def test_uninstall_suffix_legacy_venv(pipx_temp_env, metadata_version):
     # legacy uninstall on Windows only works with "canonical name characters"
     #   in suffix
     suffix = "-a"
-    executable_path = constants.PIPX_DIRS.BIN_DIR / app_name(f"{name}{suffix}")
+    executable_path = paths.ctx.bin_dir / app_name(f"{name}{suffix}")
 
     assert not run_pipx_cli(["install", PKG[name]["spec"], f"--suffix={suffix}"])
     mock_legacy_venv(f"{name}{suffix}", metadata_version=metadata_version)
@@ -99,7 +95,7 @@ def test_uninstall_suffix_legacy_venv(pipx_temp_env, metadata_version):
 
 @pytest.mark.parametrize("metadata_version", [None, "0.1", "0.2"])
 def test_uninstall_with_missing_interpreter(pipx_temp_env, metadata_version):
-    executable_path = constants.PIPX_DIRS.BIN_DIR / app_name("pycowsay")
+    executable_path = paths.ctx.bin_dir / app_name("pycowsay")
 
     assert not run_pipx_cli(["install", "pycowsay"])
     assert executable_path.exists()
@@ -117,12 +113,8 @@ def test_uninstall_with_missing_interpreter(pipx_temp_env, metadata_version):
 def test_uninstall_proper_dep_behavior(pipx_temp_env, metadata_version):
     # isort is a dependency of pylint.  Make sure that uninstalling pylint
     #   does not also uninstall isort app in LOCAL_BIN_DIR
-    isort_app_paths = [
-        constants.PIPX_DIRS.BIN_DIR / app for app in PKG["isort"]["apps"]
-    ]
-    pylint_app_paths = [
-        constants.PIPX_DIRS.BIN_DIR / app for app in PKG["pylint"]["apps"]
-    ]
+    isort_app_paths = [paths.ctx.bin_dir / app for app in PKG["isort"]["apps"]]
+    pylint_app_paths = [paths.ctx.bin_dir / app for app in PKG["pylint"]["apps"]]
 
     assert not run_pipx_cli(["install", PKG["pylint"]["spec"]])
     assert not run_pipx_cli(["install", PKG["isort"]["spec"]])
@@ -148,12 +140,8 @@ def test_uninstall_proper_dep_behavior_missing_interpreter(
 ):
     # isort is a dependency of pylint.  Make sure that uninstalling pylint
     #   does not also uninstall isort app in LOCAL_BIN_DIR
-    isort_app_paths = [
-        constants.PIPX_DIRS.BIN_DIR / app for app in PKG["isort"]["apps"]
-    ]
-    pylint_app_paths = [
-        constants.PIPX_DIRS.BIN_DIR / app for app in PKG["pylint"]["apps"]
-    ]
+    isort_app_paths = [paths.ctx.bin_dir / app for app in PKG["isort"]["apps"]]
+    pylint_app_paths = [paths.ctx.bin_dir / app for app in PKG["pylint"]["apps"]]
 
     assert not run_pipx_cli(["install", PKG["pylint"]["spec"]])
     assert not run_pipx_cli(["install", PKG["isort"]["spec"]])

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -23,6 +23,8 @@ def test_uninstall(pipx_temp_env):
 
 
 def test_uninstall_global(pipx_temp_env):
+    if sys.platform.startswith("win"):
+        pytest.skip("This behavior is undefined on Windows")
     assert not run_pipx_cli(["--global", "install", "pycowsay"])
     assert not run_pipx_cli(["--global", "uninstall", "pycowsay"])
 

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -10,6 +10,12 @@ def test_upgrade(pipx_temp_env, capsys):
     assert not run_pipx_cli(["upgrade", "pycowsay"])
 
 
+def test_upgrade_global(pipx_temp_env, capsys):
+    assert run_pipx_cli(["--global", "upgrade", "pycowsay"])
+    assert not run_pipx_cli(["--global", "install", "pycowsay"])
+    assert not run_pipx_cli(["--global", "upgrade", "pycowsay"])
+
+
 @pytest.mark.parametrize("metadata_version", [None, "0.1"])
 def test_upgrade_legacy_venv(pipx_temp_env, capsys, metadata_version):
     assert not run_pipx_cli(["install", "pycowsay"])

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest  # type: ignore
 
 from helpers import mock_legacy_venv, run_pipx_cli
@@ -11,6 +13,8 @@ def test_upgrade(pipx_temp_env, capsys):
 
 
 def test_upgrade_global(pipx_temp_env, capsys):
+    if sys.platform.startswith("win"):
+        pytest.skip("This behavior is undefined on Windows")
     assert run_pipx_cli(["--global", "upgrade", "pycowsay"])
     assert not run_pipx_cli(["--global", "install", "pycowsay"])
     assert not run_pipx_cli(["--global", "upgrade", "pycowsay"])


### PR DESCRIPTION
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
 Addressing issue #754. Added `--global` option to perform actions for all users. The global option is for pipx and affects all commands except `run` and `completions` by changing the base paths that are used to generate the install directories.
There are two important sets of changes. 
* One is a bare minimum implementation (first two commits).
* The other is a cleaner implementation (third commit).
  * This breaks out the paths into there own submodule since they definitely aren't constants anymore.

These changes also include new pytest tests and necessarily required changes to existing tests.

I'm perfectly happy to go with either of those or a complete rewrite if that's required to make this feature fit into this project. I'm not married to any of the implementation details.

## Test plan
Passes your CI process on github (via your unaltered actions in my fork https://github.com/haxwithaxe/pipx/actions/runs/6518200232).

### Manually tested by running
To verify the changes do what they are supposed to
```
python3 src/pipx --global environment
```

To test all the relevant commands for regressions.
```
python3 src/pipx --global ensurepath
sudo python3 src/pipx --global install pycowsay
sudo python3 src/pipx --global reinstall pycowsay
sudo python3 src/pipx --global inject pycowsay black
sudo python3 src/pipx --global uninject pycowsay black
sudo python3 src/pipx --global runpip pycowsay freeze
sudo python3 src/pipx --global list
sudo python3 src/pipx --global uninstall pycowsay
python3 src/pipx environment
python3 src/pipx ensurepath
python3 src/pipx install pycowsay
python3 src/pipx reinstall pycowsay
python3 src/pipx inject pycowsay black
python3 src/pipx uninject pycowsay black
python3 src/pipx runpip pycowsay freeze
python3 src/pipx list
python3 src/pipx uninstall pycowsay
```
