### PR TITLE
fix: append pip errors to log file rather than overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## dev
 
+- Append to instead of overwrite pip errors log file
+
 ## 1.3.1
 
 - Fix combining of --editable and --force flag

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -324,7 +324,7 @@ def subprocess_post_check_handle_pip_error(
         if pipx.constants.pipx_log_file is None:
             raise PipxError("Pipx internal error: No log_file present.")
         pip_error_file = pipx.constants.pipx_log_file.parent / (pipx.constants.pipx_log_file.stem + "_pip_errors.log")
-        with pip_error_file.open("w", encoding="utf-8") as pip_error_fh:
+        with pip_error_file.open("a", encoding="utf-8") as pip_error_fh:
             print("PIP STDOUT", file=pip_error_fh)
             print("----------", file=pip_error_fh)
             if completed_process.stdout is not None:


### PR DESCRIPTION
Resolves #1132 

An alternative would be to create new log files for each pip invocation, but this would require deeper changes. Appending seems like a decent solution as a first fix.

- [x] I have added an entry to `docs/changelog.md`

## Summary of changes

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
python src/pipx install visidata pycowsay --python "3.11"
python src/pipx reinstall-all --python "3.12"
```

The logs now contain pip error output from both errors: visidata and pycowsay. Exactly what should happen.