### PR TITLE
chore: modernize toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## dev
 
 - Allow skipping maintenance tasks during list command
+- Avoid repeated exception logging in a few rare cases (#1192)
 
 ## 1.4.1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,13 +55,12 @@ version.source = "vcs"
 
 [tool.ruff]
 line-length = 121
-lint.select = [
+src = ["src"]
+lint.extend-select = [
   "A",
   "B",
   "C4",
   "C9",
-  "E",
-  "F",
   "I",
   "PLC",
   "PLE",
@@ -69,20 +68,12 @@ lint.select = [
   "RSE",
   "W",
 ]
-lint.ignore = [
-  "B904",
-]
-isort = {known-first-party = ["helpers", "package_info", "pipx"]}
+lint.isort = {known-first-party = ["helpers", "package_info", "pipx"]}
 lint.mccabe.max-complexity = 15
 
 [tool.pytest.ini_options]
 markers = ["all_packages: test install with maximum number of packages"]
 
-[tool.mypy]
-show_error_codes = true
-overrides = [
-  { module = [
-  "pipx.version",
-  "pycowsay.*",
-  ], ignore_missing_imports = true },
-]
+[[tool.mypy.overrides]]
+module = ["pipx.version", "pycowsay.*"]
+ignore_missing_imports = true

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -296,7 +296,7 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:  # noqa: C901
             return commands.ensure_pipx_paths(force=args.force)
         except Exception as e:
             logger.debug("Uncaught Exception:", exc_info=True)
-            raise PipxError(str(e), wrap_message=False)
+            raise PipxError(str(e), wrap_message=False) from None
     elif args.command == "completions":
         print(constants.completion_instructions)
         return ExitCode(0)

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -209,7 +209,7 @@ class Venv:
                 self._run_pip(cmd)
         except PipxError as e:
             logging.info(e)
-            raise PipxError(f"Error uninstalling {package}.")
+            raise PipxError(f"Error uninstalling {package}.") from None
 
         if was_injected:
             self.pipx_metadata.injected_packages.pop(package)


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [x] I have added an entry to `docs/changelog.md`

## Summary of changes

This is a minor modernization of the pyproject.toml, removing deprecated options. One small change, B904 is restored, and the two failures were fixed - the exceptions are already printed/logged, so "from None" is correct (probably a Python 2 holdover).


Based on <https://learn.scientific-python.org/development/guides/repo-review/?repo=pypa%2Fpipx&branch=main>.

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
pre-commit run -a
```
