### PR TITLE
bump changelog to 1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) for keeping t
 
 <!-- towncrier release notes start -->
 
+## [1.4.3](https://github.com/pypa/pipx/tree/1.4.3) - 2024-01-16
+
+
+### Bugfixes
+
+- Autofix python version for pylauncher, when version is provided prefixed with `python` ([#1150](https://github.com/pypa/pipx/issues/1150))
+- Support building pipx wheels with setuptools-scm<7, such as on FreeBSD. ([#1208](https://github.com/pypa/pipx/issues/1208))
+
+### Improved Documentation
+
+- Provide useful error messages when unresolvable python version is passed ([#1150](https://github.com/pypa/pipx/issues/1150))
+- Introduce towncrier for managing the changelog ([#1161](https://github.com/pypa/pipx/issues/1161))
+- Add workaround for using pipx applications in shebang under macOS ([#1198](https://github.com/pypa/pipx/issues/1198))
+
+
 ## [1.4.2](https://github.com/pypa/pipx/tree/1.4.2)
 
 ### Features

--- a/changelog.d/1150.bugfix.md
+++ b/changelog.d/1150.bugfix.md
@@ -1,1 +1,0 @@
-Autofix python version for pylauncher, when version is provided prefixed with `python`

--- a/changelog.d/1150.doc.md
+++ b/changelog.d/1150.doc.md
@@ -1,1 +1,0 @@
-Provide useful error messages when unresolvable python version is passed

--- a/changelog.d/1161.doc.md
+++ b/changelog.d/1161.doc.md
@@ -1,1 +1,0 @@
-Introduce towncrier for managing the changelog

--- a/changelog.d/1198.doc.md
+++ b/changelog.d/1198.doc.md
@@ -1,1 +1,0 @@
-Add workaround for using pipx applications in shebang under macOS

--- a/changelog.d/1208.bugfix.md
+++ b/changelog.d/1208.bugfix.md
@@ -1,1 +1,0 @@
-Support building pipx wheels with setuptools-scm<7, such as on FreeBSD.

--- a/noxfile.py
+++ b/noxfile.py
@@ -133,7 +133,9 @@ def build_docs(session: nox.Session) -> None:
     session.run("mkdocs", "build", "--strict", "--site-dir", *site_dir)
     upcoming_changelog.unlink(missing_ok=True)
     for site in site_dir:
-        shutil.rmtree(Path(site, "_draft_changelog"))
+        draft_changelog_dir = Path(site, "_draft_changelog")
+        if draft_changelog_dir.exists():
+            shutil.rmtree(draft_changelog_dir)
 
 
 @nox.session(python=PYTHON_DEFAULT_VERSION)


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [ ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

Bumped the changelog to 1.4.3, as the automated bump failed. @gaborbernat 

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
# command(s) to exercise these changes
```
