### PR TITLE
Global install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## dev
 
 - [docs] Add Scoop installation instructions
+- [docs] Change Ubuntu <=22.04 installation instructions to also use a global installation (with own virtual environment)
 
 ## 1.3.3
 

--- a/README.md
+++ b/README.md
@@ -51,12 +51,15 @@ pipx ensurepath
 
 - Ubuntu 22.04 or below
 
-```
-python3 -m pip install --user pipx
-python3 -m pipx ensurepath
+```sh
+sudo apt install python3-venv
+sudo python3 -m venv --upgrade-deps /opt/pipx
+sudo /opt/pipx/bin/pip install pipx
+sudo ln -s /opt/pipx/bin/pipx /usr/local/bin/pipx
+pipx ensurepath
 ```
 
-Upgrade pipx with `python3 -m pip install --user --upgrade pipx`.
+Upgrade pipx with `sudo /opt/pipx/bin/pip install --upgrade pipx`.
 
 ### On Windows
 


### PR DESCRIPTION
- [x] I have added an entry to `docs/changelog.md`

## Summary of changes
While `pipx` aims not to clutter the global/user python environments, the current instructions do exactly that. How about we stay clean on that front, too?

These instructions use a widely available `python3-venv` package to create a virtual environment for `pipx`, so even it stays out of the still pretty vulnerable `--user` python environment.

## Test plan

Tested by running those suggested commands :)