### PR TITLE
Add codespell: config, workflow, pre-commit config and make it fix few typos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,4 @@ repos:
   - id: codespell
     additional_dependencies:
     - tomli
+    exclude: ^testdata

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,10 @@ repos:
     - "packaging>=20"
     - "platformdirs>=2.1"
     - "tomli; python_version < '3.11'"
+# Configuration for codespell is in pyproject.toml
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.2.6
+  hooks:
+  - id: codespell
+    additional_dependencies:
+    - tomli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) for keeping t
 
 ### Improved Documentation
 
-- Add additonal example for --pip-args option, to docs/examples.md
+- Add additional example for --pip-args option, to docs/examples.md
 
 ## [1.3.1](https://github.com/pypa/pipx/tree/1.3.1)
 

--- a/docs/how-pipx-works.md
+++ b/docs/how-pipx-works.md
@@ -3,7 +3,7 @@
 When installing a package and its binaries on linux (`pipx install package`) pipx will
 
 - create directory `~/.local/share/pipx/venvs/PACKAGE`
-- create or re-use a shared virtual environment that contains shared packaging library `pip` in
+- create or reuse a shared virtual environment that contains shared packaging library `pip` in
   `~/.local/share/pipx/shared/`
 - ensure the library is updated to its latest version
 - create a Virtual Environment in `~/.local/share/pipx/venvs/PACKAGE` that uses the shared pip mentioned above but
@@ -19,7 +19,7 @@ When installing a package and its binaries on linux (`pipx install package`) pip
 
 When running a binary (`pipx run BINARY`), pipx will
 
-- create or re-use a shared virtual environment that contains the shared packaging library `pip`
+- create or reuse a shared virtual environment that contains the shared packaging library `pip`
 - ensure the library is updated to its latest version
 - create a temporary directory (or reuse a cached virtual environment for this package) with a name based on a hash of
   the attributes that make the run reproducible. This includes things like the package name, spec, python version, and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,3 +86,10 @@ package = "pipx"
 [[tool.mypy.overrides]]
 module = ["pycowsay.*"]
 ignore_missing_imports = true
+
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+[tool.codespell]
+skip = '.git,*.pdf,*.svg,go.sum'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,13 @@ lint.extend-select = [
 lint.isort = {known-first-party = ["helpers", "package_info", "pipx"]}
 lint.mccabe.max-complexity = 15
 
+[tool.codespell]
+skip = '.git,*.pdf,*.svg,go.sum'
+check-hidden = true
+# case sensitive etc
+ignore-regex = '\b(UE|path/doesnt/exist)\b'
+ignore-words-list = 'astroid'
+
 [tool.pytest.ini_options]
 markers = ["all_packages: test install with maximum number of packages"]
 
@@ -88,9 +95,3 @@ module = ["pycowsay.*"]
 ignore_missing_imports = true
 
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-[tool.codespell]
-skip = '.git,*.pdf,*.svg,go.sum'
-check-hidden = true
-# case sensitive etc
-ignore-regex = '\b(UE|path/doesnt/exist)\b'
-ignore-words-list = 'astroid'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,5 +91,6 @@ ignore_missing_imports = true
 [tool.codespell]
 skip = '.git,*.pdf,*.svg,go.sum'
 check-hidden = true
-# ignore-regex = ''
-# ignore-words-list = ''
+# case sensitive etc
+ignore-regex = '\b(UE|path/doesnt/exist)\b'
+ignore-words-list = 'astroid'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ lint.mccabe.max-complexity = 15
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git,*.pdf,*.svg,go.sum'
+skip = '.git,*.pdf,*.svg,.nox'
 check-hidden = true
 # case sensitive etc
 ignore-regex = '\b(UE|path/doesnt/exist)\b'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,11 +73,10 @@ lint.mccabe.max-complexity = 15
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git,*.pdf,*.svg,.nox'
+skip = '.git,*.pdf,*.svg,.nox,testdata'
 check-hidden = true
 # case sensitive etc
 ignore-regex = '\b(UE|path/doesnt/exist)\b'
-ignore-words-list = 'astroid'
 
 [tool.pytest.ini_options]
 markers = ["all_packages: test install with maximum number of packages"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ lint.isort = {known-first-party = ["helpers", "package_info", "pipx"]}
 lint.mccabe.max-complexity = 15
 
 [tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
 skip = '.git,*.pdf,*.svg,go.sum'
 check-hidden = true
 # case sensitive etc
@@ -93,5 +94,3 @@ package = "pipx"
 [[tool.mypy.overrides]]
 module = ["pycowsay.*"]
 ignore_missing_imports = true
-
-# Ref: https://github.com/codespell-project/codespell#using-a-config-file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ lint.mccabe.max-complexity = 15
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git,*.pdf,*.svg,.nox,testdata'
+skip = '.git,*.pdf,*.svg,.nox,testdata,.mypy_cache'
 check-hidden = true
 # case sensitive etc
 ignore-regex = '\b(UE|path/doesnt/exist)\b'

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -593,7 +593,7 @@ def _add_run(subparsers: argparse._SubParsersAction, shared_parser: argparse.Arg
             then run an app from it. The environment will be cached
             and re-used for up to {constants.TEMP_VENV_EXPIRATION_THRESHOLD_DAYS} days. This
             means subsequent calls to 'run' for the same package will be faster
-            since they can re-use the cached Virtual Environment.
+            since they can reuse the cached Virtual Environment.
 
             In support of PEP 582 'run' will use apps found in a local __pypackages__
             directory, if present. Please note that this behavior is experimental,
@@ -606,7 +606,7 @@ def _add_run(subparsers: argparse._SubParsersAction, shared_parser: argparse.Arg
     p.add_argument(
         "--no-cache",
         action="store_true",
-        help="Do not re-use cached virtual environment if it exists",
+        help="Do not reuse cached virtual environment if it exists",
     )
     p.add_argument(
         "app_with_args",


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [ ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

it doesn't so I didn't bother

I see that once in a while commits fixing typos come in. With https://github.com/codespell-project/codespell you could minimize them even further since it would be harder for them to sneak in.