### PR TITLE
Normalize Windows install instructions for python.org installers and the `py` launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Upgrade pipx with `python3 -m pip install --user --upgrade pipx`.
 ### On Windows, install via pip (requires pip 19.0 or later)
 
 ```
-# If you installed python using the app-store, replace `python` with `python3` in the next line.
-python -m pip install --user pipx
+# If you installed python using Microsoft Store, replace `py` with `python3` in the next line.
+py -m pip install --user pipx
 ```
 
 It is possible (even most likely) the above finishes with a WARNING looking similar to this:
@@ -67,7 +67,7 @@ Enter the following line (even if you did not get the warning):
 This will add both the above mentioned path and the `%USERPROFILE%\.local\bin` folder to your search path.
 Restart your terminal session and verify `pipx` does run.
 
-Upgrade pipx with `python3 -m pip install --user --upgrade pipx`.
+Upgrade pipx with `py -m pip install --user --upgrade pipx`.
 
 ### Via zipapp
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,8 +18,8 @@ pipx ensurepath
 On Windows (requires pip 19.0 or later):
 
 ```
-py -3 -m pip install --user pipx
-py -3 -m pipx ensurepath
+py -m pip install --user pipx
+py -m pipx ensurepath
 ```
 
 Otherwise, install via pip (requires pip 19.0 or later):


### PR DESCRIPTION
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes

[Steve Dower reports that 95% of all Windows Python installations use the official python.org installers](https://discuss.python.org/t/microsoft-store-package-does-not-add-the-py-exe-launcher/538/11). By default, this installer installs the [`py` launcher and puts it (only) in the `PATH`](https://docs.python.org/3/using/windows.html#from-the-command-line).

- Update `pipx` Windows installations to use `py` launcher instructions by default, which will work by default for a vast majority of users
- Remove the unneeded `-3` from some `py` invocations to simplify the instructions. [The `py` launcher will already default to using the latest Python 3 release installed](https://docs.python.org/3/using/windows.html#from-the-command-line) by default and Python 2 has been end of life for almost 4 years

## Test plan

1. Install Python from [python.org ](https://www.python.org/downloads/) onto a clean Windows machine
2. Run the default `pipx` installation instructions in this MR
3. Confirm that `pipx` runs correctly using the default instructions.
