### PR TITLE
Remove installation section about dev versions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -184,12 +184,3 @@ You can easily get your shell's tab completions working by following instruction
 ```
 pipx completions
 ```
-
-## Install pipx Development Versions
-
-New versions of pipx are published as beta or release candidates. These versions look something like `0.13.0b1`, where
-`b1` signifies the first beta release of version 0.13. These releases can be tested with
-
-```
-pip install --user --upgrade --pre pipx
-```


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [ ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

This section was overlooked when removing the pre-release steps in #1130.

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
# command(s) to exercise these changes
```
