### PR TITLE
Modification to run.py to check for and upgrade to latest app version when using pipx run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## dev
 
+- Check for latest version and upgrade to latest version if it exists when running pipx run
+
 ## 1.3.3
 
 - [docs] Make the logo more visible in dark mode

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -1,12 +1,13 @@
 import datetime
 import hashlib
 import logging
+import re
 import requests
 import subprocess
+import sys
 import time
 import urllib.parse
 import urllib.request
-
 from bs4 import BeautifulSoup
 from pathlib import Path
 from shutil import which
@@ -28,6 +29,11 @@ from pipx.util import (
     run_pypackage_bin,
 )
 from pipx.venv import Venv
+
+if sys.version_info < (3, 11):
+    import tomli as tomllib
+else:
+    import tomllib
 
 logger = logging.getLogger(__name__)
 
@@ -130,9 +136,7 @@ def run_package(
 
     pypackage_bin_path = get_pypackage_bin_path(app)
     if pypackage_bin_path.exists():
-        logger.info(
-            f"Using app in local __pypackages__ directory at '{pypackage_bin_path}'"
-        )
+        logger.info(f"Using app in local __pypackages__ directory at '{pypackage_bin_path}'")
         run_pypackage_bin(pypackage_bin_path, app_args)
     if pypackages:
         raise PipxError(
@@ -228,7 +232,7 @@ def check_version(app: str):
         if latest_version:
             if version.parse(latest_version) > version.parse(current_version):
                subprocess.run(["pipx", "upgrade", app])
-        
+
 def _is_version_check_expired(venv_dir: Path) -> bool:
     version_check_file = venv_dir / "pipx_version_check"
     created_time_sec = version_check_file.stat().st_ctime
@@ -247,10 +251,10 @@ def _get_latest_version(app) -> str:
         if html_content:
             # Parse the HTML content using BeautifulSoup
             soup = BeautifulSoup(html_content, 'html.parser')
-        
+
             # Extract the latest version from the HTML
             version_element = soup.select_one('.package-header__name')
-        
+
             if version_element:
                 # Extract the version from the h1 element text
                 version_text = version_element.text.strip()
@@ -267,7 +271,7 @@ def _get_latest_version(app) -> str:
     except requests.RequestException as e:
         print(f"Error during request: {e}")
         return ""
-        
+
 def _download_and_run(
     venv_dir: Path,
     package_or_url: str,
@@ -281,15 +285,15 @@ def _download_and_run(
     verbose: bool,
 ) -> NoReturn:
     venv = Venv(venv_dir, python=python, verbose=verbose)
-    venv.create_venv(venv_args, pip_args)
 
     if venv.pipx_metadata.main_package.package is not None:
         package_name = venv.pipx_metadata.main_package.package
     else:
-        package_name = package_name_from_spec(
-            package_or_url, python, pip_args=pip_args, verbose=verbose
-        )
+        package_name = package_name_from_spec(package_or_url, python, pip_args=pip_args, verbose=verbose)
 
+    override_shared = package_name == "pip"
+
+    venv.create_venv(venv_args, pip_args, override_shared)
     venv.install_package(
         package_name=package_name,
         package_or_url=package_or_url,
@@ -312,10 +316,7 @@ def _download_and_run(
             else:
                 app_filename = app
         else:
-            all_apps = (
-                f"{a} - usage: 'pipx run --spec {package_or_url} {a} [arguments?]'"
-                for a in apps
-            )
+            all_apps = (f"{a} - usage: 'pipx run --spec {package_or_url} {a} [arguments?]'" for a in apps)
             raise PipxError(
                 APP_NOT_FOUND_ERROR_MESSAGE.format(
                     app=app,
@@ -332,9 +333,7 @@ def _download_and_run(
     venv.run_app(app, app_filename, app_args)
 
 
-def _get_temporary_venv_path(
-    requirements: List[str], python: str, pip_args: List[str], venv_args: List[str]
-) -> Path:
+def _get_temporary_venv_path(requirements: List[str], python: str, pip_args: List[str], venv_args: List[str]) -> Path:
     """Computes deterministic path using hashing function on arguments relevant
     to virtual environment's end state. Arguments used should result in idempotent
     virtual environment. (i.e. args passed to app aren't relevant, but args
@@ -382,41 +381,43 @@ def _http_get_request(url: str) -> str:
         raise PipxError(str(e)) from e
 
 
-def _get_requirements_from_script(content: str) -> Optional[List[str]]:
-    # An iterator over the lines in the script. We will
-    # read through this in sections, so it needs to be an
-    # iterator, not just a list.
-    lines = iter(content.splitlines())
+# This regex comes from PEP 723
+PEP723 = re.compile(r"(?m)^# /// (?P<type>[a-zA-Z0-9-]+)$\s(?P<content>(^#(| .*)$\s)+)^# ///$")
 
-    for line in lines:
-        if not line.startswith("#"):
-            continue
-        line_content = line[1:].strip()
-        if line_content == "Requirements:":
-            break
-    else:
-        # No "Requirements:" line in the file
+
+def _get_requirements_from_script(content: str) -> Optional[List[str]]:
+    """
+    Supports PEP 723.
+    """
+
+    name = "pyproject"
+
+    # Windows is currently getting un-normalized line endings, so normalize
+    content = content.replace("\r\n", "\n")
+
+    matches = [m for m in PEP723.finditer(content) if m.group("type") == name]
+
+    if not matches:
         return None
 
-    # We are now at the first requirement
-    requirements = []
-    for line in lines:
-        # Stop at the end of the comment block
-        if not line.startswith("#"):
-            break
-        line_content = line[1:].strip()
-        # Stop at a blank comment line
-        if not line_content:
-            break
+    if len(matches) > 1:
+        raise ValueError(f"Multiple {name} blocks found")
 
+    content = "".join(
+        line[2:] if line.startswith("# ") else line[1:] for line in matches[0].group("content").splitlines(keepends=True)
+    )
+
+    pyproject = tomllib.loads(content)
+
+    requirements = []
+    for requirement in pyproject.get("run", {}).get("requirements", []):
         # Validate the requirement
         try:
-            req = Requirement(line_content)
+            req = Requirement(requirement)
         except InvalidRequirement as e:
-            raise PipxError(f"Invalid requirement {line_content}: {str(e)}") from e
+            raise PipxError(f"Invalid requirement {requirement}: {e}") from e
 
-        # Use the normalised form of the requirement,
-        # not the original line.
+        # Use the normalised form of the requirement
         requirements.append(str(req))
 
     return requirements


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [x ] I have added an entry to `docs/changelog.md`

## Summary of changes
This pull request addresses issue #464 to check for and upgrade to the latest app version when using pipx run. pipx would check for new versions no more than once within a given time period. Right now, the time period is 24 hours. Checking for new versions involves a query of PyPI directly using their simple API to check for a specific package’s latest version. If the latest version is more recent than the currently installed version, the code automatically upgrades the package on your system. Right now, the feature can only handle apps accessible through the simple API.

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
A basic test was performed by installing an older version of cowsay and running the app. After running pipx run, the program upgraded the app to the latest version (6.1) before running cowsay.


Tested by running

```
pipx install cowsay==5.0
python3 src/pipx run cowsay -t mooo
```
