### PR TITLE
Add --pre pip flag passthrough

### DIFF
--- a/changelog.d/1236.feature.md
+++ b/changelog.d/1236.feature.md
@@ -1,0 +1,1 @@
+- Add --pre flag

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -148,6 +148,9 @@ def get_pip_args(parsed_args: Dict[str, str]) -> List[str]:
     if parsed_args.get("index_url"):
         pip_args += ["--index-url", parsed_args["index_url"]]
 
+    if parsed_args.get("pre"):
+        pip_args += ["--pre"]
+
     if parsed_args.get("pip_args"):
         pip_args += shlex.split(parsed_args.get("pip_args", ""), posix=not WINDOWS)
 
@@ -320,6 +323,7 @@ def add_pip_venv_args(parser: argparse.ArgumentParser) -> None:
         help="Give the virtual environment access to the system site-packages dir.",
     )
     parser.add_argument("--index-url", "-i", help="Base URL of Python Package Index")
+    parser.add_argument("--pre", help="Include pre-release and development versions", action="store_true",)
     parser.add_argument(
         "--editable",
         "-e",

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -323,7 +323,11 @@ def add_pip_venv_args(parser: argparse.ArgumentParser) -> None:
         help="Give the virtual environment access to the system site-packages dir.",
     )
     parser.add_argument("--index-url", "-i", help="Base URL of Python Package Index")
-    parser.add_argument("--pre", help="Include pre-release and development versions", action="store_true",)
+    parser.add_argument(
+        "--pre",
+        help="Include pre-release and development versions",
+        action="store_true",
+    )
     parser.add_argument(
         "--editable",
         "-e",


### PR DESCRIPTION
As a daily user of pipx, I use the `--pre` flag enough I thought it was worthy to add to the passthroughs. Using `--pip-args` always trips me up because of the need to specify `'\--backslashes'` 🙃.

Thanks!