### PR TITLE
Fix CI job to include `tomli` in zipapp

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ concurrency:
 
 env:
   default-python: "3.12"
+  minimum-supported-python: "3.8"
 
 jobs:
   tests:
@@ -66,10 +67,10 @@ jobs:
     steps:
       - name: Checkout ${{ github.ref }}
         uses: actions/checkout@v4
-      - name: Set up Python ${{ env.default-python }}
+      - name: Set up Python ${{ env.minimum-supported-python }}
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.default-python }}
+          python-version: ${{ env.minimum-supported-python }}
           cache: "pip"
       - name: Install nox
         run: pip install nox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Raise more user friendly error when provided `--python` version is not found
 - Update `pipx run` on scripts using `/// script` and no `run` table following the updated version of PEP 723 (#1180)
 - Avoid repeated exception logging in a few rare cases (#1192)
+- Include `tomli` into `pipx.pyz` (zipapp) so that it can be executed with Python 3.10 or earlier (#1142)
 
 ## 1.4.1
 


### PR DESCRIPTION
- [x] I have added an entry to `docs/changelog.md`

## Summary of changes

This PR changes the CI job for creating zipapp file (`pipx.pyz`) to use Python 3.8. Doing so makes shiv include `tomli` and the zipapp can be executed with Python 3.10 or earlier.

This should closes #1142.

## Test plan

Tested by running `python pipx.pyz reinstall black` and then confirm the installed black works by running `black --version`, for Python 3.8 through 3.12:

```sh
mac:~% for VER in 3.8 3.9 3.10 3.11 3.12; do python$VER pipx.pyz reinstall black; black --version; done
uninstalled black! ✨ 🌟 ✨
  installed package black 23.12.1, installed using Python 3.8.18
  These apps are now globally available
    - black
    - blackd
done! ✨ 🌟 ✨
black, 23.12.1 (compiled: yes)
Python (CPython) 3.8.18
uninstalled black! ✨ 🌟 ✨
  installed package black 23.12.1, installed using Python 3.9.18
  These apps are now globally available
    - black
    - blackd
done! ✨ 🌟 ✨
black, 23.12.1 (compiled: yes)
Python (CPython) 3.9.18
uninstalled black! ✨ 🌟 ✨
  installed package black 23.12.1, installed using Python 3.10.13
  These apps are now globally available
    - black
    - blackd
done! ✨ 🌟 ✨
black, 23.12.1 (compiled: yes)
Python (CPython) 3.10.13
uninstalled black! ✨ 🌟 ✨
  installed package black 23.12.1, installed using Python 3.11.6
  These apps are now globally available
    - black
    - blackd
done! ✨ 🌟 ✨
black, 23.12.1 (compiled: yes)
Python (CPython) 3.11.6
uninstalled black! ✨ 🌟 ✨
  installed package black 23.12.1, installed using Python 3.12.1
  These apps are now globally available
    - black
    - blackd
done! ✨ 🌟 ✨
black, 23.12.1 (compiled: yes)
Python (CPython) 3.12.1
```
