### PR TITLE
Pass real paths when running subprocesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## dev
 
+- Fix "No pyvenv.cfg file" error when using Microsoft Store Python (#1164)
 - Add `--quiet` and `--verbose` options for the `pipx` subcommands
 - [docs] Add Scoop installation instructions
 - Add ability to install multiple packages at once

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## dev
 
+- Fix "Failed to delete" error when using Microsoft Store Python
 - Fix "No pyvenv.cfg file" error when using Microsoft Store Python (#1164)
 - Add `--quiet` and `--verbose` options for the `pipx` subcommands
 - [docs] Add Scoop installation instructions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## dev
 
+- Delete directories directly instead of spawning rmdir on Windows
 - Fix "Failed to delete" error when using Microsoft Store Python
 - Fix "No pyvenv.cfg file" error when using Microsoft Store Python (#1164)
 - Add `--quiet` and `--verbose` options for the `pipx` subcommands

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -54,12 +54,7 @@ def rmdir(path: Path, safe_rm: bool = True) -> None:
 
     logger.info(f"removing directory {path}")
     try:
-        if WINDOWS:
-            # The packaged app (Microsoft Store) version of Python uses path redirections, but `rmdir` won't follow
-            # these, so use realpath() to manually apply the redirection first.
-            os.system(f'rmdir /S /Q "{os.path.realpath(path)}"')
-        else:
-            shutil.rmtree(path)
+        shutil.rmtree(path)
     except FileNotFoundError:
         pass
 

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -55,7 +55,9 @@ def rmdir(path: Path, safe_rm: bool = True) -> None:
     logger.info(f"removing directory {path}")
     try:
         if WINDOWS:
-            os.system(f'rmdir /S /Q "{str(path)}"')
+            # The packaged app (Microsoft Store) version of Python uses path redirections, but `rmdir` won't follow
+            # these, so use realpath() to manually apply the redirection first.
+            os.system(f'rmdir /S /Q "{os.path.realpath(path)}"')
         else:
             shutil.rmtree(path)
     except FileNotFoundError:


### PR DESCRIPTION
## Summary of changes

Fixes #1164 by making sure real paths are passed to executables that are not subject to path redirection.

## Test plan

```
winget install python --source=msstore
pip install .
python -m pipx ensurepath
pipx install pycowsay
pycowsay
```

The above fails without this PR with the error shown in #1164, but succeeds with this PR.

I [tried](https://github.com/dechamps/pipx/commit/8cb2b83884d736c28923bb261e550dbb425ac77e) to add a GitHub Actions job that does the above so that any future regressions will be caught, but unfortunately installing Microsoft Store apps in a GitHub Actions workflow does not appear to be easy (see e.g. Cyberboss/install-winget#1).