### PR TITLE
Make links actually links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 
 </p>
 
-**Documentation**: https://pipx.pypa.io
+**Documentation**: <https://pipx.pypa.io>
 
-**Source Code**: https://github.com/pypa/pipx
+**Source Code**: <https://github.com/pypa/pipx>
 
 _For comparison to other tools including pipsi, see
 [Comparison to Other Tools](https://pipx.pypa.io/stable/comparisons/)._


### PR DESCRIPTION
## Summary of changes

Docs don’t auto-detect links which means that https://pipx.pypa.io/stable/ shows them as plain text. This should help.