### PR TITLE
Run Subprocesses in the Directory that they will be Targeting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Fix program name in generated manual page
 - Print all environment variables in `pipx environment`
 - Return an error message when directory can't be added to PATH successfully
-- Run venv creation in isolated mode with -I
+- Run venv creation and install_package subprocesses inside distination directory self.root instead of current directory
 
 ## 1.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix program name in generated manual page
 - Print all environment variables in `pipx environment`
 - Return an error message when directory can't be added to PATH successfully
+- Run venv creation in isolated mode with -I
 
 ## 1.2.1
 

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -163,16 +163,19 @@ def run_subprocess(
     log_cmd_str: Optional[str] = None,
     log_stdout: bool = True,
     log_stderr: bool = True,
+    run_dir: Optional[str] = None,
 ) -> "subprocess.CompletedProcess[str]":
     """Run arbitrary command as subprocess, capturing stderr and stout"""
     env = dict(os.environ)
     env = _fix_subprocess_env(env)
-
+    
     if log_cmd_str is None:
         log_cmd_str = " ".join(str(c) for c in cmd)
     logger.info(f"running {log_cmd_str}")
     # windows cannot take Path objects, only strings
     cmd_str_list = [str(c) for c in cmd]
+    if run_dir:
+        os.makedirs(run_dir, exist_ok=True)
     completed_process = subprocess.run(
         cmd_str_list,
         env=env,
@@ -180,6 +183,7 @@ def run_subprocess(
         stderr=subprocess.PIPE if capture_stderr else None,
         encoding="utf-8",
         universal_newlines=True,
+        cwd=run_dir if run_dir else None,
     )
 
     if capture_stdout and log_stdout:

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -168,7 +168,6 @@ def run_subprocess(
     """Run arbitrary command as subprocess, capturing stderr and stout"""
     env = dict(os.environ)
     env = _fix_subprocess_env(env)
-    
     if log_cmd_str is None:
         log_cmd_str = " ".join(str(c) for c in cmd)
     logger.info(f"running {log_cmd_str}")

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -2,8 +2,6 @@ import json
 import logging
 import re
 import time
-import os
-import uuid
 from pathlib import Path
 from subprocess import CompletedProcess
 from typing import Dict, Generator, List, NoReturn, Optional, Set

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -2,6 +2,8 @@ import json
 import logging
 import re
 import time
+import os
+import uuid
 from pathlib import Path
 from subprocess import CompletedProcess
 from typing import Dict, Generator, List, NoReturn, Optional, Set
@@ -158,7 +160,7 @@ class Venv:
 
     def create_venv(self, venv_args: List[str], pip_args: List[str]) -> None:
         with animate("creating virtual environment", self.do_animation):
-            cmd = [self.python, "-m", "venv", "--without-pip"]
+            cmd = [self.python, "-Im", "venv", "--without-pip"]
             venv_process = run_subprocess(cmd + venv_args + [str(self.root)])
         subprocess_post_check(venv_process)
 

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -158,8 +158,9 @@ class Venv:
 
     def create_venv(self, venv_args: List[str], pip_args: List[str]) -> None:
         with animate("creating virtual environment", self.do_animation):
-            cmd = [self.python, "-Im", "venv", "--without-pip"]
-            venv_process = run_subprocess(cmd + venv_args + [str(self.root)])
+            cmd = [self.python, "-m", "venv", "--without-pip"]
+            venv_process = run_subprocess(cmd + venv_args + [str(self.root)], run_dir=str(self.root))
+
         subprocess_post_check(venv_process)
 
         shared_libs.create(self.verbose)
@@ -251,7 +252,7 @@ class Venv:
             ]
             # no logging because any errors will be specially logged by
             #   subprocess_post_check_handle_pip_error()
-            pip_process = run_subprocess(cmd, log_stdout=False, log_stderr=False)
+            pip_process = run_subprocess(cmd, log_stdout=False, log_stderr=False, run_dir=str(self.root))
         subprocess_post_check_handle_pip_error(pip_process)
         if pip_process.returncode:
             raise PipxError(

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -159,7 +159,9 @@ class Venv:
     def create_venv(self, venv_args: List[str], pip_args: List[str]) -> None:
         with animate("creating virtual environment", self.do_animation):
             cmd = [self.python, "-m", "venv", "--without-pip"]
-            venv_process = run_subprocess(cmd + venv_args + [str(self.root)], run_dir=str(self.root))
+            venv_process = run_subprocess(
+                cmd + venv_args + [str(self.root)], run_dir=str(self.root)
+            )
 
         subprocess_post_check(venv_process)
 
@@ -252,7 +254,9 @@ class Venv:
             ]
             # no logging because any errors will be specially logged by
             #   subprocess_post_check_handle_pip_error()
-            pip_process = run_subprocess(cmd, log_stdout=False, log_stderr=False, run_dir=str(self.root))
+            pip_process = run_subprocess(
+                cmd, log_stdout=False, log_stderr=False, run_dir=str(self.root)
+            )
         subprocess_post_check_handle_pip_error(pip_process)
         if pip_process.returncode:
             raise PipxError(


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Addressing #1091 
Set venv creation and install_package subprocesses to run inside the destination directory (self.root) in order to resolve a bug where python files in the cwd could break the venv creation.
Also a slight security improvement since by ignoring the python files in the cwd which could potentially override files on the sys.path

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Manually tested resolution of bug by creating a file in cwd 
`echo "blah blah" > logging.py`
then running the current release of pipx
`pipx install frogmouth`
we get the expected error
```  
File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/venv/__init__.py", line 7, in <module>
  import logging
  File "/Users/ehlewis/test/logging.py", line 1
    blah blah
         ^^^^
SyntaxError: invalid syntax

'/Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 -m venv --without-pip
/Users/ehlewis/.local/pipx/venvs/frogmouth' failed
```
running the same command with the modified `create_venv` shows a successful install and the installed package functions as expected
```
python3 src/pipx install frogmouth                                                 
  installed package frogmouth 0.9.2, installed using Python 3.12.0
  These apps are now globally available
    - frogmouth
done! ✨ 🌟 ✨
```

Repo tests were also passed successfully
https://github.com/ehlewis/pipx/actions/runs/7072019687
