### PR TITLE
Be more user-friendly by pointing to PyPA specifications instead of PEPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@
 - Drop `setuptools` and `wheel` from the shared libraries. This results in less time consumption when the libraries are
   automatically upgraded.
 - Allow running `pip` with `pipx run`
-- Support PEP 723 run requirements in `pipx run`.
+- Support [inline script metadata](https://packaging.python.org/en/latest/specifications/inline-script-metadata/)
+  in `pipx run`.
 - Imply `--include-apps` when running `pipx inject --include-deps`
 - Add `--with-suffix` for `pipx inject` command
 - `pipx install`: emit a warning when `--force` and `--python` were passed at the same time

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -103,8 +103,9 @@ virtualenvs with their dependencies installed.
 
 - Both [fades](https://github.com/PyAr/fades#how-to-mark-the-dependencies-to-be-installed) and
   [pipx run](examples.md#pipx-run-examples) allow specifying a script's dependencies in specially formatted comments,
-  but the exact syntax differs (see also [PEP 722](https://peps.python.org/pep-0722/) which seeks to standardize such
-  syntax).
+  but the exact syntax differs. (pipx's syntax is standardized by a
+  [provisional specification](https://packaging.python.org/en/latest/specifications/inline-script-metadata/),
+  fades's syntax is not standardized.)
 - Both tools automatically set up reusable virtualenvs containing the necessary dependencies.
 - Both can download Python scripts/packages to execute from remote resources.
 - fades can only run individual script files while pipx can also run packages.

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -319,13 +319,13 @@ def _http_get_request(url: str) -> str:
         raise PipxError(str(e)) from e
 
 
-# This regex comes from PEP 723
-PEP723 = re.compile(r"(?m)^# /// (?P<type>[a-zA-Z0-9-]+)$\s(?P<content>(^#(| .*)$\s)+)^# ///$")
+# This regex comes from the inline script metadata spec
+INLINE_SCRIPT_METADATA = re.compile(r"(?m)^# /// (?P<type>[a-zA-Z0-9-]+)$\s(?P<content>(^#(| .*)$\s)+)^# ///$")
 
 
 def _get_requirements_from_script(content: str) -> Optional[List[str]]:
     """
-    Supports PEP 723.
+    Supports inline script metadata.
     """
 
     name = "pyproject"
@@ -333,7 +333,7 @@ def _get_requirements_from_script(content: str) -> Optional[List[str]]:
     # Windows is currently getting un-normalized line endings, so normalize
     content = content.replace("\r\n", "\n")
 
-    matches = [m for m in PEP723.finditer(content) if m.group("type") == name]
+    matches = [m for m in INLINE_SCRIPT_METADATA.finditer(content) if m.group("type") == name]
 
     if not matches:
         return None


### PR DESCRIPTION
## Summary of changes

Link to the inline script metadata specification on packaging.python.org instead of PEP 723.