### PR TITLE
Fix python path resolution on linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Update `pipx run` on scripts using `/// script` and no `run` table following the updated version of PEP 723 (#1180)
 - Avoid repeated exception logging in a few rare cases (#1192)
 - Include `tomli` into `pipx.pyz` (zipapp) so that it can be executed with Python 3.10 or earlier (#1142)
+- Fix resolving the python executable path on linux
 
 ## 1.4.1
 

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -174,7 +174,7 @@ def run_subprocess(
     # See https://github.com/pypa/pipx/issues/1164
     # Conversely, if the binary is a symlink, then we should NOT use the real path, as Python expects to receive the
     # symlink in argv[0] so that it can locate the venv.
-    if not os.path.islink(cmd_str_list[0]):
+    if not os.path.islink(cmd_str_list[0]) and WINDOWS:
         cmd_str_list[0] = os.path.realpath(cmd_str_list[0])
     completed_process = subprocess.run(
         cmd_str_list,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,6 @@
 import sys
 
-import pytest
+import pytest  # type: ignore
 
 from pipx import util
 from pipx.util import run_subprocess

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,26 @@
+import sys
+
+import pytest
+
+from pipx import util
+from pipx.util import run_subprocess
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="Path resolution skip if not on windows")
+def test_executable_path_resolution_unix():
+    cmd = ["python99.99", "-c", "import sys;"]
+    try:
+        run_subprocess(cmd)
+    except FileNotFoundError as e:
+        assert "No such file or directory: 'python99.99'" in str(e)
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="Path resolution skip if not on windows")
+def test_executable_path_resolution_fails_on_unix_if_not_skipped(monkeypatch: pytest.MonkeyPatch):
+    cmd = ["python99.99", "-c", "import sys;"]
+    monkeypatch.setattr(util, "WINDOWS", True)
+    monkeypatch.chdir("./tests")
+    try:
+        run_subprocess(cmd)
+    except FileNotFoundError as e:
+        assert "tests/python99.99'" in str(e)


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [X] I have added an entry to `docs/changelog.md`

## Summary of changes

Only use the logic introduced in https://github.com/pypa/pipx/pull/1168 to fix a path resolution issue on windows when pipx is running on a Windows machine. 
This fixes #1195 

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
When no venv for python3.9 exists, but python is on the PATH (in my case via pyenv):
```
pipx run --python=python3.9 pycowsay moo
```
Before this change leads to the error described in #1195 , and works after this change.

Tested by running

```
pipx run --python=python3.9 pycowsay moo
```
