### PR TITLE
chore: update pre-commit and modernize Ruff config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,18 +6,18 @@
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v4.5.0
   hooks:
   - id: end-of-file-fixer
   - id: check-added-large-files
   - id: trailing-whitespace
   - id: check-yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.0.254
+  rev: v0.1.3
   hooks:
     - id: ruff
 - repo: https://github.com/psf/black
-  rev: 23.1.0
+  rev: 23.10.1
   hooks:
   - id: black
 # mypy args:
@@ -27,7 +27,7 @@ repos:
 #   cannot use --warn-unused-ignores because it conflicts with
 #     --ignore-missing-imports
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.1.1
+  rev: v1.6.1
   hooks:
   - id: mypy
     args: ['--warn-unused-ignores', '--strict-equality','--no-implicit-optional']

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -82,8 +82,8 @@ sudo PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin pipx install PACKAGE
     | `~/.local/pipx/venvs`  | `platformdirs.user_data_dir()/pipx/venv`   |
     | `~/.local/pipx/.cache` | `platformdirs.user_cache_dir()/pipx`       |
     | `~/.local/pipx/logs`   | `platformdirs.user_log_dir()/pipx/log`     |
-    
-    `user_data_dir()`, `user_cache_dir()` and `user_log_dir()` resolve to appropriate platform-specific user data, cache and log directories. 
+
+    `user_data_dir()`, `user_cache_dir()` and `user_log_dir()` resolve to appropriate platform-specific user data, cache and log directories.
     See the [platformdirs documentation](https://platformdirs.readthedocs.io/en/latest/api.html#platforms) for details.
 
 ## Upgrade pipx

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -123,11 +123,11 @@ rm -rf test_venv
 ## Pipx files not in expected locations according to documentation
 
 The default PIPX_HOME is `~/.local/pipx`, prior to the adoption of the XDG base
-directory specification after version 1.2.0. To maintain compatibility with older 
+directory specification after version 1.2.0. To maintain compatibility with older
 versions, pipx will automatically detect the old paths and use them accordingly.
 For a map of old and new paths, See [Installation](installation.md#installation-options)
 
-To migrate from the old path to the new path, you can remove the `~/.local/pipx` directory and 
+To migrate from the old path to the new path, you can remove the `~/.local/pipx` directory and
 reinstall all packages.
 
 For example, on Linux systems, you could read out `pipx`'s package information in JSON via `jq` (which you might need to install first):

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,10 +9,10 @@ PYTHON_DEFAULT_VERSION = "3.11"
 DOC_DEPENDENCIES = [".", "jinja2", "mkdocs", "mkdocs-material"]
 MAN_DEPENDENCIES = [".", "argparse-manpage[setuptools]"]
 LINT_DEPENDENCIES = [
-    "black==22.8.0",
-    "mypy==1.1.1",
+    "black==23.10.1",
+    "mypy==1.6.1",
     "packaging>=20.0",
-    "ruff==0.0.254",
+    "ruff==0.1.3",
     "types-jinja2",
 ]
 # Packages whose dependencies need an intact system PATH to compile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ include = ["/src", "/logo.png", "/pipx_demo.gif", "/*.md"]
 skip-magic-trailing-comma = true
 
 [tool.ruff]
+line-length = 121
+
+[tool.ruff.lint]
 select = [
   "A",
   "B",
@@ -67,21 +70,24 @@ select = [
 ignore = [
   "B904",
 ]
-line-length = 121
-show-source = true
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["helpers", "package_info", "pipx"]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 15
 
 [tool.pytest.ini_options]
 markers = ["all_packages: test install with maximum number of packages"]
 
+[tool.mypy]
+show_error_codes = true
+
 [[tool.mypy.overrides]]
 module = [
   "packaging.*",
-  "platformdirs"
+  "platformdirs",
+  "pycowsay.*",
+  "jinja2",
 ]
 ignore_missing_imports = true

--- a/scripts/list_test_packages.py
+++ b/scripts/list_test_packages.py
@@ -111,7 +111,7 @@ def create_test_packages_list(
             if verbose:
                 print(f"CMD: {' '.join(cmd_list)}")
             pip_download_process = subprocess.run(
-                cmd_list, capture_output=True, text=True
+                cmd_list, capture_output=True, text=True, check=False
             )
             if pip_download_process.returncode == 0:
                 print(f"Examined {test_package['spec']}{test_package_option_string}")
@@ -146,7 +146,6 @@ def create_test_packages_list(
         all_packages.append(f"{package_name}=={package_version}")
 
     with platform_package_list_path.open("w") as package_list_fh:
-        "scripts/list_test_packages.py",
         for package in sorted(all_packages):
             print(package, file=package_list_fh)
 

--- a/scripts/migrate_pipsi_to_pipx.py
+++ b/scripts/migrate_pipsi_to_pipx.py
@@ -38,7 +38,7 @@ def main():
 
     error = False
     for package in packages:
-        ret = subprocess.run(["pipsi", "uninstall", "--yes", package])
+        ret = subprocess.run(["pipsi", "uninstall", "--yes", package], check=False)
         if ret.returncode:
             error = True
             print(
@@ -49,7 +49,7 @@ def main():
             print(
                 f"uninstalled {package!r} with pipsi. Now attempting to install with pipx."
             )
-            ret = subprocess.run(["pipx", "install", package])
+            ret = subprocess.run(["pipx", "install", package], check=False)
             if ret.returncode:
                 error = True
                 print(f"Failed to install {package!r} with pipx.")

--- a/scripts/pipx_release.py
+++ b/scripts/pipx_release.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 
 def python_mypy_ok(filepath: Path) -> bool:
-    mypy_proc = subprocess.run(["mypy", filepath])
+    mypy_proc = subprocess.run(["mypy", filepath], check=False)
     return True if mypy_proc.returncode == 0 else False
 
 

--- a/scripts/update_package_cache.py
+++ b/scripts/update_package_cache.py
@@ -162,6 +162,7 @@ def update_test_packages_cache(
                 ],
                 capture_output=True,
                 text=True,
+                check=False,
             )
             if pip_download_process.returncode == 0:
                 print(f"Successfully downloaded {package_spec}")

--- a/src/pipx/interpreter.py
+++ b/src/pipx/interpreter.py
@@ -34,6 +34,7 @@ def find_py_launcher_python(python_version: Optional[str] = None) -> Optional[st
             [py, f"-{python_version}", "-c", "import sys; print(sys.executable)"],
             capture_output=True,
             text=True,
+            check=True,
         ).stdout.strip()
     return py
 
@@ -54,7 +55,7 @@ def _find_default_windows_python() -> str:
     # https://twitter.com/zooba/status/1212454929379581952
 
     proc = subprocess.run(
-        [python, "-V"], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL
+        [python, "-V"], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, check=False
     )
     if proc.returncode != 0:
         # Cover the 9009 return code pre-emptively.

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -180,6 +180,7 @@ def run_subprocess(
         stderr=subprocess.PIPE if capture_stderr else None,
         encoding="utf-8",
         universal_newlines=True,
+        check=False,
     )
 
     if capture_stdout and log_stdout:
@@ -396,6 +397,7 @@ def exec_app(
                 stderr=None,
                 encoding="utf-8",
                 universal_newlines=True,
+                check=False,
             ).returncode
         )
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,7 +109,7 @@ def pipx_local_pypiserver(request):
         str(PIPX_TESTS_PACKAGE_LIST_DIR),
         str(pipx_cache_dir),
     ]
-    check_test_packages_process = subprocess.run(check_test_packages_cmd)
+    check_test_packages_process = subprocess.run(check_test_packages_cmd, check=False)
     if check_test_packages_process.returncode != 0:
         raise Exception(
             f"Directory {str(pipx_cache_dir)} does not contain all "

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -257,7 +257,7 @@ def test_install_pip_failure(pipx_temp_env, capsys):
 def test_install_local_archive(pipx_temp_env, monkeypatch, capsys):
     monkeypatch.chdir(Path(TEST_DATA_PATH) / "local_extras")
 
-    subprocess.run([sys.executable, "-m", "pip", "wheel", "."])
+    subprocess.run([sys.executable, "-m", "pip", "wheel", "."], check=True)
     assert not run_pipx_cli(["install", "repeatme-0.1-py3-none-any.whl"])
     captured = capsys.readouterr()
     assert f"- {app_name('repeatme')}\n" in captured.out

--- a/tests/test_install_all_packages.py
+++ b/tests/test_install_all_packages.py
@@ -163,7 +163,7 @@ def module_globals() -> ModuleGlobalsData:
 
 
 def pip_cache_purge() -> None:
-    subprocess.run([sys.executable, "-m", "pip", "cache", "purge"])
+    subprocess.run([sys.executable, "-m", "pip", "cache", "purge"], check=True)
 
 
 def write_report_legend(report_legend_path: Path) -> None:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -31,6 +31,7 @@ def execvpe_mock(cmd_path, cmd_args, env):
         capture_output=False,
         encoding="utf-8",
         text=True,
+        check=False,
     ).returncode
     sys.exit(return_code)
 
@@ -145,6 +146,7 @@ def test_run_ensure_null_pythonpath():
             env=env,
             capture_output=True,
             text=True,
+            check=True,
         ).stdout
     )
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* I have added an entry to `docs/changelog.md` (not needed)

## Summary of changes

Ruff now uses the `lint` prefix for linter options (since it has a formatter now too). Also all these versions were quite old, so I've bumped things (pre-commit and tox).

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
pre-commit run -a
```
