### PR TITLE
Update troubleshooting URL in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -7,7 +7,7 @@ about: Report a bug or unexpected behavior.
 Thank you for filing a bug! Please feel free to answer as much or as little of this template as you can.
 
 Please check pipx's Troubleshooting page to see if any of those solutions help solve your issue:
-https://pypa.github.io/pipx/troubleshooting/
+https://pipx.pypa.io/stable/troubleshooting/
 -->
 
 **Describe the bug**


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [x] I have added an entry to `docs/changelog.md`

## Summary of changes

Before this change the troubleshooting URL in the bug report template takes the user to a redirect page:

   You will be redirected to https://pipx.pypa.io soon!

The redirect then takes the user to the pipx homepage.

After this change the URL in the bug report template takes the user straight to the troubleshooting page.

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

https://github.com/maxwell-k/pipx/issues/1

Tested by:

1. merging these changes into the default branch of my fork
2. visiting <https://github.com/maxwell-k/pipx/issues/new?template=bug.md>
3. checking that the page displayed a URL inside the text box
4. visiting the URL
5. checking that I am on the troubleshooting page
