### PR TITLE
Bump changelog manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## dev
 
+## 1.4.1
+
 - Set default logging level to WARNING, so debug log messages won't be shown without passing additional flags such as `--verbose`
 
 ## 1.4.0


### PR DESCRIPTION
Looks like the workflow "Bump changelog on release" can't be run successfully due to branch protection.
