### PR TITLE
docs: add install instructions for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,14 @@ sudo apt install pipx
 pipx ensurepath
 ```
 
-- Ubuntu 22.04 or below
+- Fedora:
+
+```
+sudo dnf install pipx
+pipx ensurepath
+```
+
+- Using `pip` on other distributions:
 
 ```
 python3 -m pip install --user pipx

--- a/changelog.d/1239.doc.md
+++ b/changelog.d/1239.doc.md
@@ -1,0 +1,1 @@
+Add installation instructions for Fedora

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -28,7 +28,14 @@ sudo apt install pipx
 pipx ensurepath
 ```
 
-- Ubuntu 22.04 or below
+- Fedora:
+
+```
+sudo dnf install pipx
+pipx ensurepath
+```
+
+- Using `pip` on other distributions:
 
 ```
 python3 -m pip install --user pipx
@@ -147,11 +154,18 @@ On macOS:
 brew update && brew upgrade pipx
 ```
 
-On Linux:
+On Ubuntu Linux:
 
 ```
 sudo apt upgrade pipx
 ```
+
+On Fedora Linux:
+
+```
+sudo dnf update pipx
+```
+
 
 On Windows:
 


### PR DESCRIPTION
Add instructions on how to install pipx on Fedora using dnf.

pipx has been packaged in Fedora since Fedora 32 (Jan 202) and is maintained by @musicinmybrain.

See:
- https://src.fedoraproject.org/rpms/pipx - packaging
- https://bugzilla.redhat.com/1790241 - original package review