### PR TITLE
ci: update to artifacts v2

### DIFF
--- a/.github/workflows/create_tests_package_lists.yml
+++ b/.github/workflows/create_tests_package_lists.yml
@@ -30,7 +30,7 @@ jobs:
         run:
           nox --non-interactive --session create_test_package_list-${{ matrix.python-version }} -- ./new_tests_packages
       - name: Store reports as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: lists
+          name: lists-${{ matrix.os }}-${{ matrix.python-version }}
           path: ./new_tests_packages

--- a/.github/workflows/exhaustive_package_test.yml
+++ b/.github/workflows/exhaustive_package_test.yml
@@ -27,9 +27,9 @@ jobs:
         continue-on-error: true
         run: nox --non-interactive --session test_all_packages-${{ matrix.python-version }}
       - name: Store reports as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: reports-raw
+          name: reports-raw-${{ matrix.os }}-${{ matrix.python-version }}
           path: reports
 
   report_all_packages:
@@ -39,9 +39,10 @@ jobs:
 
     steps:
       - name: Get report artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: reports-raw
+          pattern: reports-raw-*
+          merge-multiple: true
       - name: Collate reports
         run: |
           ls # DEBUG
@@ -57,7 +58,7 @@ jobs:
           cat all_packages_deps_errors_* > all_deps_errors_lf.txt
           tr -d '\r' < all_deps_errors_lf.txt > reports/all_deps_errors.txt
       - name: Store collated and raw reports as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: reports-final
           path: reports

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,7 +78,7 @@ jobs:
         run: nox --error-on-missing-interpreters --non-interactive --session zipapp
       - name: Test zipapp by installing black
         run: python ./pipx.pyz install black
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: pipx.pyz
           path: pipx.pyz
@@ -115,7 +115,7 @@ jobs:
     needs: [tests, man, zipapp]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: pipx.pyz
       - name: Upload to release


### PR DESCRIPTION
This is #1199 but targeting `main` instead of #1172, which dependabot deleted the branch for.
