### PR TITLE
Fix typo in README.md - hatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Python packages have entry points, but many do.
 If you would like to make your package compatible with pipx, all you need to do is add a
 [console scripts](https://python-packaging.readthedocs.io/en/latest/command-line-scripts.html#the-console-scripts-entry-point)
 entry point. If you're a poetry user, use [these instructions](https://python-poetry.org/docs/pyproject/#scripts). Or
-you're using hatch, [try this](https://hatch.pypa.io/latest/config/metadata/#cli).
+if you're using hatch, [try this](https://hatch.pypa.io/latest/config/metadata/#cli).
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Python packages have entry points, but many do.
 
 If you would like to make your package compatible with pipx, all you need to do is add a
 [console scripts](https://python-packaging.readthedocs.io/en/latest/command-line-scripts.html#the-console-scripts-entry-point)
-entry point. If you're a poetry user, use [these instructions](https://python-poetry.org/docs/pyproject/#scripts). Or
+entry point. If you're a poetry user, use [these instructions](https://python-poetry.org/docs/pyproject/#scripts). Or,
 if you're using hatch, [try this](https://hatch.pypa.io/latest/config/metadata/#cli).
 
 ## Features


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [ ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
# command(s) to exercise these changes
```
