### PR TITLE
Don't show debug messages when verbose isn't passed

### DIFF
--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -129,7 +129,7 @@ def _symlink_package_resource(
         mkdir(symlink_path.parent)
 
     if force:
-        logger.info(f"Force is true. Removing {str(symlink_path)}.")
+        logger.debug(f"Force is true. Removing {str(symlink_path)}.")
         try:
             symlink_path.unlink()
         except FileNotFoundError:
@@ -141,7 +141,7 @@ def _symlink_package_resource(
     is_symlink = symlink_path.is_symlink()
     if exists:
         if symlink_path.samefile(path):
-            logger.info(f"Same path {str(symlink_path)} and {str(path)}")
+            logger.debug(f"Same path {str(symlink_path)} and {str(path)}")
         else:
             logger.warning(
                 pipx_wrap(
@@ -155,7 +155,7 @@ def _symlink_package_resource(
             )
         return
     if is_symlink and not exists:
-        logger.info(f"Removing existing symlink {str(symlink_path)} since it " "pointed non-existent location")
+        logger.debug(f"Removing existing symlink {str(symlink_path)} since it pointed to non-existent location")
         symlink_path.unlink()
 
     if executable:
@@ -367,8 +367,8 @@ def package_name_from_spec(package_spec: str, python: str, *, pip_args: List[str
         # NOTE: if pypi name and installed package name differ, this means pipx
         #       will use the pypi name
         package_name = pypi_name
-        logger.info(f"Determined package name: {package_name}")
-        logger.info(f"Package name determined in {time.time()-start_time:.1f}s")
+        logger.debug(f"Determined package name: {package_name}")
+        logger.debug(f"Package name determined in {time.time()-start_time:.1f}s")
         return package_name
 
     # check syntax and clean up spec and pip_args
@@ -379,7 +379,7 @@ def package_name_from_spec(package_spec: str, python: str, *, pip_args: List[str
         venv.create_venv(venv_args=[], pip_args=[])
         package_name = venv.install_package_no_deps(package_or_url=package_spec, pip_args=pip_args)
 
-    logger.info(f"Package name determined in {time.time()-start_time:.1f}s")
+    logger.debug(f"Package name determined in {time.time()-start_time:.1f}s")
     return package_name
 
 

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -62,7 +62,7 @@ def maybe_script_content(app: str, is_path: bool) -> Optional[str]:
                 end with '.py'. To run from an SVN, try pipx --spec URL BINARY
                 """
             )
-        logger.info("Detected url. Downloading and executing as a Python file.")
+        logger.debug("Detected url. Downloading and executing as a Python file.")
 
         return _http_get_request(app)
 
@@ -94,7 +94,7 @@ def run_script(
         venv = Venv(venv_dir)
         _prepare_venv_cache(venv, None, use_cache)
         if venv_dir.exists():
-            logger.info(f"Reusing cached venv {venv_dir}")
+            logger.debug(f"Reusing cached venv {venv_dir}")
         else:
             venv = Venv(venv_dir, python=python, verbose=verbose)
             venv.create_venv(venv_args, pip_args)
@@ -126,13 +126,13 @@ def run_package(
 
     if WINDOWS:
         app_filename = f"{app}.exe"
-        logger.info(f"Assuming app is {app_filename!r} (Windows only)")
+        logger.debug(f"Assuming app is {app_filename!r} (Windows only)")
     else:
         app_filename = app
 
     pypackage_bin_path = get_pypackage_bin_path(app)
     if pypackage_bin_path.exists():
-        logger.info(f"Using app in local __pypackages__ directory at '{pypackage_bin_path}'")
+        logger.debug(f"Using app in local __pypackages__ directory at '{pypackage_bin_path}'")
         run_pypackage_bin(pypackage_bin_path, app_args)
     if pypackages:
         raise PipxError(
@@ -150,10 +150,10 @@ def run_package(
     _prepare_venv_cache(venv, bin_path, use_cache)
 
     if venv.has_app(app, app_filename):
-        logger.info(f"Reusing cached venv {venv_dir}")
+        logger.debug(f"Reusing cached venv {venv_dir}")
         venv.run_app(app, app_filename, app_args)
     else:
-        logger.info(f"venv location is {venv_dir}")
+        logger.debug(f"venv location is {venv_dir}")
         _download_and_run(
             Path(venv_dir),
             package_or_url,
@@ -250,7 +250,7 @@ def _download_and_run(
             print(f"NOTE: running app {app!r} from {package_name!r}")
             if WINDOWS:
                 app_filename = f"{app}.exe"
-                logger.info(f"Assuming app is {app_filename!r} (Windows only)")
+                logger.debug(f"Assuming app is {app_filename!r} (Windows only)")
             else:
                 app_filename = app
         else:
@@ -297,7 +297,7 @@ def _is_temporary_venv_expired(venv_dir: Path) -> bool:
 def _prepare_venv_cache(venv: Venv, bin_path: Optional[Path], use_cache: bool) -> None:
     venv_dir = venv.root
     if not use_cache and (bin_path is None or bin_path.exists()):
-        logger.info(f"Removing cached venv {str(venv_dir)}")
+        logger.debug(f"Removing cached venv {str(venv_dir)}")
         rmdir(venv_dir)
     _remove_all_expired_venvs()
 
@@ -305,7 +305,7 @@ def _prepare_venv_cache(venv: Venv, bin_path: Optional[Path], use_cache: bool) -
 def _remove_all_expired_venvs() -> None:
     for venv_dir in Path(constants.PIPX_VENV_CACHEDIR).iterdir():
         if _is_temporary_venv_expired(venv_dir):
-            logger.info(f"Removing expired venv {str(venv_dir)}")
+            logger.debug(f"Removing expired venv {str(venv_dir)}")
             rmdir(venv_dir)
 
 

--- a/src/pipx/commands/uninject.py
+++ b/src/pipx/commands/uninject.py
@@ -80,19 +80,19 @@ def uninject_dep(
 
     if not leave_deps:
         orig_not_required_packages = venv.list_installed_packages(not_required=True)
-        logger.info(f"Original not required packages: {orig_not_required_packages}")
+        logger.debug(f"Original not required packages: {orig_not_required_packages}")
 
     venv.uninstall_package(package=package_name, was_injected=True)
 
     if not leave_deps:
         new_not_required_packages = venv.list_installed_packages(not_required=True)
-        logger.info(f"New not required packages: {new_not_required_packages}")
+        logger.debug(f"New not required packages: {new_not_required_packages}")
 
         deps_of_uninstalled = new_not_required_packages - orig_not_required_packages
         if len(deps_of_uninstalled) == 0:
             pass
         else:
-            logger.info(f"Dependencies of uninstalled package: {deps_of_uninstalled}")
+            logger.debug(f"Dependencies of uninstalled package: {deps_of_uninstalled}")
 
         for dep_package_name in deps_of_uninstalled:
             venv.uninstall_package(package=dep_package_name, was_injected=False)
@@ -106,9 +106,9 @@ def uninject_dep(
             try:
                 os.unlink(path)
             except FileNotFoundError:
-                logger.info(f"tried to remove but couldn't find {path}")
+                logger.debug(f"tried to remove but couldn't find {path}")
             else:
-                logger.info(f"removed file {path}")
+                logger.debug(f"removed file {path}")
 
     print(f"Uninjected package {bold(package_name)}{deps_string} from venv {bold(venv.root.name)} {stars}")
     return True

--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -143,9 +143,9 @@ def uninstall(venv_dir: Path, local_bin_dir: Path, local_man_dir: Path, verbose:
         try:
             safe_unlink(path)
         except FileNotFoundError:
-            logger.info(f"tried to remove but couldn't find {path}")
+            logger.debug(f"tried to remove but couldn't find {path}")
         else:
-            logger.info(f"removed file {path}")
+            logger.debug(f"removed file {path}")
 
     rmdir(venv_dir)
     print(f"uninstalled {venv.name}! {stars}")

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -183,7 +183,7 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:  # noqa: C901
                     args.spec = args.spec + f"#egg={package}"
 
         venv_dir = venv_container.get_venv_dir(package)
-        logger.info(f"Virtual Environment location is {venv_dir}")
+        logger.debug(f"Virtual Environment location is {venv_dir}")
     if "skip" in args:
         skip_list = [canonicalize_name(x) for x in args.skip]
 
@@ -846,8 +846,8 @@ def setup(args: argparse.Namespace) -> None:
 
     logger.debug(f"{time.strftime('%Y-%m-%d %H:%M:%S')}")
     logger.debug(f"{' '.join(sys.argv)}")
-    logger.info(f"pipx version is {__version__}")
-    logger.info(f"Default python interpreter is '{DEFAULT_PYTHON}'")
+    logger.debug(f"pipx version is {__version__}")
+    logger.debug(f"Default python interpreter is '{DEFAULT_PYTHON}'")
 
     mkdir(constants.PIPX_LOCAL_VENVS)
     mkdir(constants.LOCAL_BIN_DIR)

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -134,7 +134,7 @@ def _parsed_package_to_package_or_url(parsed_package: ParsedPackage, remove_vers
     elif parsed_package.valid_local_path is not None:
         package_or_url = parsed_package.valid_local_path
 
-    logger.info(f"cleaned package spec: {package_or_url}")
+    logger.debug(f"cleaned package spec: {package_or_url}")
     return package_or_url
 
 

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -74,7 +74,7 @@ class _SharedLibs:
         now = time.time()
         time_since_last_update_sec = now - self.pip_path.stat().st_mtime
         if not self.has_been_logged_this_run:
-            logger.info(
+            logger.debug(
                 f"Time since last upgrade of shared libs, in seconds: {time_since_last_update_sec:.0f}. "
                 f"Upgrade will be run by pipx if greater than {SHARED_LIBS_MAX_AGE_SEC:.0f}."
             )
@@ -88,13 +88,13 @@ class _SharedLibs:
 
         # Don't try to upgrade multiple times per run
         if self.has_been_updated_this_run:
-            logger.info(f"Already upgraded libraries in {self.root}")
+            logger.debug(f"Already upgraded libraries in {self.root}")
             return
 
         if pip_args is None:
             pip_args = []
 
-        logger.info(f"Upgrading shared libraries in {self.root}")
+        logger.debug(f"Upgrading shared libraries in {self.root}")
 
         ignored_args = ["--editable"]
         _pip_args = [arg for arg in pip_args if arg not in ignored_args]

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -52,7 +52,7 @@ def rmdir(path: Path, safe_rm: bool = True) -> None:
     if not path.is_dir():
         return
 
-    logger.info(f"removing directory {path}")
+    logger.debug(f"removing directory {path}")
     try:
         shutil.rmtree(path)
     except FileNotFoundError:
@@ -71,7 +71,7 @@ def rmdir(path: Path, safe_rm: bool = True) -> None:
 def mkdir(path: Path) -> None:
     if path.is_dir():
         return
-    logger.info(f"creating directory {path}")
+    logger.debug(f"creating directory {path}")
     path.mkdir(parents=True, exist_ok=True)
 
 
@@ -165,7 +165,7 @@ def run_subprocess(
 
     if log_cmd_str is None:
         log_cmd_str = " ".join(str(c) for c in cmd)
-    logger.info(f"running {log_cmd_str}")
+    logger.debug(f"running {log_cmd_str}")
     # windows cannot take Path objects, only strings
     cmd_str_list = [str(c) for c in cmd]
     # Make sure to call the binary using its real path. This matters especially on Windows when using the packaged app
@@ -204,7 +204,7 @@ def subprocess_post_check(completed_process: "subprocess.CompletedProcess[str]",
         if raise_error:
             raise PipxError(f"{' '.join([str(x) for x in completed_process.args])!r} failed")
         else:
-            logger.info(f"{' '.join(completed_process.args)!r} failed")
+            logger.debug(f"{' '.join(completed_process.args)!r} failed")
 
 
 def dedup_ordered(input_list: List[Any]) -> List[Any]:
@@ -324,7 +324,7 @@ def subprocess_post_check_handle_pip_error(
     completed_process: "subprocess.CompletedProcess[str]",
 ) -> None:
     if completed_process.returncode:
-        logger.info(f"{' '.join(completed_process.args)!r} failed")
+        logger.debug(f"{' '.join(completed_process.args)!r} failed")
         # Save STDOUT and STDERR to file in pipx/logs/
         if pipx.constants.pipx_log_file is None:
             raise PipxError("Pipx internal error: No log_file present.")
@@ -367,7 +367,7 @@ def exec_app(
     # make sure we show cursor again before handing over control
     show_cursor()
 
-    logger.info("exec_app: " + " ".join([str(c) for c in cmd]))
+    logger.debug("exec_app: " + " ".join([str(c) for c in cmd]))
 
     if WINDOWS:
         sys.exit(

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -320,10 +320,10 @@ class Venv:
         installed_packages = self.list_installed_packages() - old_package_set
         if len(installed_packages) == 1:
             package_name = installed_packages.pop()
-            logger.info(f"Determined package name: {package_name}")
+            logger.debug(f"Determined package name: {package_name}")
         else:
-            logger.info(f"old_package_set = {old_package_set}")
-            logger.info(f"install_packages = {installed_packages}")
+            logger.debug(f"old_package_set = {old_package_set}")
+            logger.debug(f"install_packages = {installed_packages}")
             raise PipxError(
                 f"""
                 Cannot determine package name from spec {package_or_url!r}.
@@ -336,7 +336,7 @@ class Venv:
     def get_venv_metadata_for_package(self, package_name: str, package_extras: Set[str]) -> VenvMetadata:
         data_start = time.time()
         venv_metadata = inspect_venv(package_name, package_extras, self.bin_path, self.python_path, self.man_path)
-        logger.info(f"get_venv_metadata_for_package: {1e3*(time.time()-data_start):.0f}ms")
+        logger.debug(f"get_venv_metadata_for_package: {1e3*(time.time()-data_start):.0f}ms")
         return venv_metadata
 
     def _update_package_metadata(


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [ ] I have added an entry to `docs/changelog.md`

## Summary of changes
Don't show debug messages when verbose isn't passed. This is implemented by changing all `logging.info(...)` to `logging.debug(...)`.
Closes #1175.

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
# command(s) to exercise these changes
```
