### PR TITLE
Use shutil.move() instead of rename() when moving extracted Python

### DIFF
--- a/src/pipx/standalone_python.py
+++ b/src/pipx/standalone_python.py
@@ -87,7 +87,7 @@ def download_python_build_standalone(python_version: str):
         # under a directory named 'python'. We move it to the install
         # directory
         extracted_dir = download_dir / "python"
-        extracted_dir.rename(install_dir)
+        shutil.move(extracted_dir, install_dir)
 
     return str(installed_python)
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [ ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

Using `rename()` will result in an error when the source and destination are not on the same file system:
```
pipx install nox --python=3.9 --fetch-missing-python
Traceback (most recent call last):
...
  File "/workspace/pipx/src/pipx/standalone_python.py", line 90, in download_python_build_standalone
    extracted_dir.rename(install_dir)
  File "/home/gitpod/.pyenv/versions/3.12.2/lib/python3.12/pathlib.py", line 1363, in rename
    os.rename(self, target)
OSError: [Errno 18] Invalid cross-device link: '/tmp/tmp5uhdkes5/download/python' -> '/home/gitpod/.local/share/pipx/py/3.9'
```

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
 pipx install nox --python=3.9 --fetch-missing-python
```
