### PR TITLE
Add `--install` option to `pipx upgrade` command

### DIFF
--- a/changelog.d/1262.feature.md
+++ b/changelog.d/1262.feature.md
@@ -1,0 +1,3 @@
+Add `--install` option to `pipx upgrade` command.
+
+This will install the package given as argument if it is not already installed.

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -267,10 +267,12 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:  # noqa: C901
     elif args.command == "upgrade":
         return commands.upgrade(
             venv_dir,
+            args.python,
             pip_args,
             verbose,
             include_injected=args.include_injected,
             force=args.force,
+            install=args.install,
         )
     elif args.command == "upgrade-all":
         return commands.upgrade_all(
@@ -486,6 +488,12 @@ def _add_upgrade(subparsers, venv_completer: VenvCompleter, shared_parser: argpa
         help="Modify existing virtual environment and files in PIPX_BIN_DIR and PIPX_MAN_DIR",
     )
     add_pip_venv_args(p)
+    p.add_argument(
+        "--install",
+        action="store_true",
+        help="Install package spec if missing",
+    )
+    add_python_options(p)
 
 
 def _add_upgrade_all(subparsers: argparse._SubParsersAction, shared_parser: argparse.ArgumentParser) -> None:

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -73,3 +73,9 @@ def test_upgrade_no_include_injected(pipx_temp_env, capsys):
     captured = capsys.readouterr()
     assert "upgraded package pylint" in captured.out
     assert "upgraded package black" not in captured.out
+
+
+def test_upgrade_install_missing(pipx_temp_env, capsys):
+    assert not run_pipx_cli(["upgrade", "pycowsay", "--install"])
+    captured = capsys.readouterr()
+    assert "installed package pycowsay" in captured.out


### PR DESCRIPTION
Closes #1262.

- [x] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
pipx upgrade --install -p 3.10 pycowsay
```
