### PR TITLE
#1270 Make dedup_ordered type annotations more specific

### DIFF
--- a/changelog.d/1270.misc.md
+++ b/changelog.d/1270.misc.md
@@ -1,0 +1,1 @@
+Make type annotations for an internal utility function more specific.

--- a/changelog.d/1270.misc.md
+++ b/changelog.d/1270.misc.md
@@ -1,1 +1,0 @@
-Make type annotations for an internal utility function more specific.

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -211,7 +211,7 @@ def subprocess_post_check(completed_process: "subprocess.CompletedProcess[str]",
             logger.info(f"{' '.join(completed_process.args)!r} failed")
 
 
-def dedup_ordered(input_list: List[Any]) -> List[Any]:
+def dedup_ordered(input_list: List[Tuple[str, Any]]) -> List[Tuple[str, Any]]:
     output_list = []
     seen = set()
     for x in input_list:


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [ x ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)
(patch does not affect end users)
## Summary of changes
Parameter and return type annotations were made more specific for `pipx.util.dedup_ordered` as described in issue #1270.

## Test plan
There are no functional changes to the code.
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
