### PR TITLE
fix: allow older setuptools_scm versions when building

### DIFF
--- a/changelog.d/1208.bugfix.md
+++ b/changelog.d/1208.bugfix.md
@@ -1,0 +1,1 @@
+Support building pipx wheels with setuptools-scm<7, such as on FreeBSD.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,5 +84,5 @@ issue_format = "[#{issue}](https://github.com/pypa/pipx/issues/{issue})"
 package = "pipx"
 
 [[tool.mypy.overrides]]
-module = ["pipx.version", "pycowsay.*"]
+module = ["pycowsay.*"]
 ignore_missing_imports = true

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -28,7 +28,7 @@ from pipx.emojis import hazard
 from pipx.interpreter import DEFAULT_PYTHON, InterpreterResolutionError, find_python_interpreter
 from pipx.util import PipxError, mkdir, pipx_wrap, rmdir
 from pipx.venv import VenvContainer
-from pipx.version import __version__
+from pipx.version import version as __version__
 
 logger = logging.getLogger(__name__)
 

--- a/src/pipx/version.pyi
+++ b/src/pipx/version.pyi
@@ -1,0 +1,5 @@
+version: str
+version_tuple: tuple[int, int, int, str, str] | tuple[int, int, int]
+
+# Note that newer versions of setuptools_scm also add __version__, but we are
+# not forcing new versions of setuptools_scm, so only these imports are allowed.


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [x] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

Fixes #1207, supports older versions of `setuptools_scm`, not just 7+.

## Summary of changes

This uses `version.py`'s `version` attribute, which was present since the beginning, not the `__version__` alias that was added in version 7.

This also adds a `version.pyi` file, allowing mypy to check this, and removes the ignore that was needed when that file was missing.

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested in CI.
