### PR TITLE
Run venv Creation in Isolated Mode (#1091)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix program name in generated manual page
 - Print all environment variables in `pipx environment`
 - Return an error message when directory can't be added to PATH successfully
+- Run venv creation in isolated mode with -I
 
 ## 1.2.1
 

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -2,8 +2,6 @@ import json
 import logging
 import re
 import time
-import os
-import uuid
 from pathlib import Path
 from subprocess import CompletedProcess
 from typing import Dict, Generator, List, NoReturn, Optional, Set

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -2,6 +2,8 @@ import json
 import logging
 import re
 import time
+import os
+import uuid
 from pathlib import Path
 from subprocess import CompletedProcess
 from typing import Dict, Generator, List, NoReturn, Optional, Set
@@ -158,7 +160,7 @@ class Venv:
 
     def create_venv(self, venv_args: List[str], pip_args: List[str]) -> None:
         with animate("creating virtual environment", self.do_animation):
-            cmd = [self.python, "-m", "venv", "--without-pip"]
+            cmd = [self.python, "-Im", "venv", "--without-pip"]
             venv_process = run_subprocess(cmd + venv_args + [str(self.root)])
         subprocess_post_check(venv_process)
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Addressing #1091 
Created venv using [isolated mode](https://docs.python.org/3/using/cmdline.html#cmdoption-I) by passing the -I flag in order to resolve a bug where python files in the cwd could break the venv creation.
Also a slight security improvement since by ignoring the python files in the cwd which could potentially override files on the sys.path

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Manually tested resolution of bug by creating a file in cwd 
`echo "blah blah" > logging.py`
then running the current release of pipx
`pipx install frogmouth`
we get the expected error
```  
File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/venv/__init__.py", line 7, in <module>
  import logging
  File "/Users/ehlewis/test/logging.py", line 1
    blah blah
         ^^^^
SyntaxError: invalid syntax

'/Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 -m venv --without-pip
/Users/ehlewis/.local/pipx/venvs/frogmouth' failed
```
running the same command with the modified `create_venv` shows a successful install and the installed package functions as expected
```
python3 src/pipx install frogmouth                                                 
  installed package frogmouth 0.9.2, installed using Python 3.12.0
  These apps are now globally available
    - frogmouth
done! ✨ 🌟 ✨
```

