### PR TITLE
tests: fix regex to include build numbers

### DIFF
--- a/scripts/list_test_packages.py
+++ b/scripts/list_test_packages.py
@@ -130,7 +130,7 @@ def create_test_packages_list(
     all_packages = []
     for downloaded_filename in downloaded_list:
         wheel_re = re.search(
-            r"(.+)\-([^-]+)\-([^-]+)\-([^-]+)\-([^-]+)\.whl$", downloaded_filename
+            r"([^-]+)\-([^-]+)\-([^-]+)\-([^-]+)\-([^-]+)(-[^-]+)?\.whl$", downloaded_filename
         )
         src_re = re.search(r"(.+)\-([^-]+)\.(?:tar.gz|zip)$", downloaded_filename)
         if wheel_re:

--- a/testdata/tests_packages/macos21-python3.7.txt
+++ b/testdata/tests_packages/macos21-python3.7.txt
@@ -20,7 +20,7 @@ attrs==22.1.0
 awscli==1.18.168
 backcall==0.2.0
 beautifulsoup4==4.11.1
-black-22.10.0==1fixedarch
+black==22.10.0
 black==22.8.0
 bleach==5.0.1
 boto3==1.26.20

--- a/testdata/tests_packages/macos21-python3.8.txt
+++ b/testdata/tests_packages/macos21-python3.8.txt
@@ -21,7 +21,7 @@ attrs==22.1.0
 awscli==1.18.168
 backcall==0.2.0
 beautifulsoup4==4.11.1
-black-22.10.0==1fixedarch
+black==22.10.0
 black==22.8.0
 bleach==5.0.1
 boto3==1.26.20


### PR DESCRIPTION
This fixes the regex in the case where a wheel has a build number (as black did on macOS).

<!-- add an 'x' in the brackets below -->
* I have added an entry to `docs/changelog.md` (tests only)

## Summary of changes

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
nox -s create_test_package_list-3.7
```

Side note: why is the macOS version in the filename? Could it be removed? This is making a lot of different files for different macOS versions, and is why this wasn't in in CI yet, but I hit it, since I was making new ones since mac23 didn't exist.
