### PR TITLE
Fix combining of `--editable` and `--force` flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,6 @@ docs/docs.md
 pipx.1
 .pipx_tests
 /.coverage*
-testdata
+/testdata
+!/testdata/empty_project
+/.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## dev
 
+- Fix combining of --editable and --force flag
+
 ## 1.3.0
 
 - Check whether pip module exists in shared lib before performing any actions, such as `reinstall-all`.

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -58,7 +58,7 @@ def install(
             )
         if force:
             print(f"Installing to existing venv {venv.name!r}")
-            pip_args += ["--force-reinstall"]
+            pip_args = ["--force-reinstall"] + pip_args
         else:
             print(
                 pipx_wrap(

--- a/testdata/empty_project/README.md
+++ b/testdata/empty_project/README.md
@@ -1,0 +1,1 @@
+Empty project used for testing only

--- a/testdata/empty_project/empty_project/main.py
+++ b/testdata/empty_project/empty_project/main.py
@@ -1,0 +1,6 @@
+def main():
+    pass
+
+
+if __name__ == "__main__":
+    main()

--- a/testdata/empty_project/pyproject.toml
+++ b/testdata/empty_project/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = [
+  "setuptools",
+  "wheel",
+]
+
+[project]
+name = "empty-project"
+version = "0.1.0"
+description = "Empty Python Project"
+authors = [{ name = "My Name", email = "me@example.com" }]
+requires-python = ">=3.8"
+classifiers = [
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+]
+scripts.empty-project = "empty_project.main:cli"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -13,6 +13,8 @@ from pipx import constants
 
 TEST_DATA_PATH = "./testdata/test_package_specifier"
 
+SOURCE_DIR = Path(__file__).parent.parent.resolve()
+
 
 def test_help_text(monkeypatch, capsys):
     mock_exit = mock.Mock(side_effect=ValueError("raised in test to exit early"))
@@ -283,6 +285,17 @@ def test_force_install_changes(pipx_temp_env, capsys):
     assert not run_pipx_cli(["install", "nox", "--force"])
     captured = capsys.readouterr()
     assert "2022.1.7" not in captured.out
+
+
+def test_force_install_changes_editable(pipx_temp_env, capsys):
+    empty_project_path_as_string = (SOURCE_DIR / "testdata" / "empty_project").as_posix()
+    assert not run_pipx_cli(["install", "--editable", empty_project_path_as_string])
+    captured = capsys.readouterr()
+    assert "empty-project" in captured.out
+
+    assert not run_pipx_cli(["install", "--editable", empty_project_path_as_string, "--force"])
+    captured = capsys.readouterr()
+    assert "Installing to existing venv 'empty-project'" in captured.out
 
 
 def test_preinstall(pipx_temp_env, caplog):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -13,8 +13,6 @@ from pipx import constants
 
 TEST_DATA_PATH = "./testdata/test_package_specifier"
 
-SOURCE_DIR = Path(__file__).parent.parent.resolve()
-
 
 def test_help_text(monkeypatch, capsys):
     mock_exit = mock.Mock(side_effect=ValueError("raised in test to exit early"))
@@ -287,8 +285,8 @@ def test_force_install_changes(pipx_temp_env, capsys):
     assert "2022.1.7" not in captured.out
 
 
-def test_force_install_changes_editable(pipx_temp_env, capsys):
-    empty_project_path_as_string = (SOURCE_DIR / "testdata" / "empty_project").as_posix()
+def test_force_install_changes_editable(pipx_temp_env, root, capsys):
+    empty_project_path_as_string = (root / "testdata" / "empty_project").as_posix()
     assert not run_pipx_cli(["install", "--editable", empty_project_path_as_string])
     captured = capsys.readouterr()
     assert "empty-project" in captured.out


### PR DESCRIPTION


<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

The 1.3.0 version of `pipx` (with #933) introduced a but where the `--force-reinstall` flag caused failure when also the `--editable` flag was used - because it was adding the `--force-reinstall` flag after `--editable` one (and `--editable` flag expects url/path to the Python package to install to follow it.

The change fixes it by adding the `--force-reinstall` flag at the beginning rather than at the end of arguments to avoid this kind of problem also in case other flags might have similar problem.

Fixes: #1122

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
pytest tests/test_install.py::test_force_install_changes_editable
```

<img width="1476" alt="Screenshot 2023-12-02 at 20 11 27" src="https://github.com/pypa/pipx/assets/595491/600d2298-a635-40bc-a553-7ca1978d45e8">
