### PR TITLE
install docs: reorganize, discourage installing `pipx` with `pipx`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ _For comparison to other tools including pipsi, see [Comparison to Other Tools](
 
 ## Install pipx
 
+> [!NOTE]
+> It is not recommended to install `pipx` via `pipx`. If you'd like
+> to do this anyway, take a look at the
+> [`pipx-in-pipx`](https://github.com/mattsb42-meta/pipx-in-pipx) project and
+> read about the limitations there.
+
 ### On macOS
 
 ```
@@ -69,7 +75,7 @@ Restart your terminal session and verify `pipx` does run.
 
 Upgrade pipx with `py -m pip install --user --upgrade pipx`.
 
-### Via zipapp
+### Using pipx without installing (via zipapp)
 
 You can also use pipx without installing it.
 The zipapp can be downloaded from [Github releases](https://github.com/pypa/pipx/releases) and you can invoke it with a Python 3.7+ interpreter:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,6 +46,7 @@ python pipx.pyz ensurepath
 ### <a name="pre-commit"></a> Using pipx with pre-commit
 
 Pipx has [pre-commit](https://pre-commit.com/) support. This lets you run applications:
+
 * That can be run using `pipx run` but don't have native pre-commit support.
 * Using its prebuilt wheel from pypi.org instead of building it from source.
 * Using pipx's `--spec` and `--index-url` flags.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,7 +6,7 @@ You also need to have `pip` installed on your machine for `python3`. Installing 
 
 pipx works on macOS, linux, and Windows.
 
-## Install pipx
+## Installing pipx
 
 On macOS:
 
@@ -29,16 +29,21 @@ python3 -m pip install --user pipx
 python3 -m pipx ensurepath
 ```
 
-Or via zipapp:
+!!!caution
+    It is not recommended to install `pipx` via `pipx`. If you'd like
+    to do this anyway, take a look at the
+    [`pipx-in-pipx`](https://github.com/mattsb42-meta/pipx-in-pipx) project and
+    read about the limitations there.
 
-You can also use pipx without installing it.
+
+### Using pipx without installing (via zipapp)
 The zipapp can be downloaded from [Github releases](https://github.com/pypa/pipx/releases) and you can invoke it with a Python 3.7+ interpreter:
 
 ```
 python pipx.pyz ensurepath
 ```
 
-<a name="pre-commit"></a>Or use with pre-commit:
+### <a name="pre-commit"></a> Using pipx with pre-commit
 
 Pipx has [pre-commit](https://pre-commit.com/) support. This lets you run applications:
 * That can be run using `pipx run` but don't have native pre-commit support.
@@ -58,7 +63,7 @@ Example configuration for use of the code linter [yapf](https://github.com/googl
     types: ['python']
 ```
 
-### Installation Options
+## Installation Options
 
 The default binary location for pipx-installed apps is `~/.local/bin`. This can be overridden with the environment variable `PIPX_BIN_DIR`.
 


### PR DESCRIPTION
I also added a link to a seemingly relevant, but untested by me, project. Let me know if you'd prefer to remove that link.

* (seems unnecessary) I have added an entry to `docs/changelog.md`

## Summary of changes

- Added a note discouraging installing `pipx` with `pipx`, since that seems to
  be unsupported. E.g. `pipx remove pipx` breaks all programs installed with
such a pipx, see the README of https://github.com/mattsb42-meta/pipx-in-pipx
for more caveats.

- I also added a link to the above project in the docs, mainly for its README.
  I'm not sure how well the project itself works; let me know if I should
remove the link.

- Reorganized the header structure of the installation docs slightly for clarity

- Fixed list spacing; MkDocs previously didn't render that list as a list.

## Test plan
I checked with `nox -s watch-docs` that the resulting docs seem to look OK.