### PR TITLE
Remove executable name option from help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## dev
 
+- Fix `--help` by removing the option to pass an executable name to `--python`
 - [docs] Add Scoop installation instructions
 
 ## 1.3.3

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -355,8 +355,8 @@ def _add_install(subparsers: argparse._SubParsersAction) -> None:
         "--python",
         # Don't pass a default Python here so we know whether --python flag was passed
         help=(
-            "Python to install with. Possible values can be the executable name (python3.11), "
-            "the version to pass to py launcher (3.11), or the full path to the executable."
+            "Python to run with. Possible values can be the version to pass to py launcher "
+            "(3.11) or the full path to the executable. "
             f"Requires Python {MINIMUM_PYTHON_VERSION} or above."
         ),
     )
@@ -616,8 +616,8 @@ def _add_run(subparsers: argparse._SubParsersAction) -> None:
         "--python",
         default=DEFAULT_PYTHON,
         help=(
-            "Python to run with. Possible values can be the executable name (python3.11), "
-            "the version to pass to py launcher (3.11), or the full path to the executable. "
+            "Python to run with. Possible values can be the version to pass to py launcher "
+            "(3.11) or the full path to the executable. "
             f"Requires Python {MINIMUM_PYTHON_VERSION} or above."
         ),
     )


### PR DESCRIPTION
This is only one approach to addressing #1150 and may not be preferred.

<!-- add an 'x' in the brackets below -->

- [x] I have added an entry to `docs/changelog.md`

## Summary of changes

This is a change to the help text for install and run to remove the description of passing an executable name. After this change the help does not suggest invocations including `--python python3.11` which lead to #1150 . Fixes https://github.com/pypa/pipx/issues/1150

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running:

```
.nox/develop-3-12/bin/python src/pipx install --help
.nox/develop-3-12/bin/python src/pipx run --help
```

Example excerpt from output:

```
  --python PYTHON       Python to run with. Possible values can be the version to pass to py launcher
                        (3.11) or the full path to the executable. Requires Python 3.8 or above.
```
