### PR TITLE
Run Subprocesses in Destination dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## dev
 
+- Run venv creation and install_package subprocesses inside distination directory self.root instead of current directory
+
 ## 1.3.1
 
 - Fix combining of --editable and --force flag

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -161,6 +161,7 @@ def run_subprocess(
     log_cmd_str: Optional[str] = None,
     log_stdout: bool = True,
     log_stderr: bool = True,
+    run_dir: Optional[str] = None,
 ) -> "subprocess.CompletedProcess[str]":
     """Run arbitrary command as subprocess, capturing stderr and stout"""
     env = dict(os.environ)
@@ -169,6 +170,8 @@ def run_subprocess(
     if log_cmd_str is None:
         log_cmd_str = " ".join(str(c) for c in cmd)
     logger.info(f"running {log_cmd_str}")
+    if run_dir:
+        os.makedirs(run_dir, exist_ok=True)
     # windows cannot take Path objects, only strings
     cmd_str_list = [str(c) for c in cmd]
     completed_process = subprocess.run(
@@ -179,6 +182,7 @@ def run_subprocess(
         encoding="utf-8",
         universal_newlines=True,
         check=False,
+        cwd=run_dir if run_dir else None,
     )
 
     if capture_stdout and log_stdout:

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -157,7 +157,9 @@ class Venv:
             cmd = [self.python, "-m", "venv"]
             if not override_shared:
                 cmd.append("--without-pip")
-            venv_process = run_subprocess(cmd + venv_args + [str(self.root)])
+            venv_process = run_subprocess(
+                cmd + venv_args + [str(self.root)], run_dir=str(self.root)
+            )
         subprocess_post_check(venv_process)
 
         shared_libs.create(self.verbose)
@@ -248,7 +250,9 @@ class Venv:
             ]
             # no logging because any errors will be specially logged by
             #   subprocess_post_check_handle_pip_error()
-            pip_process = run_subprocess(cmd, log_stdout=False, log_stderr=False)
+            pip_process = run_subprocess(
+                cmd, log_stdout=False, log_stderr=False, run_dir=str(self.root)
+            )
         subprocess_post_check_handle_pip_error(pip_process)
         if pip_process.returncode:
             raise PipxError(f"Error installing {full_package_description(package_name, package_or_url)}.")


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Addressing #1091 
Set venv creation and install_package subprocesses to run inside the destination directory (self.root) in order to resolve a bug where python files in the cwd could break the venv creation.
Also a slight security improvement since by ignoring the python files in the cwd which could potentially override files on the sys.path

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Manually tested resolution of bug by creating a file in cwd 
`echo "blah blah" > logging.py`
then running the current release of pipx
`pipx install frogmouth`
we get the expected error
```  
File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/venv/__init__.py", line 7, in <module>
  import logging
  File "/Users/ehlewis/test/logging.py", line 1
    blah blah
         ^^^^
SyntaxError: invalid syntax

'/Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 -m venv --without-pip
/Users/ehlewis/.local/pipx/venvs/frogmouth' failed
```
running the same command with the modified `create_venv` shows a successful install and the installed package functions as expected
```
python3 src/pipx install frogmouth                                                 
  installed package frogmouth 0.9.2, installed using Python 3.12.0
  These apps are now globally available
    - frogmouth
done! ✨ 🌟 ✨
```

Repo tests were also passed successfully
https://github.com/ehlewis/pipx/actions/runs/7072389139
