### PR TITLE
Fix creation of test cache for clean checkout

### DIFF
--- a/scripts/update_package_cache.py
+++ b/scripts/update_package_cache.py
@@ -57,7 +57,7 @@ def update_test_packages_cache(package_list_dir_path: Path, pipx_package_cache_p
 
     platform_package_list_path = get_platform_list_path(package_list_dir_path)
     packages_dir_path = get_platform_packages_dir_path(pipx_package_cache_path)
-    packages_dir_path.mkdir(exist_ok=True)
+    packages_dir_path.mkdir(exist_ok=True, parents=True)
 
     packages_dir_files = list(packages_dir_path.iterdir())
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

(I think I do not need to add this change to changelog - it's purely development environment fix). 

## Summary of changes

The development environment test cache creation is pretty cool, but for first-time user creating the cache does not work cleanly because it misses directories and cache cannot be created.

Adding `parents=True` fixes the problem.

## Test plan
Tested by running

```
rm -rf .pipx_tests .pytest_cache
pytest tests/test_install.py
```

This failed with:

```
Exception: Directory /Users/jarek/IdeaProjects/pipx/.pipx_tests/package_cache does not contain all package distribution files necessary to run pipx tests. Please run the following command to populate it: /Users/jarek/IdeaProjects/pipx/venv/bin/python scripts/update_package_cache.py testdata/tests_packages /Users/jarek/IdeaProjects/pipx/.pipx_tests/package_cache
```

Before the fix running:

```
/Users/jarek/IdeaProjects/pipx/venv/bin/python scripts/update_package_cache.py testdata/tests_packages /Users/jarek/IdeaProjects/pipx/.pipx_tests/package_cache
```

causes "No such file or directory"

After the fix, environment gets setup properly


