### PR TITLE
Set default logging level to WARNING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## dev
 
+- Set default logging level to WARNING, so debug log messages won't be shown without passing additonal flags such as `--verbose`
+
+## 1.4.0
+
 - Delete directories directly instead of spawning rmdir on Windows
 - Fix "Failed to delete" error when using Microsoft Store Python
 - Fix "No pyvenv.cfg file" error when using Microsoft Store Python (#1164)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## dev
 
-- Set default logging level to WARNING, so debug log messages won't be shown without passing additonal flags such as `--verbose`
+- Set default logging level to WARNING, so debug log messages won't be shown without passing additional flags such as `--verbose`
 
 ## 1.4.0
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -840,7 +840,7 @@ def setup(args: argparse.Namespace) -> None:
         print_version()
         sys.exit(0)
 
-    verbose = getattr(args, 'verbose', 0) - getattr(args, 'quiet', 0)
+    verbose = getattr(args, "verbose", 0) - getattr(args, "quiet", 0)
 
     setup_logging(verbose)
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -699,15 +699,6 @@ def get_command_parser() -> argparse.ArgumentParser:
 
     completer_venvs = InstalledVenvsCompleter(venv_container)
 
-    parser = argparse.ArgumentParser(
-        prog=prog_name(),
-        formatter_class=LineWrapRawTextHelpFormatter,
-        description=PIPX_DESCRIPTION,
-    )
-    parser.man_short_description = PIPX_DESCRIPTION.splitlines()[1]  # type: ignore
-
-    subparsers = parser.add_subparsers(dest="command", description="Get help for commands with pipx COMMAND --help")
-
     shared_parser = argparse.ArgumentParser(add_help=False)
 
     shared_parser.add_argument(
@@ -722,6 +713,16 @@ def get_command_parser() -> argparse.ArgumentParser:
     )
 
     shared_parser.add_argument("--verbose", "-v", action="count", default=0, help=("Give more output."))
+
+    parser = argparse.ArgumentParser(
+        prog=prog_name(),
+        formatter_class=LineWrapRawTextHelpFormatter,
+        description=PIPX_DESCRIPTION,
+        parents=[shared_parser],
+    )
+    parser.man_short_description = PIPX_DESCRIPTION.splitlines()[1]  # type: ignore
+
+    subparsers = parser.add_subparsers(dest="command", description="Get help for commands with pipx COMMAND --help")
 
     _add_install(subparsers, shared_parser)
     _add_uninject(subparsers, completer_venvs.use, shared_parser)
@@ -840,7 +841,7 @@ def setup(args: argparse.Namespace) -> None:
         print_version()
         sys.exit(0)
 
-    verbose = getattr(args, "verbose", 0) - getattr(args, "quiet", 0)
+    verbose = args.verbose - args.quiet
 
     setup_logging(verbose)
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -786,12 +786,12 @@ def setup_log_file() -> Path:
         return _setup_log_file(platformdirs.user_log_path("pipx"))
 
 
-def setup_logging(verbose: bool) -> None:
+def setup_logging(verbose: int) -> None:
     pipx_str = bold(green("pipx >")) if sys.stdout.isatty() else "pipx >"
     pipx.constants.pipx_log_file = setup_log_file()
 
     # Determine logging level
-    level_number = max(0, 2 - verbose) * 10
+    level_number = max(0, logging.WARNING - 10 * verbose)
 
     level = logging.getLevelName(level_number)
 
@@ -840,7 +840,7 @@ def setup(args: argparse.Namespace) -> None:
         print_version()
         sys.exit(0)
 
-    verbose = args.verbose - args.quiet
+    verbose = getattr(args, 'verbose', 0) - getattr(args, 'quiet', 0)
 
     setup_logging(verbose)
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Set the default logging level to WARNING, so debug log messages won't be shown without passing additional flags such as `--verbose`.

Closes #1175
Closes #1177 

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
nox -s tests-3.12
```
