### PR TITLE
Add repology shield to installation.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ _For comparison to other tools including pipsi, see
 
 <details>
   <summary>Packaging status</summary>
-  
+
   [![Packaging status](https://repology.org/badge/vertical-allrepos/pipx.svg?columns=3&exclude_unsupported=1)](https://repology.org/metapackage/pipx/versions)
 </details>
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,6 @@ _For comparison to other tools including pipsi, see
 
 ## Install pipx
 
-<details>
-  <summary>Packaging status</summary>
-
-  [![Packaging status](https://repology.org/badge/vertical-allrepos/pipx.svg?columns=3&exclude_unsupported=1)](https://repology.org/metapackage/pipx/versions)
-</details>
-
 > [!WARNING]
 >
 > It is not recommended to install `pipx` via `pipx`. If you'd like to do this anyway, take a look at the

--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ _For comparison to other tools including pipsi, see
 
 ## Install pipx
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/pipx.svg?columns=3&exclude_unsupported=1)](https://repology.org/metapackage/pipx/versions)
+<details>
+  <summary>Packaging status</summary>
+  
+  [![Packaging status](https://repology.org/badge/vertical-allrepos/pipx.svg?columns=3&exclude_unsupported=1)](https://repology.org/metapackage/pipx/versions)
+</details>
 
 > [!WARNING]
 >

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 
 </p>
 
+[![Packaging status](https://repology.org/badge/vertical-allrepos/pipx.svg)](https://repology.org/metapackage/pipx/versions)
+
 **Documentation**: <https://pipx.pypa.io>
 
 **Source Code**: <https://github.com/pypa/pipx>

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@
 
 </p>
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/pipx.svg)](https://repology.org/metapackage/pipx/versions)
-
 **Documentation**: <https://pipx.pypa.io>
 
 **Source Code**: <https://github.com/pypa/pipx>
@@ -28,6 +26,8 @@ _For comparison to other tools including pipsi, see
 [Comparison to Other Tools](https://pipx.pypa.io/stable/comparisons/)._
 
 ## Install pipx
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/pipx.svg?columns=3&exclude_unsupported=1)](https://repology.org/metapackage/pipx/versions)
 
 > [!WARNING]
 >

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,6 +9,9 @@ You also need to have `pip` installed on your machine for `python3`. Installing 
 
 pipx works on macOS, linux, and Windows.
 
+[![Packaging status](https://repology.org/badge/vertical-allrepos/pipx.svg?columns=3&exclude_unsupported=1)](https://repology.org/metapackage/pipx/versions)
+
+
 ## Installing pipx
 
 ### On macOS:


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [ ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes
This PR adds a repology shield to README as per #234

It only includes [pipx](https://repology.org/project/pipx/versions) since [python:pipx](https://repology.org/project/python:pipx/versions) redirects to the former.

I used the Markdown syntax suggested in the issue, so the shield is left aligned. I can use the same syntax as the badges to center align it, if that is preferred.



## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
# command(s) to exercise these changes
```
