### PR TITLE
[dependabot] ci: fix artifacts v2

### DIFF
--- a/.github/workflows/create_tests_package_lists.yml
+++ b/.github/workflows/create_tests_package_lists.yml
@@ -32,5 +32,5 @@ jobs:
       - name: Store reports as artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: lists
+          name: lists-${{ matrix.os }}-${{ matrix.python-version }}
           path: ./new_tests_packages

--- a/.github/workflows/exhaustive_package_test.yml
+++ b/.github/workflows/exhaustive_package_test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Store reports as artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: reports-raw
+          name: reports-raw-${{ matrix.os }}-${{ matrix.python-version }}
           path: reports
 
   report_all_packages:
@@ -41,7 +41,8 @@ jobs:
       - name: Get report artifacts
         uses: actions/download-artifact@v4
         with:
-          name: reports-raw
+          pattern: reports-raw-*
+          merge-multiple: true
       - name: Collate reports
         run: |
           ls # DEBUG


### PR DESCRIPTION
This PR targets #1172. You could also target `main` then link the PR I mentioned to be closed.

## Summary of changes

This updates for artifact v2 (upload-artifact@v4 / download-artifact@v4) by avoiding the auto-merge feature that was removed.

## Test plan

CI change. Looks like it needs to be manually triggered.