### PR TITLE
fix: nicer tracebacks in run mode on scripts

### DIFF
--- a/changelog.d/1191.fix.md
+++ b/changelog.d/1191.fix.md
@@ -1,0 +1,1 @@
+Report correct filename in tracebacks with `pipx run <scriptname>`

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -81,7 +81,7 @@ def run_script(
 ) -> NoReturn:
     requirements = _get_requirements_from_script(content)
     if requirements is None:
-        python_path = python
+        python_path = Path(python)
     else:
         # Note that the environment name is based on the identified
         # requirements, and *not* on the script name. This is deliberate, as

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -81,10 +81,7 @@ def run_script(
 ) -> NoReturn:
     requirements = _get_requirements_from_script(content)
     if requirements is None:
-        if isinstance(content, Path):
-            exec_app([python, content, *app_args])
-        else:
-            exec_app([python, "-c", content, *app_args])
+        python_path = python
     else:
         # Note that the environment name is based on the identified
         # requirements, and *not* on the script name. This is deliberate, as
@@ -102,10 +99,12 @@ def run_script(
             venv = Venv(venv_dir, python=python, verbose=verbose)
             venv.create_venv(venv_args, pip_args)
             venv.install_unmanaged_packages(requirements, pip_args)
-        if isinstance(content, Path):
-            exec_app([venv.python_path, content, *app_args])
-        else:
-            exec_app([venv.python_path, "-c", content, *app_args])
+        python_path = venv.python_path
+
+    if isinstance(content, Path):
+        exec_app([python_path, content, *app_args])
+    else:
+        exec_app([python_path, "-c", content, *app_args])
 
 
 def run_package(

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -248,7 +248,7 @@ def test_run_correct_traceback(capfd, pipx_temp_env, tmp_path):
     script = tmp_path / "test.py"
     script.write_text(
         textwrap.dedent(
-            f"""
+            """
                 raise RuntimeError("Should fail")
             """
         ).strip()
@@ -259,7 +259,6 @@ def test_run_correct_traceback(capfd, pipx_temp_env, tmp_path):
 
     captured = capfd.readouterr()
     assert "test.py" in captured.err
-
 
 
 @mock.patch("os.execvpe", new=execvpe_mock)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -244,6 +244,25 @@ def test_run_with_requirements_old(caplog, pipx_temp_env, tmp_path):
 
 
 @mock.patch("os.execvpe", new=execvpe_mock)
+def test_run_correct_traceback(capfd, pipx_temp_env, tmp_path):
+    script = tmp_path / "test.py"
+    script.write_text(
+        textwrap.dedent(
+            f"""
+                raise RuntimeError("Should fail")
+            """
+        ).strip()
+    )
+
+    with pytest.raises(SystemExit):
+        run_pipx_cli(["run", str(script)])
+
+    captured = capfd.readouterr()
+    assert "test.py" in captured.err
+
+
+
+@mock.patch("os.execvpe", new=execvpe_mock)
 def test_run_with_args(caplog, pipx_temp_env, tmp_path):
     script = tmp_path / "test.py"
     out = tmp_path / "output.txt"


### PR DESCRIPTION
This is one way to improve the tracebacks as reported in #1187 and mentioned in #1180.

<!-- add an 'x' in the brackets below -->

- [x] I have added an entry to `docs/changelog.md`

## Summary of changes

This is the simplest way I initially see to get filenames. Instead of passing around the contents of the script as a string, scripts are passed around as Paths, which allows the run command to run the path rather than passing the string on the command line.

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

If you start with this script:

```python
import httpx
```

You get this:

```console
$ pipx run ./script.py
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import httpx
ModuleNotFoundError: No module named 'httpx'
```

After this PR, you get this:

```console
$ pipx run ./script.py
Traceback (most recent call last):
  File "/Users/henryschreiner/git/software/pipx/script.py", line 1, in <module>
    import httpx
ModuleNotFoundError: No module named 'httpx'
```
