### PR TITLE
Updated PR: Added --global option to perform actions for all users (#754)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ _For comparison to other tools including pipsi, see
 ```
 brew install pipx
 pipx ensurepath
+sudo pipx ensurepath --global # optional to allow pipx actions with --global argument
 ```
 
 Upgrade pipx with `brew update && brew upgrade pipx`.
@@ -49,6 +50,7 @@ Upgrade pipx with `brew update && brew upgrade pipx`.
 sudo apt update
 sudo apt install pipx
 pipx ensurepath
+sudo pipx ensurepath --global # optional to allow pipx actions with --global argument
 ```
 
 - Fedora:
@@ -56,6 +58,7 @@ pipx ensurepath
 ```
 sudo dnf install pipx
 pipx ensurepath
+sudo pipx ensurepath --global # optional to allow pipx actions with --global argument
 ```
 
 - Using `pip` on other distributions:
@@ -63,6 +66,7 @@ pipx ensurepath
 ```
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath
+sudo pipx ensurepath --global # optional to allow pipx actions with --global argument
 ```
 
 Upgrade pipx with `python3 -m pip install --user --upgrade pipx`.

--- a/changelog.d/754.feature.md
+++ b/changelog.d/754.feature.md
@@ -1,0 +1,3 @@
+Add `--global` option to `pipx` commands.
+
+This will run the action in a global scope and affect environment for all system users.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -17,6 +17,7 @@ pipx install --include-deps jupyter
 pipx install --pip-args='--pre' poetry
 pipx install --pip-args='--index-url=<private-repo-host>:<private-repo-port> --trusted-host=<private-repo-host>:<private-repo-port>' private-repo-package
 pipx install --index-url https://test.pypi.org/simple/ --pip-args='--extra-index-url https://pypi.org/simple/' some-package
+pipx --global install pycowsay
 ```
 
 ## `pipx run` examples

--- a/docs/how-pipx-works.md
+++ b/docs/how-pipx-works.md
@@ -17,7 +17,7 @@ When installing a package and its binaries on linux (`pipx install package`) pip
 - on operating systems which have the `man` command, as long as `~/.local/share/man` is a recognized search path of man,
   you can now view the new manual pages globally
 - adding `--global` flag to any `pipx` command will execute the action in global scope which will expose app to all
-  users - [reference](installation.md#global-installation)
+  users - [reference](installation.md#global-installation). Note that this is not available on Windows.
 
 When running a binary (`pipx run BINARY`), pipx will
 

--- a/docs/how-pipx-works.md
+++ b/docs/how-pipx-works.md
@@ -16,6 +16,8 @@ When installing a package and its binaries on linux (`pipx install package`) pip
 - as long as `~/.local/bin/` is on your PATH, you can now invoke the new binaries globally
 - on operating systems which have the `man` command, as long as `~/.local/share/man` is a recognized search path of man,
   you can now view the new manual pages globally
+- adding `--global` flag to any `pipx` command will execute the action in global scope which will expose app to all
+  users - [reference](installation.md#global-installation)
 
 When running a binary (`pipx run BINARY`), pipx will
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -162,7 +162,7 @@ can be overridden with environment variable `PIPX_GLOBAL_MAN_DIR`. Finally, defa
 is `/opt/pipx`, can be overridden with environment variable `PIPX_GLOBAL_HOME`. Make sure to run `sudo pipx ensurepath --global`
 if you intend to use this feature.
 
-Note that `--global` argument is not supported on Windows.
+Note that the `--global` argument is not supported on Windows.
 
 ## Upgrade pipx
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -133,10 +133,12 @@ sudo PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin PIPX_MAN_DIR=/usr/local/sha
 # Example: $ sudo PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin PIPX_MAN_DIR=/usr/local/share/man pipx install cowsay
 ```
 
-Pipx also comes with a `--global` which helps to execute actions globally to give access to any user. By default the
-global binary location is set to `/usr/local/bin`, can be overridden with `PIPX_GLOBAL_BIN_DIR`. Default global manual
-page location is `/usr/local/share/man`. This can be overridden with `PIPX_GLOBAL_MAN_DIR`. Default global virtual
-environment location is `/opt/pipx`, can be overridden with `PIPX_GLOBAL_HOME`.
+### Global installation
+
+Pipx also comes with a `--global` argument which helps to execute actions globally to give app access to any user. By
+default the global binary location is set to `/usr/local/bin`, can be overridden with `PIPX_GLOBAL_BIN_DIR`. Default
+global manual page location is `/usr/local/share/man`. This can be overridden with `PIPX_GLOBAL_MAN_DIR`. Default global
+virtual environment location is `/opt/pipx`, can be overridden with `PIPX_GLOBAL_HOME`.
 
 > [!NOTE]
 >

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -133,6 +133,11 @@ sudo PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin PIPX_MAN_DIR=/usr/local/sha
 # Example: $ sudo PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin PIPX_MAN_DIR=/usr/local/share/man pipx install cowsay
 ```
 
+Pipx also comes with a `--global` which helps to execute actions globally to give access to any user. By default the
+global binary location is set to `/usr/local/bin`, can be overridden with `PIPX_GLOBAL_BIN_DIR`. Default global manual
+page location is `/usr/local/share/man`. This can be overridden with `PIPX_GLOBAL_MAN_DIR`. Default global virtual
+environment location is `/opt/pipx`, can be overridden with `PIPX_GLOBAL_HOME`.
+
 > [!NOTE]
 >
 > After version 1.2.0, the default pipx paths have been moved from `~/.local/pipx` to specific user data directories on

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,6 +19,7 @@ pipx works on macOS, linux, and Windows.
 ```
 brew install pipx
 pipx ensurepath
+sudo pipx ensurepath --global # optional to allow pipx actions in global scope. See "Global installation" section below.
 ```
 
 ### On Linux:
@@ -29,6 +30,7 @@ pipx ensurepath
 sudo apt update
 sudo apt install pipx
 pipx ensurepath
+sudo pipx ensurepath --global # optional to allow pipx actions in global scope. See "Global installation" section below.
 ```
 
 - Fedora:
@@ -36,6 +38,7 @@ pipx ensurepath
 ```
 sudo dnf install pipx
 pipx ensurepath
+sudo pipx ensurepath --global # optional to allow pipx actions in global scope. See "Global installation" section below.
 ```
 
 - Using `pip` on other distributions:
@@ -43,6 +46,7 @@ pipx ensurepath
 ```
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath
+sudo pipx ensurepath --global # optional to allow pipx actions in global scope. See "Global installation" section below.
 ```
 
 
@@ -155,7 +159,8 @@ Pipx also comes with a `--global` argument which helps to execute actions in glo
 all system users. By default the global binary location is set to `/usr/local/bin` and can be overridden with the
 environment variable `PIPX_GLOBAL_BIN_DIR`. Default global manual page location is `/usr/local/share/man`. This
 can be overridden with environment variable `PIPX_GLOBAL_MAN_DIR`. Finally, default global virtual environment location
-is `/opt/pipx`, can be overridden with environment variable `PIPX_GLOBAL_HOME`.
+is `/opt/pipx`, can be overridden with environment variable `PIPX_GLOBAL_HOME`. Make sure to run `sudo pipx ensurepath --global`
+if you intend to use this feature.
 
 Note that `--global` argument is not supported on Windows.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -133,13 +133,6 @@ sudo PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin PIPX_MAN_DIR=/usr/local/sha
 # Example: $ sudo PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin PIPX_MAN_DIR=/usr/local/share/man pipx install cowsay
 ```
 
-### Global installation
-
-Pipx also comes with a `--global` argument which helps to execute actions globally to give app access to any user. By
-default the global binary location is set to `/usr/local/bin`, can be overridden with `PIPX_GLOBAL_BIN_DIR`. Default
-global manual page location is `/usr/local/share/man`. This can be overridden with `PIPX_GLOBAL_MAN_DIR`. Default global
-virtual environment location is `/opt/pipx`, can be overridden with `PIPX_GLOBAL_HOME`.
-
 > [!NOTE]
 >
 > After version 1.2.0, the default pipx paths have been moved from `~/.local/pipx` to specific user data directories on
@@ -155,6 +148,16 @@ virtual environment location is `/opt/pipx`, can be overridden with `PIPX_GLOBAL
 >
 > `user_data_dir()`, `user_cache_dir()` and `user_log_dir()` resolve to appropriate platform-specific user data, cache and log directories.
 > See the [platformdirs documentation](https://platformdirs.readthedocs.io/en/latest/api.html#platforms) for details.
+
+### Global installation
+
+Pipx also comes with a `--global` argument which helps to execute actions in global scope which exposes the app to
+all system users. By default the global binary location is set to `/usr/local/bin` and can be overridden with the
+environment variable `PIPX_GLOBAL_BIN_DIR`. Default global manual page location is `/usr/local/share/man`. This
+can be overridden with environment variable `PIPX_GLOBAL_MAN_DIR`. Finally, default global virtual environment location
+is `/opt/pipx`, can be overridden with environment variable `PIPX_GLOBAL_HOME`.
+
+Note that `--global` argument is not supported on Windows.
 
 ## Upgrade pipx
 

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -15,7 +15,7 @@ from packaging.utils import canonicalize_name
 
 from pipx import paths
 from pipx.colors import bold, red
-from pipx.constants import MAN_SECTIONS, PIPX_STANDALONE_PYTHON_CACHEDIR, WINDOWS
+from pipx.constants import MAN_SECTIONS, WINDOWS
 from pipx.emojis import hazard, stars
 from pipx.package_specifier import parse_specifier_for_install, valid_pypi_name
 from pipx.pipx_metadata_file import PackageInfo
@@ -242,7 +242,7 @@ def get_venv_summary(
     for man_section in MAN_SECTIONS:
         exposed_man_paths |= get_exposed_man_paths_for_package(
             venv.man_path / man_section,
-            constants.LOCAL_MAN_DIR / man_section,
+            paths.ctx.man_dir / man_section,
             man_pages,
         )
     exposed_man_pages = sorted(str(Path(p.parent.name) / p.name) for p in exposed_man_paths)
@@ -252,7 +252,7 @@ def get_venv_summary(
     python_version = venv.pipx_metadata.python_version if venv.pipx_metadata.python_version is not None else ""
     source_interpreter = venv.pipx_metadata.source_interpreter
     is_standalone = (
-        str(source_interpreter).startswith(str(PIPX_STANDALONE_PYTHON_CACHEDIR.resolve()))
+        str(source_interpreter).startswith(str(paths.ctx.standalone_python_cachedir.resolve()))
         if source_interpreter
         else False
     )

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -231,7 +231,7 @@ def get_venv_summary(
 
     exposed_app_paths = get_exposed_paths_for_package(
         venv.bin_path,
-        constants.LOCAL_BIN_DIR,
+        constants.PIPX_DIRS.BIN_DIR,
         [add_suffix(app, package_metadata.suffix) for app in apps],
     )
     exposed_binary_names = sorted(p.name for p in exposed_app_paths)

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -13,7 +13,7 @@ from typing import Dict, List, Optional, Set, Tuple
 import userpath  # type: ignore
 from packaging.utils import canonicalize_name
 
-from pipx import constants
+from pipx import paths
 from pipx.colors import bold, red
 from pipx.constants import MAN_SECTIONS, PIPX_STANDALONE_PYTHON_CACHEDIR, WINDOWS
 from pipx.emojis import hazard, stars
@@ -231,7 +231,7 @@ def get_venv_summary(
 
     exposed_app_paths = get_exposed_paths_for_package(
         venv.bin_path,
-        constants.PIPX_DIRS.BIN_DIR,
+        paths.ctx.bin_dir,
         [add_suffix(app, package_metadata.suffix) for app in apps],
     )
     exposed_binary_names = sorted(p.name for p in exposed_app_paths)

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -98,6 +98,15 @@ def ensure_path(location: Path, *, force: bool) -> Tuple[bool, bool]:
 def ensure_pipx_paths(force: bool) -> ExitCode:
     """Returns pipx exit code."""
     bin_paths = {paths.ctx.bin_dir}
+    if paths.ctx.is_global:
+        paths.ctx.make_local()
+        another_path = paths.ctx.bin_dir
+        paths.ctx.make_global()
+    else:
+        paths.ctx.make_global()
+        another_path = paths.ctx.bin_dir
+        paths.ctx.make_local()
+    bin_paths.add(another_path)
 
     pipx_user_bin_path = get_pipx_user_bin_path()
     if pipx_user_bin_path is not None:

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -6,7 +6,7 @@ from typing import Optional, Tuple
 
 import userpath  # type: ignore
 
-from pipx import constants
+from pipx import paths
 from pipx.constants import EXIT_CODE_OK, ExitCode
 from pipx.emojis import hazard, stars
 from pipx.util import pipx_wrap
@@ -97,7 +97,7 @@ def ensure_path(location: Path, *, force: bool) -> Tuple[bool, bool]:
 
 def ensure_pipx_paths(force: bool) -> ExitCode:
     """Returns pipx exit code."""
-    bin_paths = {constants.PIPX_DIRS.BIN_DIR}
+    bin_paths = {paths.ctx.bin_dir}
 
     pipx_user_bin_path = get_pipx_user_bin_path()
     if pipx_user_bin_path is not None:

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -98,15 +98,6 @@ def ensure_path(location: Path, *, force: bool) -> Tuple[bool, bool]:
 def ensure_pipx_paths(force: bool) -> ExitCode:
     """Returns pipx exit code."""
     bin_paths = {paths.ctx.bin_dir}
-    if paths.ctx.is_global:
-        paths.ctx.make_local()
-        another_path = paths.ctx.bin_dir
-        paths.ctx.make_global()
-    else:
-        paths.ctx.make_global()
-        another_path = paths.ctx.bin_dir
-        paths.ctx.make_local()
-    bin_paths.add(another_path)
 
     pipx_user_bin_path = get_pipx_user_bin_path()
     if pipx_user_bin_path is not None:

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -97,7 +97,7 @@ def ensure_path(location: Path, *, force: bool) -> Tuple[bool, bool]:
 
 def ensure_pipx_paths(force: bool) -> ExitCode:
     """Returns pipx exit code."""
-    bin_paths = {constants.LOCAL_BIN_DIR}
+    bin_paths = {constants.PIPX_DIRS.BIN_DIR}
 
     pipx_user_bin_path = get_pipx_user_bin_path()
     if pipx_user_bin_path is not None:

--- a/src/pipx/commands/environment.py
+++ b/src/pipx/commands/environment.py
@@ -1,6 +1,7 @@
 import os
 
-from pipx.constants import EXIT_CODE_OK, PIPX_DIRS, ExitCode
+from pipx import paths
+from pipx.constants import EXIT_CODE_OK, ExitCode
 from pipx.emojis import EMOJI_SUPPORT
 from pipx.interpreter import DEFAULT_PYTHON
 from pipx.util import PipxError
@@ -18,15 +19,15 @@ def environment(value: str) -> ExitCode:
         "USE_EMOJI",
     ]
     derived_values = {
-        "PIPX_HOME": PIPX_DIRS.HOME,
-        "PIPX_BIN_DIR": PIPX_DIRS.BIN_DIR,
-        "PIPX_MAN_DIR": PIPX_DIRS.MAN_DIR,
-        "PIPX_SHARED_LIBS": PIPX_DIRS.SHARED_LIBS,
-        "PIPX_LOCAL_VENVS": PIPX_DIRS.LOCAL_VENVS,
-        "PIPX_LOG_DIR": PIPX_DIRS.LOG_DIR,
-        "PIPX_TRASH_DIR": PIPX_DIRS.TRASH_DIR,
-        "PIPX_VENV_CACHEDIR": PIPX_DIRS.VENV_CACHEDIR,
-        "PIPX_STANDALONE_PYTHON_CACHEDIR": PIPX_DIRS.STANDALONE_PYTHON_CACHEDIR,
+        "PIPX_HOME": paths.ctx.home,
+        "PIPX_BIN_DIR": paths.ctx.bin_dir,
+        "PIPX_MAN_DIR": paths.ctx.man_dir,
+        "PIPX_SHARED_LIBS": paths.ctx.shared_libs,
+        "PIPX_LOCAL_VENVS": paths.ctx.venvs,
+        "PIPX_LOG_DIR": paths.ctx.logs,
+        "PIPX_TRASH_DIR": paths.ctx.trash,
+        "PIPX_VENV_CACHEDIR": paths.ctx.venv_cache,
+        "PIPX_STANDALONE_PYTHON_CACHEDIR": paths.ctx.standalone_python_cachedir,
         "PIPX_DEFAULT_PYTHON": DEFAULT_PYTHON,
         "USE_EMOJI": str(EMOJI_SUPPORT).lower(),
     }

--- a/src/pipx/commands/environment.py
+++ b/src/pipx/commands/environment.py
@@ -1,18 +1,6 @@
 import os
 
-from pipx.constants import (
-    EXIT_CODE_OK,
-    LOCAL_BIN_DIR,
-    LOCAL_MAN_DIR,
-    PIPX_HOME,
-    PIPX_LOCAL_VENVS,
-    PIPX_LOG_DIR,
-    PIPX_SHARED_LIBS,
-    PIPX_STANDALONE_PYTHON_CACHEDIR,
-    PIPX_TRASH_DIR,
-    PIPX_VENV_CACHEDIR,
-    ExitCode,
-)
+from pipx.constants import EXIT_CODE_OK, PIPX_DIRS, ExitCode
 from pipx.emojis import EMOJI_SUPPORT
 from pipx.interpreter import DEFAULT_PYTHON
 from pipx.util import PipxError
@@ -30,15 +18,15 @@ def environment(value: str) -> ExitCode:
         "USE_EMOJI",
     ]
     derived_values = {
-        "PIPX_HOME": PIPX_HOME,
-        "PIPX_BIN_DIR": LOCAL_BIN_DIR,
-        "PIPX_MAN_DIR": LOCAL_MAN_DIR,
-        "PIPX_SHARED_LIBS": PIPX_SHARED_LIBS,
-        "PIPX_LOCAL_VENVS": PIPX_LOCAL_VENVS,
-        "PIPX_LOG_DIR": PIPX_LOG_DIR,
-        "PIPX_TRASH_DIR": PIPX_TRASH_DIR,
-        "PIPX_VENV_CACHEDIR": PIPX_VENV_CACHEDIR,
-        "PIPX_STANDALONE_PYTHON_CACHEDIR": PIPX_STANDALONE_PYTHON_CACHEDIR,
+        "PIPX_HOME": PIPX_DIRS.HOME,
+        "PIPX_BIN_DIR": PIPX_DIRS.BIN_DIR,
+        "PIPX_MAN_DIR": PIPX_DIRS.MAN_DIR,
+        "PIPX_SHARED_LIBS": PIPX_DIRS.SHARED_LIBS,
+        "PIPX_LOCAL_VENVS": PIPX_DIRS.LOCAL_VENVS,
+        "PIPX_LOG_DIR": PIPX_DIRS.LOG_DIR,
+        "PIPX_TRASH_DIR": PIPX_DIRS.TRASH_DIR,
+        "PIPX_VENV_CACHEDIR": PIPX_DIRS.VENV_CACHEDIR,
+        "PIPX_STANDALONE_PYTHON_CACHEDIR": PIPX_DIRS.STANDALONE_PYTHON_CACHEDIR,
         "PIPX_DEFAULT_PYTHON": DEFAULT_PYTHON,
         "USE_EMOJI": str(EMOJI_SUPPORT).lower(),
     }

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -71,8 +71,8 @@ def inject_dep(
         run_post_install_actions(
             venv,
             package_name,
-            constants.LOCAL_BIN_DIR,
-            constants.LOCAL_MAN_DIR,
+            constants.PIPX_DIRS.BIN_DIR,
+            constants.PIPX_DIRS.MAN_DIR,
             venv_dir,
             include_dependencies,
             force=force,

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 from typing import List, Optional
 
-from pipx import constants
+from pipx import paths
 from pipx.colors import bold
 from pipx.commands.common import package_name_from_spec, run_post_install_actions
 from pipx.constants import EXIT_CODE_INJECT_ERROR, EXIT_CODE_OK, ExitCode
@@ -71,8 +71,8 @@ def inject_dep(
         run_post_install_actions(
             venv,
             package_name,
-            constants.PIPX_DIRS.BIN_DIR,
-            constants.PIPX_DIRS.MAN_DIR,
+            paths.ctx.bin_dir,
+            paths.ctx.man_dir,
             venv_dir,
             include_dependencies,
             force=force,

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -46,7 +46,7 @@ def install(
 
     for package_name, package_spec in zip(package_names, package_specs):
         if venv_dir is None:
-            venv_container = VenvContainer(constants.PIPX_LOCAL_VENVS)
+            venv_container = VenvContainer(constants.PIPX_DIRS.LOCAL_VENVS)
             venv_dir = venv_container.get_venv_dir(f"{package_name}{suffix}")
 
         try:

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import List, Optional
 
-from pipx import constants
+from pipx import paths
 from pipx.commands.common import package_name_from_spec, run_post_install_actions
 from pipx.constants import (
     EXIT_CODE_INSTALL_VENV_EXISTS,
@@ -46,7 +46,7 @@ def install(
 
     for package_name, package_spec in zip(package_names, package_specs):
         if venv_dir is None:
-            venv_container = VenvContainer(constants.PIPX_DIRS.LOCAL_VENVS)
+            venv_container = VenvContainer(paths.ctx.venvs)
             venv_dir = venv_container.get_venv_dir(f"{package_name}{suffix}")
 
         try:

--- a/src/pipx/commands/interpreter.py
+++ b/src/pipx/commands/interpreter.py
@@ -1,14 +1,14 @@
 from pathlib import Path
 from typing import List
 
-from pipx import constants
+from pipx import constants, paths
 from pipx.pipx_metadata_file import PipxMetadata
 from pipx.util import is_paths_relative, rmdir
 from pipx.venv import Venv, VenvContainer
 
 
 def get_installed_standalone_interpreters() -> List[Path]:
-    return [python_dir for python_dir in constants.PIPX_STANDALONE_PYTHON_CACHEDIR.iterdir() if python_dir.is_dir()]
+    return [python_dir for python_dir in paths.ctx.standalone_python_cachedir.iterdir() if python_dir.is_dir()]
 
 
 def get_venvs_using_standalone_interpreter(venv_container: VenvContainer) -> List[Venv]:
@@ -35,7 +35,7 @@ def list_interpreters(
     interpreters = get_installed_standalone_interpreters()
     venvs = get_venvs_using_standalone_interpreter(venv_container)
     output: list[str] = []
-    output.append(f"Standalone interpreters are in {constants.PIPX_STANDALONE_PYTHON_CACHEDIR}")
+    output.append(f"Standalone interpreters are in {paths.ctx.standalone_python_cachedir}")
     for interpreter in interpreters:
         output.append(f"Python {interpreter.name}")
         used_in = get_interpreter_users(interpreter, venvs)

--- a/src/pipx/commands/list_packages.py
+++ b/src/pipx/commands/list_packages.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 from typing import Any, Collection, Dict, Tuple
 
-from pipx import constants, shared_libs
+from pipx import paths, shared_libs
 from pipx.colors import bold
 from pipx.commands.common import VenvProblems, get_venv_summary, venv_health_check
 from pipx.constants import EXIT_CODE_LIST_PROBLEM, EXIT_CODE_OK, ExitCode
@@ -43,14 +43,18 @@ def list_short(venv_dirs: Collection[Path]) -> VenvProblems:
     return all_venv_problems
 
 
-def list_text(venv_dirs: Collection[Path], include_injected: bool, venv_root_dir: str) -> VenvProblems:
+def list_text(
+    venv_dirs: Collection[Path], include_injected: bool, venv_root_dir: str
+) -> VenvProblems:
     print(f"venvs are in {bold(venv_root_dir)}")
-    print(f"apps are exposed on your $PATH at {bold(str(constants.PIPX_DIRS.BIN_DIR))}")
-    print(f"manual pages are exposed at {bold(str(constants.PIPX_DIRS.MAN_DIR))}")
+    print(f"apps are exposed on your $PATH at {bold(str(paths.ctx.bin_dir))}")
+    print(f"manual pages are exposed at {bold(str(paths.ctx.man_dir))}")
 
     all_venv_problems = VenvProblems()
     for venv_dir in venv_dirs:
-        package_summary, venv_problems = get_venv_summary(venv_dir, include_injected=include_injected)
+        package_summary, venv_problems = get_venv_summary(
+            venv_dir, include_injected=include_injected
+        )
         if venv_problems.any_():
             logger.warning(package_summary)
         else:
@@ -68,7 +72,9 @@ def list_json(venv_dirs: Collection[Path]) -> VenvProblems:
     }
     all_venv_problems = VenvProblems()
     for venv_dir in venv_dirs:
-        (venv_metadata, venv_problems, warning_str) = get_venv_metadata_summary(venv_dir)
+        (venv_metadata, venv_problems, warning_str) = get_venv_metadata_summary(
+            venv_dir
+        )
         all_venv_problems.or_(venv_problems)
         if venv_problems.any_():
             warning_messages.append(warning_str)
@@ -77,7 +83,9 @@ def list_json(venv_dirs: Collection[Path]) -> VenvProblems:
         spec_metadata["venvs"][venv_dir.name] = {}
         spec_metadata["venvs"][venv_dir.name]["metadata"] = venv_metadata.to_dict()
 
-    print(json.dumps(spec_metadata, indent=4, sort_keys=True, cls=JsonEncoderHandlesPath))
+    print(
+        json.dumps(spec_metadata, indent=4, sort_keys=True, cls=JsonEncoderHandlesPath)
+    )
     for warning_message in warning_messages:
         logger.warning(warning_message)
 
@@ -119,7 +127,8 @@ def list_packages(
         )
     if all_venv_problems.invalid_interpreter:
         logger.warning(
-            "\nOne or more packages have a missing python interpreter.\n" "    To fix, execute: pipx reinstall-all"
+            "\nOne or more packages have a missing python interpreter.\n"
+            "    To fix, execute: pipx reinstall-all"
         )
     if all_venv_problems.missing_metadata:
         logger.warning(

--- a/src/pipx/commands/list_packages.py
+++ b/src/pipx/commands/list_packages.py
@@ -45,8 +45,8 @@ def list_short(venv_dirs: Collection[Path]) -> VenvProblems:
 
 def list_text(venv_dirs: Collection[Path], include_injected: bool, venv_root_dir: str) -> VenvProblems:
     print(f"venvs are in {bold(venv_root_dir)}")
-    print(f"apps are exposed on your $PATH at {bold(str(constants.LOCAL_BIN_DIR))}")
-    print(f"manual pages are exposed at {bold(str(constants.LOCAL_MAN_DIR))}")
+    print(f"apps are exposed on your $PATH at {bold(str(constants.PIPX_DIRS.BIN_DIR))}")
+    print(f"manual pages are exposed at {bold(str(constants.PIPX_DIRS.MAN_DIR))}")
 
     all_venv_problems = VenvProblems()
     for venv_dir in venv_dirs:

--- a/src/pipx/commands/list_packages.py
+++ b/src/pipx/commands/list_packages.py
@@ -43,18 +43,14 @@ def list_short(venv_dirs: Collection[Path]) -> VenvProblems:
     return all_venv_problems
 
 
-def list_text(
-    venv_dirs: Collection[Path], include_injected: bool, venv_root_dir: str
-) -> VenvProblems:
+def list_text(venv_dirs: Collection[Path], include_injected: bool, venv_root_dir: str) -> VenvProblems:
     print(f"venvs are in {bold(venv_root_dir)}")
     print(f"apps are exposed on your $PATH at {bold(str(paths.ctx.bin_dir))}")
     print(f"manual pages are exposed at {bold(str(paths.ctx.man_dir))}")
 
     all_venv_problems = VenvProblems()
     for venv_dir in venv_dirs:
-        package_summary, venv_problems = get_venv_summary(
-            venv_dir, include_injected=include_injected
-        )
+        package_summary, venv_problems = get_venv_summary(venv_dir, include_injected=include_injected)
         if venv_problems.any_():
             logger.warning(package_summary)
         else:
@@ -72,9 +68,7 @@ def list_json(venv_dirs: Collection[Path]) -> VenvProblems:
     }
     all_venv_problems = VenvProblems()
     for venv_dir in venv_dirs:
-        (venv_metadata, venv_problems, warning_str) = get_venv_metadata_summary(
-            venv_dir
-        )
+        (venv_metadata, venv_problems, warning_str) = get_venv_metadata_summary(venv_dir)
         all_venv_problems.or_(venv_problems)
         if venv_problems.any_():
             warning_messages.append(warning_str)
@@ -83,9 +77,7 @@ def list_json(venv_dirs: Collection[Path]) -> VenvProblems:
         spec_metadata["venvs"][venv_dir.name] = {}
         spec_metadata["venvs"][venv_dir.name]["metadata"] = venv_metadata.to_dict()
 
-    print(
-        json.dumps(spec_metadata, indent=4, sort_keys=True, cls=JsonEncoderHandlesPath)
-    )
+    print(json.dumps(spec_metadata, indent=4, sort_keys=True, cls=JsonEncoderHandlesPath))
     for warning_message in warning_messages:
         logger.warning(warning_message)
 
@@ -127,8 +119,7 @@ def list_packages(
         )
     if all_venv_problems.invalid_interpreter:
         logger.warning(
-            "\nOne or more packages have a missing python interpreter.\n"
-            "    To fix, execute: pipx reinstall-all"
+            "\nOne or more packages have a missing python interpreter.\n" "    To fix, execute: pipx reinstall-all"
         )
     if all_venv_problems.missing_metadata:
         logger.warning(

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -5,6 +5,7 @@ from typing import List, Sequence
 from packaging.utils import canonicalize_name
 
 import pipx.shared_libs  # import instead of from so mockable in tests
+from pipx import paths
 from pipx.commands.inject import inject_dep
 from pipx.commands.install import install
 from pipx.commands.uninstall import uninstall
@@ -12,7 +13,6 @@ from pipx.constants import (
     EXIT_CODE_OK,
     EXIT_CODE_REINSTALL_INVALID_PYTHON,
     EXIT_CODE_REINSTALL_VENV_NONEXISTENT,
-    PIPX_DIRS,
     ExitCode,
 )
 from pipx.emojis import error, sleep

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -5,7 +5,6 @@ from typing import List, Sequence
 from packaging.utils import canonicalize_name
 
 import pipx.shared_libs  # import instead of from so mockable in tests
-from pipx import paths
 from pipx.commands.inject import inject_dep
 from pipx.commands.install import install
 from pipx.commands.uninstall import uninstall

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -12,6 +12,7 @@ from pipx.constants import (
     EXIT_CODE_OK,
     EXIT_CODE_REINSTALL_INVALID_PYTHON,
     EXIT_CODE_REINSTALL_VENV_NONEXISTENT,
+    PIPX_DIRS,
     ExitCode,
 )
 from pipx.emojis import error, sleep

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -288,7 +288,7 @@ def _get_temporary_venv_path(requirements: List[str], python: str, pip_args: Lis
     m.update("".join(pip_args).encode())
     m.update("".join(venv_args).encode())
     venv_folder_name = m.hexdigest()[:15]  # 15 chosen arbitrarily
-    return Path(constants.PIPX_VENV_CACHEDIR) / venv_folder_name
+    return Path(constants.PIPX_DIRS.VENV_CACHEDIR) / venv_folder_name
 
 
 def _is_temporary_venv_expired(venv_dir: Path) -> bool:
@@ -308,7 +308,7 @@ def _prepare_venv_cache(venv: Venv, bin_path: Optional[Path], use_cache: bool) -
 
 
 def _remove_all_expired_venvs() -> None:
-    for venv_dir in Path(constants.PIPX_VENV_CACHEDIR).iterdir():
+    for venv_dir in Path(constants.PIPX_DIRS.VENV_CACHEDIR).iterdir():
         if _is_temporary_venv_expired(venv_dir):
             logger.info(f"Removing expired venv {str(venv_dir)}")
             rmdir(venv_dir)

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -12,7 +12,7 @@ from typing import List, NoReturn, Optional, Union
 
 from packaging.requirements import InvalidRequirement, Requirement
 
-from pipx import constants
+from pipx import paths
 from pipx.commands.common import package_name_from_spec
 from pipx.constants import TEMP_VENV_EXPIRATION_THRESHOLD_DAYS, WINDOWS
 from pipx.emojis import hazard
@@ -288,7 +288,7 @@ def _get_temporary_venv_path(requirements: List[str], python: str, pip_args: Lis
     m.update("".join(pip_args).encode())
     m.update("".join(venv_args).encode())
     venv_folder_name = m.hexdigest()[:15]  # 15 chosen arbitrarily
-    return Path(constants.PIPX_DIRS.VENV_CACHEDIR) / venv_folder_name
+    return Path(paths.ctx.venv_cache) / venv_folder_name
 
 
 def _is_temporary_venv_expired(venv_dir: Path) -> bool:
@@ -308,7 +308,7 @@ def _prepare_venv_cache(venv: Venv, bin_path: Optional[Path], use_cache: bool) -
 
 
 def _remove_all_expired_venvs() -> None:
-    for venv_dir in Path(constants.PIPX_DIRS.VENV_CACHEDIR).iterdir():
+    for venv_dir in Path(paths.ctx.venv_cache).iterdir():
         if _is_temporary_venv_expired(venv_dir):
             logger.info(f"Removing expired venv {str(venv_dir)}")
             rmdir(venv_dir)

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 from typing import List, Optional, Sequence
 
-from pipx import commands, constants
+from pipx import commands, paths
 from pipx.colors import bold, red
 from pipx.commands.common import expose_resources_globally
 from pipx.constants import EXIT_CODE_OK, ExitCode
@@ -50,7 +50,7 @@ def _upgrade_package(
     if package_metadata.include_apps:
         expose_resources_globally(
             "app",
-            constants.PIPX_DIRS.BIN_DIR,
+            paths.ctx.bin_dir,
             package_metadata.app_paths,
             force=force,
             suffix=package_metadata.suffix,
@@ -61,7 +61,7 @@ def _upgrade_package(
         for _, app_paths in package_metadata.app_paths_of_dependencies.items():
             expose_resources_globally(
                 "app",
-                constants.PIPX_DIRS.BIN_DIR,
+                paths.ctx.bin_dir,
                 app_paths,
                 force=force,
                 suffix=package_metadata.suffix,

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -50,7 +50,7 @@ def _upgrade_package(
     if package_metadata.include_apps:
         expose_resources_globally(
             "app",
-            constants.LOCAL_BIN_DIR,
+            constants.PIPX_DIRS.BIN_DIR,
             package_metadata.app_paths,
             force=force,
             suffix=package_metadata.suffix,
@@ -61,7 +61,7 @@ def _upgrade_package(
         for _, app_paths in package_metadata.app_paths_of_dependencies.items():
             expose_resources_globally(
                 "app",
-                constants.LOCAL_BIN_DIR,
+                constants.PIPX_DIRS.BIN_DIR,
                 app_paths,
                 force=force,
                 suffix=package_metadata.suffix,

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -55,7 +55,7 @@ def _upgrade_package(
             force=force,
             suffix=package_metadata.suffix,
         )
-        expose_resources_globally("man", constants.LOCAL_MAN_DIR, package_metadata.man_paths, force=force)
+        expose_resources_globally("man", paths.ctx.man_dir, package_metadata.man_paths, force=force)
 
     if package_metadata.include_dependencies:
         for _, app_paths in package_metadata.app_paths_of_dependencies.items():
@@ -67,7 +67,7 @@ def _upgrade_package(
                 suffix=package_metadata.suffix,
             )
         for _, man_paths in package_metadata.man_paths_of_dependencies.items():
-            expose_resources_globally("man", constants.LOCAL_MAN_DIR, man_paths, force=force)
+            expose_resources_globally("man", paths.ctx.man_dir, man_paths, force=force)
 
     if old_version == new_version:
         if upgrading_all:
@@ -113,8 +113,8 @@ def _upgrade_venv(
                 venv_args=[],
                 package_names=None,
                 package_specs=[str(venv_dir).split(os.path.sep)[-1]],
-                local_bin_dir=constants.LOCAL_BIN_DIR,
-                local_man_dir=constants.LOCAL_MAN_DIR,
+                local_bin_dir=paths.ctx.bin_dir,
+                local_man_dir=paths.ctx.man_dir,
                 python=python,
                 pip_args=pip_args,
                 verbose=verbose,

--- a/src/pipx/constants.py
+++ b/src/pipx/constants.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import sysconfig
 from textwrap import dedent
@@ -7,6 +8,7 @@ PIPX_SHARED_PTH = "pipx_shared.pth"
 TEMP_VENV_EXPIRATION_THRESHOLD_DAYS = 14
 MINIMUM_PYTHON_VERSION = "3.8"
 MAN_SECTIONS = ["man%d" % i for i in range(1, 10)]
+FETCH_MISSING_PYTHON = os.environ.get("PIPX_FETCH_MISSING_PYTHON", False)
 
 
 ExitCode = NewType("ExitCode", int)

--- a/src/pipx/constants.py
+++ b/src/pipx/constants.py
@@ -8,39 +8,16 @@ from typing import NewType, Optional
 from platformdirs import user_cache_path, user_data_path, user_log_path
 
 
-def load_dir_from_environ(dir_name: str, default: Path) -> Path:
-    env = os.environ.get(dir_name, default)
-    return Path(os.path.expanduser(env)).resolve()
-
-
 DEFAULT_PIPX_HOME = user_data_path("pipx")
 FALLBACK_PIPX_HOME = Path.home() / ".local/pipx"
 DEFAULT_PIPX_BIN_DIR = Path.home() / ".local/bin"
 DEFAULT_PIPX_MAN_DIR = Path.home() / ".local/share/man"
 MAN_SECTIONS = ["man%d" % i for i in range(1, 10)]
 
-if FALLBACK_PIPX_HOME.exists() or os.environ.get("PIPX_HOME") is not None:
-    PIPX_HOME = load_dir_from_environ("PIPX_HOME", FALLBACK_PIPX_HOME)
-    PIPX_LOCAL_VENVS = PIPX_HOME / "venvs"
-    PIPX_STANDALONE_PYTHON_CACHEDIR = PIPX_HOME / "py"
-    PIPX_LOG_DIR = PIPX_HOME / "logs"
-    DEFAULT_PIPX_SHARED_LIBS = PIPX_HOME / "shared"
-    PIPX_TRASH_DIR = PIPX_HOME / ".trash"
-    PIPX_VENV_CACHEDIR = PIPX_HOME / ".cache"
-else:
-    PIPX_HOME = DEFAULT_PIPX_HOME
-    PIPX_LOCAL_VENVS = PIPX_HOME / "venvs"
-    PIPX_STANDALONE_PYTHON_CACHEDIR = PIPX_HOME / "py"
-    PIPX_LOG_DIR = user_log_path("pipx")
-    DEFAULT_PIPX_SHARED_LIBS = PIPX_HOME / "shared"
-    PIPX_TRASH_DIR = PIPX_HOME / "trash"
-    PIPX_VENV_CACHEDIR = user_cache_path("pipx")
-
-PIPX_SHARED_LIBS = load_dir_from_environ("PIPX_SHARED_LIBS", DEFAULT_PIPX_SHARED_LIBS)
 PIPX_SHARED_PTH = "pipx_shared.pth"
-LOCAL_BIN_DIR = load_dir_from_environ("PIPX_BIN_DIR", DEFAULT_PIPX_BIN_DIR)
-LOCAL_MAN_DIR = load_dir_from_environ("PIPX_MAN_DIR", DEFAULT_PIPX_MAN_DIR)
-FETCH_MISSING_PYTHON = os.environ.get("PIPX_FETCH_MISSING_PYTHON", False)
+DEFAULT_PIPX_GLOBAL_BIN_DIR = "/usr/local/bin"
+DEFAULT_PIPX_GLOBAL_MAN_DIR = "/usr/local/share/man"
+DEFAULT_PIPX_GLOBAL_HOME = "/opt/pipx"
 TEMP_VENV_EXPIRATION_THRESHOLD_DAYS = 14
 MINIMUM_PYTHON_VERSION = "3.8"
 
@@ -58,6 +35,82 @@ EXIT_CODE_REINSTALL_INVALID_PYTHON = ExitCode(1)
 EXIT_CODE_SPECIFIED_PYTHON_EXECUTABLE_NOT_FOUND = ExitCode(1)
 
 pipx_log_file: Optional[Path] = None
+
+
+def get_expanded_environ(env_name):
+    val = os.environ.get(env_name)
+    if val is not None:
+        val = os.path.expanduser(val)
+    return val
+
+
+class PIPXDirs:
+    _base_home = get_expanded_environ("PIPX_HOME")
+    _base_bin = get_expanded_environ("PIPX_BIN_DIR")
+    _base_man = get_expanded_environ("PIPX_MAN_DIR")
+    _base_shared_libs = os.environ.get("PIPX_SHARED_LIBS")
+    _fallback_home = Path.home() / ".local/pipx"
+    _in_home = _base_home is not None or _fallback_home.exists()
+
+    @property
+    def LOCAL_VENVS(self) -> Path:
+        return self.HOME / "venvs"
+
+    @property
+    def LOG_DIR(self) -> Path:
+        if self._in_home:
+            return self.HOME / "logs"
+        return user_log_path("pipx")
+
+    @property
+    def TRASH_DIR(self) -> Path:
+        if self._in_home:
+            return self.HOME / ".trash"
+        return self.HOME / "trash"
+
+    @property
+    def VENV_CACHEDIR(self) -> Path:
+        if self._in_home:
+            return self.HOME / ".cache"
+        return user_cache_path("pipx")
+
+    @property
+    def BIN_DIR(self) -> Path:
+        return Path(self._base_bin or DEFAULT_PIPX_BIN_DIR).resolve()
+
+    @property
+    def MAN_DIR(self) -> Path:
+        return Path(self._base_man or DEFAULT_PIPX_MAN_DIR).resolve()
+
+    @property
+    def HOME(self) -> Path:
+        if self._base_home:
+            home = Path(self._base_home)
+        elif self._fallback_home.exists():
+            home = self._fallback_home
+        else:
+            home = Path(DEFAULT_PIPX_HOME)
+        return home.resolve()
+
+    @property
+    def DEFAULT_SHARED_LIBS(self) -> Path:
+        return self.HOME / "shared"
+
+    @property
+    def SHARED_LIBS(self) -> Path:
+        return Path(self._base_shared_libs or self.DEFAULT_SHARED_LIBS).resolve()
+
+    def make_global(self) -> None:
+        self._base_home = DEFAULT_PIPX_GLOBAL_HOME
+        self._base_bin = DEFAULT_PIPX_GLOBAL_BIN_DIR
+        self._base_man = DEFAULT_PIPX_GLOBAL_MAN_DIR
+
+    @property
+    def STANDALONE_PYTHON_CACHEDIR(self) -> Path:
+        return self.HOME / "py"
+
+
+PIPX_DIRS = PIPXDirs()
 
 
 def is_windows() -> bool:

--- a/src/pipx/constants.py
+++ b/src/pipx/constants.py
@@ -1,25 +1,13 @@
-import os
 import sys
 import sysconfig
-from pathlib import Path
 from textwrap import dedent
-from typing import NewType, Optional
-
-from platformdirs import user_cache_path, user_data_path, user_log_path
-
-
-DEFAULT_PIPX_HOME = user_data_path("pipx")
-FALLBACK_PIPX_HOME = Path.home() / ".local/pipx"
-DEFAULT_PIPX_BIN_DIR = Path.home() / ".local/bin"
-DEFAULT_PIPX_MAN_DIR = Path.home() / ".local/share/man"
-MAN_SECTIONS = ["man%d" % i for i in range(1, 10)]
+from typing import NewType
 
 PIPX_SHARED_PTH = "pipx_shared.pth"
-DEFAULT_PIPX_GLOBAL_BIN_DIR = "/usr/local/bin"
-DEFAULT_PIPX_GLOBAL_MAN_DIR = "/usr/local/share/man"
-DEFAULT_PIPX_GLOBAL_HOME = "/opt/pipx"
 TEMP_VENV_EXPIRATION_THRESHOLD_DAYS = 14
 MINIMUM_PYTHON_VERSION = "3.8"
+MAN_SECTIONS = ["man%d" % i for i in range(1, 10)]
+
 
 ExitCode = NewType("ExitCode", int)
 # pipx shell exit codes
@@ -33,84 +21,6 @@ EXIT_CODE_UNINSTALL_ERROR = ExitCode(1)
 EXIT_CODE_REINSTALL_VENV_NONEXISTENT = ExitCode(1)
 EXIT_CODE_REINSTALL_INVALID_PYTHON = ExitCode(1)
 EXIT_CODE_SPECIFIED_PYTHON_EXECUTABLE_NOT_FOUND = ExitCode(1)
-
-pipx_log_file: Optional[Path] = None
-
-
-def get_expanded_environ(env_name):
-    val = os.environ.get(env_name)
-    if val is not None:
-        val = os.path.expanduser(val)
-    return val
-
-
-class PIPXDirs:
-    _base_home = get_expanded_environ("PIPX_HOME")
-    _base_bin = get_expanded_environ("PIPX_BIN_DIR")
-    _base_man = get_expanded_environ("PIPX_MAN_DIR")
-    _base_shared_libs = os.environ.get("PIPX_SHARED_LIBS")
-    _fallback_home = Path.home() / ".local/pipx"
-    _in_home = _base_home is not None or _fallback_home.exists()
-
-    @property
-    def LOCAL_VENVS(self) -> Path:
-        return self.HOME / "venvs"
-
-    @property
-    def LOG_DIR(self) -> Path:
-        if self._in_home:
-            return self.HOME / "logs"
-        return user_log_path("pipx")
-
-    @property
-    def TRASH_DIR(self) -> Path:
-        if self._in_home:
-            return self.HOME / ".trash"
-        return self.HOME / "trash"
-
-    @property
-    def VENV_CACHEDIR(self) -> Path:
-        if self._in_home:
-            return self.HOME / ".cache"
-        return user_cache_path("pipx")
-
-    @property
-    def BIN_DIR(self) -> Path:
-        return Path(self._base_bin or DEFAULT_PIPX_BIN_DIR).resolve()
-
-    @property
-    def MAN_DIR(self) -> Path:
-        return Path(self._base_man or DEFAULT_PIPX_MAN_DIR).resolve()
-
-    @property
-    def HOME(self) -> Path:
-        if self._base_home:
-            home = Path(self._base_home)
-        elif self._fallback_home.exists():
-            home = self._fallback_home
-        else:
-            home = Path(DEFAULT_PIPX_HOME)
-        return home.resolve()
-
-    @property
-    def DEFAULT_SHARED_LIBS(self) -> Path:
-        return self.HOME / "shared"
-
-    @property
-    def SHARED_LIBS(self) -> Path:
-        return Path(self._base_shared_libs or self.DEFAULT_SHARED_LIBS).resolve()
-
-    def make_global(self) -> None:
-        self._base_home = DEFAULT_PIPX_GLOBAL_HOME
-        self._base_bin = DEFAULT_PIPX_GLOBAL_BIN_DIR
-        self._base_man = DEFAULT_PIPX_GLOBAL_MAN_DIR
-
-    @property
-    def STANDALONE_PYTHON_CACHEDIR(self) -> Path:
-        return self.HOME / "py"
-
-
-PIPX_DIRS = PIPXDirs()
 
 
 def is_windows() -> bool:

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -934,7 +934,9 @@ def setup(args: argparse.Namespace) -> None:
 
     mkdir(paths.ctx.venvs)
     mkdir(paths.ctx.bin_dir)
+    mkdir(paths.ctx.man_dir)
     mkdir(paths.ctx.venv_cache)
+    mkdir(paths.ctx.standalone_python_cachedir)
 
     for cachedir in [
         paths.ctx.venv_cache,

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -183,7 +183,7 @@ def run_pipx_command(
     args: argparse.Namespace, subparsers: Dict[str, argparse.ArgumentParser]
 ) -> ExitCode:  # noqa: C901
     verbose = args.verbose if "verbose" in args else False
-    if args.is_global:
+    if not constants.WINDOWS and args.is_global:
         constants.PIPX_DIRS.make_global()
     pip_args = get_pip_args(vars(args))
     venv_args = get_venv_args(vars(args))
@@ -875,12 +875,13 @@ def get_command_parser() -> Tuple[argparse.ArgumentParser, Dict[str, argparse.Ar
     _add_ensurepath(subparsers, shared_parser)
     _add_environment(subparsers, shared_parser)
 
-    parser.add_argument(
-        "--global",
-        action="store_true",
-        dest="is_global",
-        help="Preform action globally for all users.",
-    )
+    if not constants.WINDOWS:
+        parser.add_argument(
+            "--global",
+            action="store_true",
+            dest="is_global",
+            help="Preform action globally for all users.",
+        )
     parser.add_argument("--version", action="store_true", help="Print version and exit")
     subparsers.add_parser(
         "completions",

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -627,16 +627,8 @@ def _add_interpreter(
         description="Get help for commands with pipx interpreter COMMAND --help",
         dest="interpreter_command",
     )
-    s.add_parser(
-        "list",
-        help="List available interpreters",
-        description="List available interpreters",
-    )
-    s.add_parser(
-        "prune",
-        help="Prune unused interpreters",
-        description="Prune unused interpreters",
-    )
+    s.add_parser("list", help="List available interpreters", description="List available interpreters")
+    s.add_parser("prune", help="Prune unused interpreters", description="Prune unused interpreters")
     return p
 
 

--- a/src/pipx/paths.py
+++ b/src/pipx/paths.py
@@ -27,7 +27,6 @@ class _PathContext:
     _base_shared_libs: Optional[Union[Path, str]] = get_expanded_environ("PIPX_SHARED_LIBS")
     _fallback_home: Path = Path.home() / ".local/pipx"
     _home_exists: bool = _base_home is not None or _fallback_home.exists()
-    is_global: bool = False
     log_file: Optional[Path] = None
 
     @property
@@ -79,14 +78,12 @@ class _PathContext:
         self._base_bin = get_expanded_environ("PIPX_BIN_DIR")
         self._base_man = get_expanded_environ("PIPX_MAN_DIR")
         self._home_exists = self._base_home is not None or self._fallback_home.exists()
-        self.is_global = False
 
     def make_global(self) -> None:
         self._base_home = get_expanded_environ("PIPX_GLOBAL_HOME") or DEFAULT_PIPX_GLOBAL_HOME
         self._base_bin = get_expanded_environ("PIPX_GLOBAL_BIN_DIR") or DEFAULT_PIPX_GLOBAL_BIN_DIR
         self._base_man = get_expanded_environ("PIPX_GLOBAL_MAN_DIR") or DEFAULT_PIPX_GLOBAL_MAN_DIR
         self._home_exists = self._base_home is not None or self._fallback_home.exists()
-        self.is_global = True
 
     @property
     def standalone_python_cachedir(self) -> Path:

--- a/src/pipx/paths.py
+++ b/src/pipx/paths.py
@@ -73,6 +73,12 @@ class _PathContext:
     def shared_libs(self) -> Path:
         return Path(self._base_shared_libs or self.home / "shared").resolve()
 
+    def make_local(self) -> None:
+        self._base_home = get_expanded_environ("PIPX_HOME")
+        self._base_bin = get_expanded_environ("PIPX_BIN_DIR")
+        self._base_man = get_expanded_environ("PIPX_MAN_DIR")
+        self._home_exists = self._base_home is not None or self._fallback_home.exists()
+
     def make_global(self) -> None:
         self._base_home = get_expanded_environ("PIPX_GLOBAL_HOME") or DEFAULT_PIPX_GLOBAL_HOME
         self._base_bin = get_expanded_environ("PIPX_GLOBAL_BIN_DIR") or DEFAULT_PIPX_GLOBAL_BIN_DIR

--- a/src/pipx/paths.py
+++ b/src/pipx/paths.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 from platformdirs import user_cache_path, user_data_path, user_log_path
 
@@ -16,15 +16,15 @@ DEFAULT_PIPX_GLOBAL_MAN_DIR = "/usr/local/share/man"
 def get_expanded_environ(env_name: str) -> Optional[Path]:
     val = os.environ.get(env_name)
     if val is not None:
-        val = Path(val).expanduser().resolve()
+        return Path(val).expanduser().resolve()
     return val
 
 
 class _PathContext:
-    _base_home: Optional[Path] = get_expanded_environ("PIPX_HOME")
-    _base_bin: Optional[Path] = get_expanded_environ("PIPX_BIN_DIR")
-    _base_man: Optional[Path] = get_expanded_environ("PIPX_MAN_DIR")
-    _base_shared_libs: Optional[Path] = get_expanded_environ("PIPX_SHARED_LIBS")
+    _base_home: Optional[Union[Path, str]] = get_expanded_environ("PIPX_HOME")
+    _base_bin: Optional[Union[Path, str]] = get_expanded_environ("PIPX_BIN_DIR")
+    _base_man: Optional[Union[Path, str]] = get_expanded_environ("PIPX_MAN_DIR")
+    _base_shared_libs: Optional[Union[Path, str]] = get_expanded_environ("PIPX_SHARED_LIBS")
     _fallback_home: Path = Path.home() / ".local/pipx"
     _in_home: bool = _base_home is not None or _fallback_home.exists()
     log_file: Optional[Path] = None

--- a/src/pipx/paths.py
+++ b/src/pipx/paths.py
@@ -26,7 +26,7 @@ class _PathContext:
     _base_man: Optional[Union[Path, str]] = get_expanded_environ("PIPX_MAN_DIR")
     _base_shared_libs: Optional[Union[Path, str]] = get_expanded_environ("PIPX_SHARED_LIBS")
     _fallback_home: Path = Path.home() / ".local/pipx"
-    _in_home: bool = _base_home is not None or _fallback_home.exists()
+    _home_exists: bool = _base_home is not None or _fallback_home.exists()
     log_file: Optional[Path] = None
 
     @property
@@ -35,19 +35,19 @@ class _PathContext:
 
     @property
     def logs(self) -> Path:
-        if self._in_home:
+        if self._home_exists:
             return self.home / "logs"
         return user_log_path("pipx")
 
     @property
     def trash(self) -> Path:
-        if self._in_home:
+        if self._home_exists:
             return self.home / ".trash"
         return self.home / "trash"
 
     @property
     def venv_cache(self) -> Path:
-        if self._in_home:
+        if self._home_exists:
             return self.home / ".cache"
         return user_cache_path("pipx")
 
@@ -74,9 +74,9 @@ class _PathContext:
         return Path(self._base_shared_libs or self.home / "shared").resolve()
 
     def make_global(self) -> None:
-        self._base_home = DEFAULT_PIPX_GLOBAL_HOME
-        self._base_bin = DEFAULT_PIPX_GLOBAL_BIN_DIR
-        self._base_man = DEFAULT_PIPX_GLOBAL_MAN_DIR
+        self._base_home = get_expanded_environ("PIPX_GLOBAL_HOME") or DEFAULT_PIPX_GLOBAL_HOME
+        self._base_bin = get_expanded_environ("PIPX_GLOBAL_BIN_DIR") or DEFAULT_PIPX_GLOBAL_BIN_DIR
+        self._base_man = get_expanded_environ("PIPX_GLOBAL_MAN_DIR") or DEFAULT_PIPX_GLOBAL_MAN_DIR
 
     @property
     def standalone_python_cachedir(self) -> Path:

--- a/src/pipx/paths.py
+++ b/src/pipx/paths.py
@@ -76,6 +76,7 @@ class _PathContext:
     def make_global(self) -> None:
         self._base_home = DEFAULT_PIPX_GLOBAL_HOME
         self._base_bin = DEFAULT_PIPX_GLOBAL_BIN_DIR
+        self._base_man = DEFAULT_PIPX_GLOBAL_MAN_DIR
 
     @property
     def standalone_python_cachedir(self) -> Path:

--- a/src/pipx/paths.py
+++ b/src/pipx/paths.py
@@ -27,6 +27,7 @@ class _PathContext:
     _base_shared_libs: Optional[Union[Path, str]] = get_expanded_environ("PIPX_SHARED_LIBS")
     _fallback_home: Path = Path.home() / ".local/pipx"
     _home_exists: bool = _base_home is not None or _fallback_home.exists()
+    is_global: bool = False
     log_file: Optional[Path] = None
 
     @property
@@ -78,12 +79,14 @@ class _PathContext:
         self._base_bin = get_expanded_environ("PIPX_BIN_DIR")
         self._base_man = get_expanded_environ("PIPX_MAN_DIR")
         self._home_exists = self._base_home is not None or self._fallback_home.exists()
+        self.is_global = False
 
     def make_global(self) -> None:
         self._base_home = get_expanded_environ("PIPX_GLOBAL_HOME") or DEFAULT_PIPX_GLOBAL_HOME
         self._base_bin = get_expanded_environ("PIPX_GLOBAL_BIN_DIR") or DEFAULT_PIPX_GLOBAL_BIN_DIR
         self._base_man = get_expanded_environ("PIPX_GLOBAL_MAN_DIR") or DEFAULT_PIPX_GLOBAL_MAN_DIR
         self._home_exists = self._base_home is not None or self._fallback_home.exists()
+        self.is_global = True
 
     @property
     def standalone_python_cachedir(self) -> Path:

--- a/src/pipx/paths.py
+++ b/src/pipx/paths.py
@@ -1,0 +1,85 @@
+import os
+from pathlib import Path
+from typing import Optional
+
+from platformdirs import user_cache_path, user_data_path, user_log_path
+
+DEFAULT_PIPX_HOME = user_data_path("pipx")
+FALLBACK_PIPX_HOME = Path.home() / ".local/pipx"
+DEFAULT_PIPX_BIN_DIR = Path.home() / ".local/bin"
+DEFAULT_PIPX_MAN_DIR = Path.home() / ".local/share/man"
+DEFAULT_PIPX_GLOBAL_HOME = "/opt/pipx"
+DEFAULT_PIPX_GLOBAL_BIN_DIR = "/usr/local/bin"
+DEFAULT_PIPX_GLOBAL_MAN_DIR = "/usr/local/share/man"
+
+
+def get_expanded_environ(env_name: str) -> Optional[Path]:
+    val = os.environ.get(env_name)
+    if val is not None:
+        val = Path(val).expanduser().resolve()
+    return val
+
+
+class _PathContext:
+    _base_home: Optional[Path] = get_expanded_environ("PIPX_HOME")
+    _base_bin: Optional[Path] = get_expanded_environ("PIPX_BIN_DIR")
+    _base_man: Optional[Path] = get_expanded_environ("PIPX_MAN_DIR")
+    _base_shared_libs: Optional[Path] = get_expanded_environ("PIPX_SHARED_LIBS")
+    _fallback_home: Path = Path.home() / ".local/pipx"
+    _in_home: bool = _base_home is not None or _fallback_home.exists()
+    log_file: Optional[Path] = None
+
+    @property
+    def venvs(self) -> Path:
+        return self.home / "venvs"
+
+    @property
+    def logs(self) -> Path:
+        if self._in_home:
+            return self.home / "logs"
+        return user_log_path("pipx")
+
+    @property
+    def trash(self) -> Path:
+        if self._in_home:
+            return self.home / ".trash"
+        return self.home / "trash"
+
+    @property
+    def venv_cache(self) -> Path:
+        if self._in_home:
+            return self.home / ".cache"
+        return user_cache_path("pipx")
+
+    @property
+    def bin_dir(self) -> Path:
+        return Path(self._base_bin or DEFAULT_PIPX_BIN_DIR).resolve()
+
+    @property
+    def man_dir(self) -> Path:
+        return Path(self._base_man or DEFAULT_PIPX_MAN_DIR).resolve()
+
+    @property
+    def home(self) -> Path:
+        if self._base_home:
+            home = Path(self._base_home)
+        elif self._fallback_home.exists():
+            home = self._fallback_home
+        else:
+            home = Path(DEFAULT_PIPX_HOME)
+        return home.resolve()
+
+    @property
+    def shared_libs(self) -> Path:
+        return Path(self._base_shared_libs or self.home / "shared").resolve()
+
+    def make_global(self) -> None:
+        self._base_home = DEFAULT_PIPX_GLOBAL_HOME
+        self._base_bin = DEFAULT_PIPX_GLOBAL_BIN_DIR
+
+    @property
+    def standalone_python_cachedir(self) -> Path:
+        return self.home / "py"
+
+
+ctx = _PathContext()

--- a/src/pipx/paths.py
+++ b/src/pipx/paths.py
@@ -77,6 +77,7 @@ class _PathContext:
         self._base_home = get_expanded_environ("PIPX_GLOBAL_HOME") or DEFAULT_PIPX_GLOBAL_HOME
         self._base_bin = get_expanded_environ("PIPX_GLOBAL_BIN_DIR") or DEFAULT_PIPX_GLOBAL_BIN_DIR
         self._base_man = get_expanded_environ("PIPX_GLOBAL_MAN_DIR") or DEFAULT_PIPX_GLOBAL_MAN_DIR
+        self._home_exists = self._base_home is not None or self._fallback_home.exists()
 
     @property
     def standalone_python_cachedir(self) -> Path:

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -23,7 +23,7 @@ SHARED_LIBS_MAX_AGE_SEC = datetime.timedelta(days=30).total_seconds()
 
 class _SharedLibs:
     def __init__(self) -> None:
-        self.root = constants.PIPX_SHARED_LIBS
+        self.root = constants.PIPX_DIRS.SHARED_LIBS
         self.bin_path, self.python_path, self.man_path = get_venv_paths(self.root)
         self.pip_path = self.bin_path / ("pip" if not WINDOWS else "pip.exe")
         # i.e. bin_path is ~/.local/share/pipx/shared/bin

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -4,7 +4,7 @@ import time
 from pathlib import Path
 from typing import List, Optional
 
-from pipx import constants
+from pipx import paths
 from pipx.animate import animate
 from pipx.constants import WINDOWS
 from pipx.interpreter import DEFAULT_PYTHON
@@ -23,7 +23,7 @@ SHARED_LIBS_MAX_AGE_SEC = datetime.timedelta(days=30).total_seconds()
 
 class _SharedLibs:
     def __init__(self) -> None:
-        self.root = constants.PIPX_DIRS.SHARED_LIBS
+        self.root = paths.ctx.shared_libs
         self.bin_path, self.python_path, self.man_path = get_venv_paths(self.root)
         self.pip_path = self.bin_path / ("pip" if not WINDOWS else "pip.exe")
         # i.e. bin_path is ~/.local/share/pipx/shared/bin

--- a/src/pipx/standalone_python.py
+++ b/src/pipx/standalone_python.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 from urllib.request import urlopen
 
-from pipx import constants
+from pipx import constants, paths
 from pipx.animate import animate
 from pipx.util import PipxError
 
@@ -58,7 +58,7 @@ def download_python_build_standalone(python_version: str):
     # we'll convert it to a bare version number
     python_version = re.sub(r"[c]?python", "", python_version)
 
-    install_dir = constants.PIPX_STANDALONE_PYTHON_CACHEDIR / python_version
+    install_dir = paths.ctx.standalone_python_cachedir / python_version
     installed_python = install_dir / "python.exe" if constants.WINDOWS else install_dir / "bin" / "python3"
 
     if installed_python.exists():
@@ -125,7 +125,7 @@ def _unpack(full_version, download_link, archive: Path, download_dir: Path):
 def get_or_update_index():
     """Get or update the index of available python builds from
     the python-build-standalone repository."""
-    index_file = constants.PIPX_STANDALONE_PYTHON_CACHEDIR / "index.json"
+    index_file = paths.ctx.standalone_python_cachedir / "index.json"
     if index_file.exists():
         index = json.loads(index_file.read_text())
         # update index after 30 days

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -23,7 +23,7 @@ from typing import (
 
 import pipx.constants
 from pipx.animate import show_cursor
-from pipx.constants import MINGW, PIPX_TRASH_DIR, WINDOWS
+from pipx.constants import MINGW, WINDOWS
 
 logger = logging.getLogger(__name__)
 
@@ -42,10 +42,10 @@ class RelevantSearch(NamedTuple):
 
 
 def _get_trash_file(path: Path) -> Path:
-    if not PIPX_TRASH_DIR.is_dir():
-        PIPX_TRASH_DIR.mkdir()
+    if not pipx.constants.PIPX_DIRS.TRASH_DIR.is_dir():
+        pipx.constants.PIPX_DIRS.TRASH_DIR.mkdir()
     prefix = "".join(random.choices(string.ascii_lowercase, k=8))
-    return PIPX_TRASH_DIR / f"{prefix}.{path.name}"
+    return pipx.constants.PIPX_DIRS.TRASH_DIR / f"{prefix}.{path.name}"
 
 
 def rmdir(path: Path, safe_rm: bool = True) -> None:

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -21,7 +21,7 @@ from typing import (
     Union,
 )
 
-import pipx.constants
+from pipx import paths
 from pipx.animate import show_cursor
 from pipx.constants import MINGW, WINDOWS
 
@@ -42,10 +42,10 @@ class RelevantSearch(NamedTuple):
 
 
 def _get_trash_file(path: Path) -> Path:
-    if not pipx.constants.PIPX_DIRS.TRASH_DIR.is_dir():
-        pipx.constants.PIPX_DIRS.TRASH_DIR.mkdir()
+    if not paths.ctx.trash.is_dir():
+        paths.ctx.trash.mkdir()
     prefix = "".join(random.choices(string.ascii_lowercase, k=8))
-    return pipx.constants.PIPX_DIRS.TRASH_DIR / f"{prefix}.{path.name}"
+    return paths.ctx.trash / f"{prefix}.{path.name}"
 
 
 def rmdir(path: Path, safe_rm: bool = True) -> None:
@@ -330,9 +330,9 @@ def subprocess_post_check_handle_pip_error(
     if completed_process.returncode:
         logger.info(f"{' '.join(completed_process.args)!r} failed")
         # Save STDOUT and STDERR to file in pipx/logs/
-        if pipx.constants.pipx_log_file is None:
+        if paths.ctx.log_file is None:
             raise PipxError("Pipx internal error: No log_file present.")
-        pip_error_file = pipx.constants.pipx_log_file.parent / (pipx.constants.pipx_log_file.stem + "_pip_errors.log")
+        pip_error_file = paths.ctx.log_file.parent / (paths.ctx.log_file.stem + "_pip_errors.log")
         with pip_error_file.open("w", encoding="utf-8") as pip_error_fh:
             print("PIP STDOUT", file=pip_error_fh)
             print("----------", file=pip_error_fh)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,17 +154,7 @@ def pipx_local_pypiserver(request, root: Path, tmp_path_factory) -> Iterator[str
     os.environ["NO_PROXY"] = "127.0.0.1"
     cache = str(pipx_cache_dir / f"{sys.version_info[0]}.{sys.version_info[1]}")
     server = str(Path(sys.executable).parent / "pypi-server")
-    cmd = [
-        server,
-        "run",
-        "--verbose",
-        "--disable-fallback",
-        "--host",
-        "127.0.0.1",
-        "--port",
-        str(port),
-        cache,
-    ]
+    cmd = [server, "run", "--verbose", "--disable-fallback", "--host", "127.0.0.1", "--port", str(port), cache]
     cmd += ["--log-file", str(server_log)]
     pypiserver_process = subprocess.Popen(cmd, cwd=root)
     url = f"http://127.0.0.1:{port}/simple/"
@@ -201,14 +191,7 @@ def utils_temp_dir(tmp_path_factory):
 
 
 @pytest.fixture
-def pipx_temp_env(
-    tmp_path,
-    monkeypatch,
-    pipx_session_shared_dir,
-    request,
-    utils_temp_dir,
-    pipx_local_pypiserver,
-):
+def pipx_temp_env(tmp_path, monkeypatch, pipx_session_shared_dir, request, utils_temp_dir, pipx_local_pypiserver):
     """Sets up temporary paths for pipx to install into.
 
     Shared libs are setup once per session, all other pipx dirs, constants are
@@ -217,14 +200,7 @@ def pipx_temp_env(
     Also adds environment variables as necessary to make pip installations
     seamless.
     """
-    pipx_temp_env_helper(
-        pipx_session_shared_dir,
-        tmp_path,
-        monkeypatch,
-        request,
-        utils_temp_dir,
-        pipx_local_pypiserver,
-    )
+    pipx_temp_env_helper(pipx_session_shared_dir, tmp_path, monkeypatch, request, utils_temp_dir, pipx_local_pypiserver)
 
 
 @pytest.fixture
@@ -238,11 +214,4 @@ def pipx_ultra_temp_env(tmp_path, monkeypatch, request, utils_temp_dir, pipx_loc
     seamless.
     """
     shared_dir = Path(tmp_path) / "shareddir"
-    pipx_temp_env_helper(
-        shared_dir,
-        tmp_path,
-        monkeypatch,
-        request,
-        utils_temp_dir,
-        pipx_local_pypiserver,
-    )
+    pipx_temp_env_helper(shared_dir, tmp_path, monkeypatch, request, utils_temp_dir, pipx_local_pypiserver)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,9 +64,7 @@ def pytest_configure(config):
     config.option.markexpr = new_markexpr
 
 
-def pipx_temp_env_helper(
-    pipx_shared_dir, tmp_path, monkeypatch, request, utils_temp_dir, pypi
-):
+def pipx_temp_env_helper(pipx_shared_dir, tmp_path, monkeypatch, request, utils_temp_dir, pypi):
     home_dir = Path(tmp_path) / "subdir" / "pipxhome"
     bin_dir = Path(tmp_path) / "otherdir" / "pipxbindir"
     man_dir = Path(tmp_path) / "otherdir" / "pipxmandir"
@@ -95,24 +93,16 @@ def pipx_temp_env_helper(
     # macOS needs /usr/bin in PATH to compile certain packages, but
     #   applications in /usr/bin cause test_install.py tests to raise warnings
     #   which make tests fail (e.g. on Github ansible apps exist in /usr/bin)
-    monkeypatch.setenv(
-        "PATH_ORIG", str(paths.ctx.bin_dir) + os.pathsep + os.environ["PATH"]
-    )
+    monkeypatch.setenv("PATH_ORIG", str(paths.ctx.bin_dir) + os.pathsep + os.environ["PATH"])
     monkeypatch.setenv("PATH_TEST", str(paths.ctx.bin_dir))
-    monkeypatch.setenv(
-        "PATH", str(paths.ctx.bin_dir) + os.pathsep + str(utils_temp_dir)
-    )
+    monkeypatch.setenv("PATH", str(paths.ctx.bin_dir) + os.pathsep + str(utils_temp_dir))
     # On Windows, monkeypatch pipx.commands.common._can_symlink_cache to
     #   indicate that paths.ctx.bin_dir and paths.ctx.man_dir
     #   cannot use symlinks, even if we're running as administrator and
     #   symlinks are actually possible.
     if WIN:
-        monkeypatch.setitem(
-            commands.common._can_symlink_cache, paths.ctx.bin_dir, False
-        )
-        monkeypatch.setitem(
-            commands.common._can_symlink_cache, paths.ctx.man_dir, False
-        )
+        monkeypatch.setitem(commands.common._can_symlink_cache, paths.ctx.bin_dir, False)
+        monkeypatch.setitem(commands.common._can_symlink_cache, paths.ctx.man_dir, False)
     if not request.config.option.net_pypiserver:
         # IMPORTANT: use 127.0.0.1 not localhost
         #   Using localhost on Windows creates enormous slowdowns
@@ -143,9 +133,7 @@ def pipx_local_pypiserver(request, root: Path, tmp_path_factory) -> Iterator[str
         str(PIPX_TESTS_PACKAGE_LIST_DIR),
         str(pipx_cache_dir),
     ]
-    check_test_packages_process = subprocess.run(
-        check_test_packages_cmd, check=False, cwd=root
-    )
+    check_test_packages_process = subprocess.run(check_test_packages_cmd, check=False, cwd=root)
     if check_test_packages_process.returncode != 0:
         raise Exception(
             f"Directory {str(pipx_cache_dir)} does not contain all "
@@ -240,9 +228,7 @@ def pipx_temp_env(
 
 
 @pytest.fixture
-def pipx_ultra_temp_env(
-    tmp_path, monkeypatch, request, utils_temp_dir, pipx_local_pypiserver
-):
+def pipx_ultra_temp_env(tmp_path, monkeypatch, request, utils_temp_dir, pipx_local_pypiserver):
     """Sets up temporary paths for pipx to install into.
 
     Fully temporary environment, every test function starts as if pipx has

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -201,6 +201,8 @@ def pipx_temp_env(tmp_path, monkeypatch, pipx_session_shared_dir, request, utils
     seamless.
     """
     pipx_temp_env_helper(pipx_session_shared_dir, tmp_path, monkeypatch, request, utils_temp_dir, pipx_local_pypiserver)
+    yield
+    paths.ctx.make_local()
 
 
 @pytest.fixture
@@ -215,3 +217,5 @@ def pipx_ultra_temp_env(tmp_path, monkeypatch, request, utils_temp_dir, pipx_loc
     """
     shared_dir = Path(tmp_path) / "shareddir"
     pipx_temp_env_helper(shared_dir, tmp_path, monkeypatch, request, utils_temp_dir, pipx_local_pypiserver)
+    yield
+    paths.ctx.make_local()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,8 +70,8 @@ def pipx_temp_env_helper(pipx_shared_dir, tmp_path, monkeypatch, request, utils_
     man_dir = Path(tmp_path) / "otherdir" / "pipxmandir"
 
     global_home_dir = Path(tmp_path) / "global" / "pipxhome"
-    global_bin_dir = Path(tmp_path) / "global" / "pipxbindir"
-    global_man_dir = Path(tmp_path) / "otherdir" / "pipxmandir"
+    global_bin_dir = Path(tmp_path) / "global_otherdir" / "pipxbindir"
+    global_man_dir = Path(tmp_path) / "global_otherdir" / "pipxmandir"
 
     # Patch in test specific base paths
     monkeypatch.setattr(paths.ctx, "_base_shared_libs", pipx_shared_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,18 +68,22 @@ def pipx_temp_env_helper(pipx_shared_dir, tmp_path, monkeypatch, request, utils_
     home_dir = Path(tmp_path) / "subdir" / "pipxhome"
     bin_dir = Path(tmp_path) / "otherdir" / "pipxbindir"
     man_dir = Path(tmp_path) / "otherdir" / "pipxmandir"
+    
+    global_home_dir = Path(tmp_path) / "global" / "pipxhome"
+    global_bin_dir = Path(tmp_path) / "global" / "pipxbindir"
+    global_man_dir = Path(tmp_path) / "otherdir" / "pipxmandir"
 
-    monkeypatch.setattr(constants, "PIPX_SHARED_LIBS", pipx_shared_dir)
+    # Patch in test specific base paths
+    monkeypatch.setattr(constants.PIPX_DIRS, "_base_shared_libs", pipx_shared_dir)
+    monkeypatch.setattr(constants.PIPX_DIRS, "_base_home", home_dir)
+    monkeypatch.setattr(constants.PIPX_DIRS, "_base_bin", bin_dir)
+    monkeypatch.setattr(constants.PIPX_DIRS, "_base_man", man_dir)
+    # Patch the default global paths so developers don't contaminate their own systems
+    monkeypatch.setattr(constants, "DEFAULT_PIPX_GLOBAL_BIN_DIR", global_bin_dir)
+    monkeypatch.setattr(constants, "DEFAULT_PIPX_GLOBAL_HOME", global_home_dir)
+    monkeypatch.setattr(constants, "DEFAULT_PIPX_GLOBAL_MAN_DIR", global_man_dir)
     monkeypatch.setattr(shared_libs, "shared_libs", shared_libs._SharedLibs())
     monkeypatch.setattr(venv, "shared_libs", shared_libs.shared_libs)
-
-    monkeypatch.setattr(constants, "PIPX_HOME", home_dir)
-    monkeypatch.setattr(constants, "LOCAL_BIN_DIR", bin_dir)
-    monkeypatch.setattr(constants, "LOCAL_MAN_DIR", man_dir)
-    monkeypatch.setattr(constants, "PIPX_STANDALONE_PYTHON_CACHEDIR", home_dir / "py")
-    monkeypatch.setattr(constants, "PIPX_LOCAL_VENVS", home_dir / "venvs")
-    monkeypatch.setattr(constants, "PIPX_VENV_CACHEDIR", home_dir / ".cache")
-    monkeypatch.setattr(constants, "PIPX_LOG_DIR", home_dir / "logs")
 
     monkeypatch.setattr(interpreter, "DEFAULT_PYTHON", sys.executable)
 
@@ -89,16 +93,20 @@ def pipx_temp_env_helper(pipx_shared_dir, tmp_path, monkeypatch, request, utils_
     # macOS needs /usr/bin in PATH to compile certain packages, but
     #   applications in /usr/bin cause test_install.py tests to raise warnings
     #   which make tests fail (e.g. on Github ansible apps exist in /usr/bin)
-    monkeypatch.setenv("PATH_ORIG", str(bin_dir) + os.pathsep + os.environ["PATH"])
-    monkeypatch.setenv("PATH_TEST", str(bin_dir))
-    monkeypatch.setenv("PATH", str(bin_dir) + os.pathsep + str(utils_temp_dir))
+    monkeypatch.setenv(
+        "PATH_ORIG", str(constants.PIPX_DIRS.BIN_DIR) + os.pathsep + os.environ["PATH"]
+    )
+    monkeypatch.setenv("PATH_TEST", str(constants.PIPX_DIRS.BIN_DIR))
+    monkeypatch.setenv(
+        "PATH", str(constants.PIPX_DIRS.BIN_DIR) + os.pathsep + str(utils_temp_dir)
+    )
     # On Windows, monkeypatch pipx.commands.common._can_symlink_cache to
-    #   indicate that constants.LOCAL_BIN_DIR and constants.LOCAL_MAN_DIR
+    #   indicate that constants.PIPX_DIRS.BIN_DIR and constants.PIPX_DIRS.MAN_DIR
     #   cannot use symlinks, even if we're running as administrator and
     #   symlinks are actually possible.
     if WIN:
-        monkeypatch.setitem(commands.common._can_symlink_cache, constants.LOCAL_BIN_DIR, False)
-        monkeypatch.setitem(commands.common._can_symlink_cache, constants.LOCAL_MAN_DIR, False)
+        monkeypatch.setitem(commands.common._can_symlink_cache, constants.PIPX_DIRS.BIN_DIR, False)
+        monkeypatch.setitem(commands.common._can_symlink_cache, constants.PIPX_DIRS.MAN_DIR, False)
     if not request.config.option.net_pypiserver:
         # IMPORTANT: use 127.0.0.1 not localhost
         #   Using localhost on Windows creates enormous slowdowns

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -110,7 +110,7 @@ def mock_legacy_venv(venv_name: str, metadata_version: Optional[str] = None) -> 
     one with a previous metadata version.
     metadata_version=None refers to no metadata file (pipx pre-0.15.0.0)
     """
-    venv_dir = Path(constants.PIPX_LOCAL_VENVS) / canonicalize_name(venv_name)
+    venv_dir = Path(constants.PIPX_DIRS.LOCAL_VENVS) / canonicalize_name(venv_name)
 
     if metadata_version == "0.4":
         # Current metadata version, do nothing
@@ -204,7 +204,9 @@ def assert_package_metadata(test_metadata, ref_metadata):
 
 
 def remove_venv_interpreter(venv_name):
-    _, venv_python_path, _ = util.get_venv_paths(constants.PIPX_LOCAL_VENVS / venv_name)
+    _, venv_python_path, _ = util.get_venv_paths(
+        constants.PIPX_DIRS.LOCAL_VENVS / venv_name
+    )
     assert venv_python_path.is_file()
     venv_python_path.unlink()
     assert not venv_python_path.is_file()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -9,7 +9,7 @@ from unittest import mock
 from packaging.utils import canonicalize_name
 
 from package_info import PKG
-from pipx import constants, main, pipx_metadata_file, util
+from pipx import constants, main, paths, pipx_metadata_file, util
 
 WIN = sys.platform.startswith("win")
 
@@ -110,7 +110,7 @@ def mock_legacy_venv(venv_name: str, metadata_version: Optional[str] = None) -> 
     one with a previous metadata version.
     metadata_version=None refers to no metadata file (pipx pre-0.15.0.0)
     """
-    venv_dir = Path(constants.PIPX_DIRS.LOCAL_VENVS) / canonicalize_name(venv_name)
+    venv_dir = Path(paths.ctx.venvs) / canonicalize_name(venv_name)
 
     if metadata_version == "0.4":
         # Current metadata version, do nothing
@@ -204,9 +204,7 @@ def assert_package_metadata(test_metadata, ref_metadata):
 
 
 def remove_venv_interpreter(venv_name):
-    _, venv_python_path, _ = util.get_venv_paths(
-        constants.PIPX_DIRS.LOCAL_VENVS / venv_name
-    )
+    _, venv_python_path, _ = util.get_venv_paths(paths.ctx.venvs / venv_name)
     assert venv_python_path.is_file()
     venv_python_path.unlink()
     assert not venv_python_path.is_file()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 from unittest import mock
 
-import pytest
+import pytest  # type: ignore
 from packaging.utils import canonicalize_name
 
 from package_info import PKG

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 from unittest import mock
 
+import pytest
 from packaging.utils import canonicalize_name
 
 from package_info import PKG
@@ -208,3 +209,6 @@ def remove_venv_interpreter(venv_name):
     assert venv_python_path.is_file()
     venv_python_path.unlink()
     assert not venv_python_path.is_file()
+
+
+skip_if_windows = pytest.mark.skipif(sys.platform.startswith("win"), reason="This behavior is undefined on Windows")

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 
 from helpers import run_pipx_cli, skip_if_windows
+from pipx import paths
 
 
 def load_dir_from_environ(dir_name: str, default: Path) -> Path:
@@ -71,3 +72,5 @@ def test_cli_global(monkeypatch, capsys):
     # Checking just for the sake of completeness
     assert "PIPX_DEFAULT_PYTHON" in captured.out
     assert "USE_EMOJI" in captured.out
+    # reset to local to avoid side effects
+    paths.ctx.make_local()

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,4 +1,7 @@
+import sys
 from pathlib import Path
+
+import pytest  # type: ignore
 
 from helpers import run_pipx_cli
 from pipx.constants import load_dir_from_environ
@@ -52,6 +55,8 @@ def test_resolve_user_dir_in_env_paths_env_not_set(monkeypatch):
 
 
 def test_cli_global(monkeypatch, capsys):
+    if sys.platform.startswith("win"):
+        pytest.skip("This behavior is undefined on Windows")
     assert not run_pipx_cli(["--global", "environment"])
     captured = capsys.readouterr()
     assert "PIPX_HOME=/opt/pipx" in captured.out

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,8 +1,8 @@
+import fnmatch
 import os
 from pathlib import Path
 
 from helpers import run_pipx_cli, skip_if_windows
-from pipx import paths
 
 
 def load_dir_from_environ(dir_name: str, default: Path) -> Path:
@@ -58,19 +58,17 @@ def test_resolve_user_dir_in_env_paths_env_not_set(monkeypatch):
 
 
 @skip_if_windows
-def test_cli_global(monkeypatch, capsys):
+def test_cli_global(pipx_temp_env, monkeypatch, capsys):
     assert not run_pipx_cli(["--global", "environment"])
     captured = capsys.readouterr()
-    assert "PIPX_HOME=/opt/pipx" in captured.out
-    assert "PIPX_BIN_DIR=/usr/local/bin" in captured.out
-    assert "PIPX_MAN_DIR=/usr/local/share/man" in captured.out
-    assert "PIPX_SHARED_LIBS=/opt/pipx/shared" in captured.out
-    assert "PIPX_LOCAL_VENVS=/opt/pipx/venvs" in captured.out
-    assert "PIPX_LOG_DIR=/opt/pipx/logs" in captured.out
-    assert "PIPX_TRASH_DIR=/opt/pipx/.trash" in captured.out
-    assert "PIPX_VENV_CACHEDIR=/opt/pipx/.cache" in captured.out
+    assert fnmatch.fnmatch(captured.out, "*PIPX_HOME=*global/pipxhome*")
+    assert fnmatch.fnmatch(captured.out, "*PIPX_BIN_DIR=*global_otherdir/pipxbindir*")
+    assert fnmatch.fnmatch(captured.out, "*PIPX_MAN_DIR=*global_otherdir/pipxmandir*")
+    assert "PIPX_SHARED_LIBS" in captured.out
+    assert fnmatch.fnmatch(captured.out, "*PIPX_LOCAL_VENVS=*global/pipxhome/venvs*")
+    assert fnmatch.fnmatch(captured.out, "*PIPX_LOG_DIR=*global/pipxhome/logs*")
+    assert fnmatch.fnmatch(captured.out, "*PIPX_TRASH_DIR=*global/pipxhome/.trash*")
+    assert fnmatch.fnmatch(captured.out, "*PIPX_VENV_CACHEDIR=*global/pipxhome/.cache*")
     # Checking just for the sake of completeness
     assert "PIPX_DEFAULT_PYTHON" in captured.out
     assert "USE_EMOJI" in captured.out
-    # reset to local to avoid side effects
-    paths.ctx.make_local()

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,10 +1,15 @@
+import os
 import sys
 from pathlib import Path
 
 import pytest  # type: ignore
 
 from helpers import run_pipx_cli
-from pipx.constants import load_dir_from_environ
+
+
+def load_dir_from_environ(dir_name: str, default: Path) -> Path:
+    env = os.environ.get(dir_name, default)
+    return Path(os.path.expanduser(env)).resolve()
 
 
 def test_cli(monkeypatch, capsys):

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -49,3 +49,19 @@ def test_resolve_user_dir_in_env_paths_env_not_set(monkeypatch):
     home = Path.home()
     env_dir = load_dir_from_environ("TEST_DIR", Path.home())
     assert env_dir == home
+
+
+def test_cli_global(monkeypatch, capsys):
+    assert not run_pipx_cli(["--global", "environment"])
+    captured = capsys.readouterr()
+    assert "PIPX_HOME=/opt/pipx" in captured.out
+    assert "PIPX_BIN_DIR=/usr/local/bin" in captured.out
+    assert "PIPX_MAN_DIR=/usr/local/share/man" in captured.out
+    assert "PIPX_SHARED_LIBS=/opt/pipx/shared" in captured.out
+    assert "PIPX_LOCAL_VENVS=/opt/pipx/venvs" in captured.out
+    assert "PIPX_LOG_DIR=/opt/pipx/logs" in captured.out
+    assert "PIPX_TRASH_DIR=/opt/pipx/.trash" in captured.out
+    assert "PIPX_VENV_CACHEDIR=/opt/pipx/.cache" in captured.out
+    # Checking just for the sake of completeness
+    assert "PIPX_DEFAULT_PYTHON" in captured.out
+    assert "USE_EMOJI" in captured.out

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,10 +1,7 @@
 import os
-import sys
 from pathlib import Path
 
-import pytest  # type: ignore
-
-from helpers import run_pipx_cli
+from helpers import run_pipx_cli, skip_if_windows
 
 
 def load_dir_from_environ(dir_name: str, default: Path) -> Path:
@@ -59,9 +56,8 @@ def test_resolve_user_dir_in_env_paths_env_not_set(monkeypatch):
     assert env_dir == home
 
 
+@skip_if_windows
 def test_cli_global(monkeypatch, capsys):
-    if sys.platform.startswith("win"):
-        pytest.skip("This behavior is undefined on Windows")
     assert not run_pipx_cli(["--global", "environment"])
     captured = capsys.readouterr()
     assert "PIPX_HOME=/opt/pipx" in captured.out

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -10,17 +10,18 @@ def load_dir_from_environ(dir_name: str, default: Path) -> Path:
     return Path(os.path.expanduser(env)).resolve()
 
 
-def test_cli(monkeypatch, capsys):
+def test_cli(pipx_temp_env, monkeypatch, capsys):
     assert not run_pipx_cli(["environment"])
     captured = capsys.readouterr()
-    assert "PIPX_HOME" in captured.out
-    assert "PIPX_BIN_DIR" in captured.out
-    assert "PIPX_MAN_DIR" in captured.out
+    assert fnmatch.fnmatch(captured.out, "*PIPX_HOME=*subdir/pipxhome*")
+    assert fnmatch.fnmatch(captured.out, "*PIPX_BIN_DIR=*otherdir/pipxbindir*")
+    assert fnmatch.fnmatch(captured.out, "*PIPX_MAN_DIR=*otherdir/pipxmandir*")
     assert "PIPX_SHARED_LIBS" in captured.out
-    assert "PIPX_LOCAL_VENVS" in captured.out
-    assert "PIPX_LOG_DIR" in captured.out
-    assert "PIPX_TRASH_DIR" in captured.out
-    assert "PIPX_VENV_CACHEDIR" in captured.out
+    assert fnmatch.fnmatch(captured.out, "*PIPX_LOCAL_VENVS=*subdir/pipxhome/venvs*")
+    assert fnmatch.fnmatch(captured.out, "*PIPX_LOG_DIR=*subdir/pipxhome/logs*")
+    assert fnmatch.fnmatch(captured.out, "*PIPX_TRASH_DIR=*subdir/pipxhome/.trash*")
+    assert fnmatch.fnmatch(captured.out, "*PIPX_VENV_CACHEDIR=*subdir/pipxhome/.cache*")
+    # Checking just for the sake of completeness
     assert "PIPX_DEFAULT_PYTHON" in captured.out
     assert "USE_EMOJI" in captured.out
     assert "Environment variables (set by user):" in captured.out

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -9,6 +9,11 @@ def test_inject_simple(pipx_temp_env, capsys):
     assert not run_pipx_cli(["inject", "pycowsay", PKG["black"]["spec"]])
 
 
+def test_inject_simple_global(pipx_temp_env, capsys):
+    assert not run_pipx_cli(["--global", "install", "pycowsay"])
+    assert not run_pipx_cli(["--global", "inject", "pycowsay", PKG["black"]["spec"]])
+
+
 @pytest.mark.parametrize("metadata_version", PIPX_METADATA_LEGACY_VERSIONS)
 def test_inject_simple_legacy_venv(pipx_temp_env, capsys, metadata_version):
     assert not run_pipx_cli(["install", "pycowsay"])
@@ -41,9 +46,15 @@ def test_inject_include_apps(pipx_temp_env, capsys, with_suffix):
         install_args = [f"--suffix={suffix}"]
 
     assert not run_pipx_cli(["install", "pycowsay", *install_args])
-    assert not run_pipx_cli(["inject", f"pycowsay{suffix}", PKG["black"]["spec"], "--include-deps"])
+    assert not run_pipx_cli(
+        ["inject", f"pycowsay{suffix}", PKG["black"]["spec"], "--include-deps"]
+    )
 
     if suffix:
-        assert run_pipx_cli(["inject", "pycowsay", PKG["black"]["spec"], "--include-deps"])
+        assert run_pipx_cli(
+            ["inject", "pycowsay", PKG["black"]["spec"], "--include-deps"]
+        )
 
-    assert not run_pipx_cli(["inject", f"pycowsay{suffix}", PKG["black"]["spec"], "--include-deps"])
+    assert not run_pipx_cli(
+        ["inject", f"pycowsay{suffix}", PKG["black"]["spec"], "--include-deps"]
+    )

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -2,7 +2,6 @@ import pytest  # type: ignore
 
 from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli, skip_if_windows
 from package_info import PKG
-from pipx import paths
 
 
 def test_inject_simple(pipx_temp_env, capsys):
@@ -14,8 +13,6 @@ def test_inject_simple(pipx_temp_env, capsys):
 def test_inject_simple_global(pipx_temp_env, capsys):
     assert not run_pipx_cli(["--global", "install", "pycowsay"])
     assert not run_pipx_cli(["--global", "inject", "pycowsay", PKG["black"]["spec"]])
-    # reset to local to avoid side effects
-    paths.ctx.make_local()
 
 
 @pytest.mark.parametrize("metadata_version", PIPX_METADATA_LEGACY_VERSIONS)

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -50,15 +50,9 @@ def test_inject_include_apps(pipx_temp_env, capsys, with_suffix):
         install_args = [f"--suffix={suffix}"]
 
     assert not run_pipx_cli(["install", "pycowsay", *install_args])
-    assert not run_pipx_cli(
-        ["inject", f"pycowsay{suffix}", PKG["black"]["spec"], "--include-deps"]
-    )
+    assert not run_pipx_cli(["inject", f"pycowsay{suffix}", PKG["black"]["spec"], "--include-deps"])
 
     if suffix:
-        assert run_pipx_cli(
-            ["inject", "pycowsay", PKG["black"]["spec"], "--include-deps"]
-        )
+        assert run_pipx_cli(["inject", "pycowsay", PKG["black"]["spec"], "--include-deps"])
 
-    assert not run_pipx_cli(
-        ["inject", f"pycowsay{suffix}", PKG["black"]["spec"], "--include-deps"]
-    )
+    assert not run_pipx_cli(["inject", f"pycowsay{suffix}", PKG["black"]["spec"], "--include-deps"])

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -2,6 +2,7 @@ import pytest  # type: ignore
 
 from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli, skip_if_windows
 from package_info import PKG
+from pipx import paths
 
 
 def test_inject_simple(pipx_temp_env, capsys):
@@ -13,6 +14,8 @@ def test_inject_simple(pipx_temp_env, capsys):
 def test_inject_simple_global(pipx_temp_env, capsys):
     assert not run_pipx_cli(["--global", "install", "pycowsay"])
     assert not run_pipx_cli(["--global", "inject", "pycowsay", PKG["black"]["spec"]])
+    # reset to local to avoid side effects
+    paths.ctx.make_local()
 
 
 @pytest.mark.parametrize("metadata_version", PIPX_METADATA_LEGACY_VERSIONS)

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -1,8 +1,6 @@
-import sys
-
 import pytest  # type: ignore
 
-from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli
+from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli, skip_if_windows
 from package_info import PKG
 
 
@@ -11,9 +9,8 @@ def test_inject_simple(pipx_temp_env, capsys):
     assert not run_pipx_cli(["inject", "pycowsay", PKG["black"]["spec"]])
 
 
+@skip_if_windows
 def test_inject_simple_global(pipx_temp_env, capsys):
-    if sys.platform.startswith("win"):
-        pytest.skip("This behavior is undefined on Windows")
     assert not run_pipx_cli(["--global", "install", "pycowsay"])
     assert not run_pipx_cli(["--global", "inject", "pycowsay", PKG["black"]["spec"]])
 

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest  # type: ignore
 
 from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli
@@ -10,6 +12,8 @@ def test_inject_simple(pipx_temp_env, capsys):
 
 
 def test_inject_simple_global(pipx_temp_env, capsys):
+    if sys.platform.startswith("win"):
+        pytest.skip("This behavior is undefined on Windows")
     assert not run_pipx_cli(["--global", "install", "pycowsay"])
     assert not run_pipx_cli(["--global", "inject", "pycowsay", PKG["black"]["spec"]])
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -16,9 +16,7 @@ TEST_DATA_PATH = "./testdata/test_package_specifier"
 
 def test_help_text(monkeypatch, capsys):
     mock_exit = mock.Mock(side_effect=ValueError("raised in test to exit early"))
-    with mock.patch.object(sys, "exit", mock_exit), pytest.raises(
-        ValueError, match="raised in test to exit early"
-    ):
+    with mock.patch.object(sys, "exit", mock_exit), pytest.raises(ValueError, match="raised in test to exit early"):
         run_pipx_cli(["install", "--help"])
     captured = capsys.readouterr()
     assert "apps you can run from anywhere" in captured.out
@@ -46,9 +44,7 @@ def install_packages(capsys, pipx_temp_env, caplog, packages, package_names=()):
     "package_name, package_spec",
     [("pycowsay", "pycowsay"), ("black", PKG["black"]["spec"])],
 )
-def test_install_easy_packages(
-    capsys, pipx_temp_env, caplog, package_name, package_spec
-):
+def test_install_easy_packages(capsys, pipx_temp_env, caplog, package_name, package_spec):
     install_packages(capsys, pipx_temp_env, caplog, [package_spec], [package_name])
 
 
@@ -66,9 +62,7 @@ def test_install_easy_multiple_packages(capsys, pipx_temp_env, caplog):
     "package_name, package_spec",
     [("pycowsay", "pycowsay"), ("black", PKG["black"]["spec"])],
 )
-def test_install_easy_packages_globally(
-    capsys, pipx_temp_env, caplog, package_name, package_spec
-):
+def test_install_easy_packages_globally(capsys, pipx_temp_env, caplog, package_name, package_spec):
     if sys.platform.startswith("win"):
         pytest.skip("This behavior is undefined on Windows")
     install_packages(capsys, pipx_temp_env, caplog, [package_spec], [package_name])
@@ -83,9 +77,7 @@ def test_install_easy_packages_globally(
         ("shell-functools", PKG["shell-functools"]["spec"]),
     ],
 )
-def test_install_tricky_packages(
-    capsys, pipx_temp_env, caplog, package_name, package_spec
-):
+def test_install_tricky_packages(capsys, pipx_temp_env, caplog, package_name, package_spec):
     if os.getenv("FAST"):
         pytest.skip("skipping slow tests")
     if sys.platform.startswith("win") and package_name == "ansible":
@@ -112,9 +104,7 @@ def test_install_tricky_multiple_packages(capsys, pipx_temp_env, caplog):
         ("nox", "https://github.com/wntrblm/nox/archive/2022.1.7.zip"),
     ],
 )
-def test_install_package_specs(
-    capsys, pipx_temp_env, caplog, package_name, package_spec
-):
+def test_install_package_specs(capsys, pipx_temp_env, caplog, package_name, package_spec):
     install_packages(capsys, pipx_temp_env, caplog, [package_spec], [package_name])
 
 
@@ -144,10 +134,7 @@ def test_install_same_package_twice_no_force(pipx_temp_env, capsys):
     assert not run_pipx_cli(["install", "pycowsay"])
     assert not run_pipx_cli(["install", "pycowsay"])
     captured = capsys.readouterr()
-    assert (
-        "'pycowsay' already seems to be installed. Not modifying existing installation"
-        in captured.out
-    )
+    assert "'pycowsay' already seems to be installed. Not modifying existing installation" in captured.out
 
 
 def test_include_deps(pipx_temp_env, capsys):
@@ -162,9 +149,7 @@ def test_include_deps(pipx_temp_env, capsys):
         ("tox-ini-fmt", PKG["tox-ini-fmt"]["spec"]),
     ],
 )
-def test_name_tricky_characters(
-    caplog, capsys, pipx_temp_env, package_name, package_spec
-):
+def test_name_tricky_characters(caplog, capsys, pipx_temp_env, package_name, package_spec):
     install_packages(capsys, pipx_temp_env, caplog, [package_spec], [package_name])
 
 
@@ -175,9 +160,7 @@ def test_extra(pipx_temp_env, capsys):
 
 
 def test_install_local_extra(pipx_temp_env, capsys, monkeypatch, root):
-    assert not run_pipx_cli(
-        ["install", str(root / f"{TEST_DATA_PATH}/local_extras[cow]"), "--include-deps"]
-    )
+    assert not run_pipx_cli(["install", str(root / f"{TEST_DATA_PATH}/local_extras[cow]"), "--include-deps"])
     captured = capsys.readouterr()
     assert f"- {app_name('pycowsay')}\n" in captured.out
     assert f"- {Path('man6/pycowsay.6')}\n" in captured.out
@@ -185,18 +168,14 @@ def test_install_local_extra(pipx_temp_env, capsys, monkeypatch, root):
 
 def test_path_warning(pipx_temp_env, capsys, monkeypatch, caplog):
     assert not run_pipx_cli(["install", "pycowsay"])
-    assert "is not on your PATH environment variable" not in unwrap_log_text(
-        caplog.text
-    )
+    assert "is not on your PATH environment variable" not in unwrap_log_text(caplog.text)
 
     monkeypatch.setenv("PATH", "")
     assert not run_pipx_cli(["install", "pycowsay", "--force"])
     assert "is not on your PATH environment variable" in unwrap_log_text(caplog.text)
 
 
-def test_existing_symlink_points_to_existing_wrong_location_warning(
-    pipx_temp_env, caplog, capsys
-):
+def test_existing_symlink_points_to_existing_wrong_location_warning(pipx_temp_env, caplog, capsys):
     if sys.platform.startswith("win"):
         pytest.skip("pipx does not use symlinks on Windows")
 
@@ -211,14 +190,12 @@ def test_existing_symlink_points_to_existing_wrong_location_warning(
     assert "is not on your PATH environment variable" not in captured.err
 
 
-def test_existing_man_page_symlink_points_to_existing_wrong_location_warning(
-    pipx_temp_env, caplog, capsys
-):
+def test_existing_man_page_symlink_points_to_existing_wrong_location_warning(pipx_temp_env, caplog, capsys):
     if sys.platform.startswith("win"):
         pytest.skip("pipx does not use symlinks on Windows")
 
-    (constants.LOCAL_MAN_DIR / "man6").mkdir(exist_ok=True, parents=True)
-    (constants.LOCAL_MAN_DIR / "man6" / "pycowsay.6").symlink_to(os.devnull)
+    (paths.ctx.man_dir / "man6").mkdir(exist_ok=True, parents=True)
+    (paths.ctx.man_dir / "man6" / "pycowsay.6").symlink_to(os.devnull)
     assert not run_pipx_cli(["install", "pycowsay"])
     captured = capsys.readouterr()
     assert "File exists at" in unwrap_log_text(caplog.text)
@@ -242,8 +219,8 @@ def test_existing_man_page_symlink_points_to_nothing(pipx_temp_env, capsys):
     if sys.platform.startswith("win"):
         pytest.skip("pipx does not use symlinks on Windows")
 
-    (constants.LOCAL_MAN_DIR / "man6").mkdir(exist_ok=True, parents=True)
-    (constants.LOCAL_MAN_DIR / "man6" / "pycowsay.6").symlink_to("/asdf/jkl")
+    (paths.ctx.man_dir / "man6").mkdir(exist_ok=True, parents=True)
+    (paths.ctx.man_dir / "man6" / "pycowsay.6").symlink_to("/asdf/jkl")
     assert not run_pipx_cli(["install", "pycowsay"])
     captured = capsys.readouterr()
     # pipx should realize the symlink points to nothing and replace it,
@@ -304,7 +281,7 @@ def test_man_page_install(pipx_temp_env, capsys):
     assert not run_pipx_cli(["install", "pycowsay"])
     captured = capsys.readouterr()
     assert f"- {Path('man6/pycowsay.6')}" in captured.out
-    assert (constants.LOCAL_MAN_DIR / "man6" / "pycowsay.6").exists()
+    assert (paths.ctx.man_dir / "man6" / "pycowsay.6").exists()
 
 
 def test_install_pip_failure(pipx_temp_env, capsys):
@@ -313,9 +290,7 @@ def test_install_pip_failure(pipx_temp_env, capsys):
 
     assert "Fatal error from pip" in captured.err
 
-    pip_log_file_match = re.search(
-        r"Full pip output in file:\s+(\S.+)$", captured.err, re.MULTILINE
-    )
+    pip_log_file_match = re.search(r"Full pip output in file:\s+(\S.+)$", captured.err, re.MULTILINE)
     assert pip_log_file_match
     assert Path(pip_log_file_match[1]).exists()
 
@@ -332,9 +307,7 @@ def test_install_local_archive(pipx_temp_env, monkeypatch, capsys, root):
 
 
 def test_force_install_changes(pipx_temp_env, capsys):
-    assert not run_pipx_cli(
-        ["install", "https://github.com/wntrblm/nox/archive/2022.1.7.zip"]
-    )
+    assert not run_pipx_cli(["install", "https://github.com/wntrblm/nox/archive/2022.1.7.zip"])
     captured = capsys.readouterr()
     assert "2022.1.7" in captured.out
 
@@ -349,9 +322,7 @@ def test_force_install_changes_editable(pipx_temp_env, root, capsys):
     captured = capsys.readouterr()
     assert "empty-project" in captured.out
 
-    assert not run_pipx_cli(
-        ["install", "--editable", empty_project_path_as_string, "--force"]
-    )
+    assert not run_pipx_cli(["install", "--editable", empty_project_path_as_string, "--force"])
     captured = capsys.readouterr()
     assert "Installing to existing venv 'empty-project'" in captured.out
 
@@ -378,9 +349,7 @@ def test_passed_python_and_force_flag_warning(pipx_temp_env, capsys):
     assert "--python is ignored when --force is passed." not in captured.out
 
 
-def test_install_run_in_separate_directory(
-    caplog, capsys, pipx_temp_env, monkeypatch, tmp_path
-):
+def test_install_run_in_separate_directory(caplog, capsys, pipx_temp_env, monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     f = Path("argparse.py")
     f.touch()

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -16,7 +16,9 @@ TEST_DATA_PATH = "./testdata/test_package_specifier"
 
 def test_help_text(monkeypatch, capsys):
     mock_exit = mock.Mock(side_effect=ValueError("raised in test to exit early"))
-    with mock.patch.object(sys, "exit", mock_exit), pytest.raises(ValueError, match="raised in test to exit early"):
+    with mock.patch.object(sys, "exit", mock_exit), pytest.raises(
+        ValueError, match="raised in test to exit early"
+    ):
         run_pipx_cli(["install", "--help"])
     captured = capsys.readouterr()
     assert "apps you can run from anywhere" in captured.out
@@ -44,7 +46,9 @@ def install_packages(capsys, pipx_temp_env, caplog, packages, package_names=()):
     "package_name, package_spec",
     [("pycowsay", "pycowsay"), ("black", PKG["black"]["spec"])],
 )
-def test_install_easy_packages(capsys, pipx_temp_env, caplog, package_name, package_spec):
+def test_install_easy_packages(
+    capsys, pipx_temp_env, caplog, package_name, package_spec
+):
     install_packages(capsys, pipx_temp_env, caplog, [package_spec], [package_name])
 
 
@@ -67,7 +71,7 @@ def test_install_easy_packages_globally(
 ):
     if sys.platform.startswith("win"):
         pytest.skip("This behavior is undefined on Windows")
-    install_package(capsys, pipx_temp_env, caplog, package_spec, package_name)
+    install_packages(capsys, pipx_temp_env, caplog, [package_spec], [package_name])
 
 
 @pytest.mark.parametrize(
@@ -79,7 +83,9 @@ def test_install_easy_packages_globally(
         ("shell-functools", PKG["shell-functools"]["spec"]),
     ],
 )
-def test_install_tricky_packages(capsys, pipx_temp_env, caplog, package_name, package_spec):
+def test_install_tricky_packages(
+    capsys, pipx_temp_env, caplog, package_name, package_spec
+):
     if os.getenv("FAST"):
         pytest.skip("skipping slow tests")
     if sys.platform.startswith("win") and package_name == "ansible":
@@ -106,7 +112,9 @@ def test_install_tricky_multiple_packages(capsys, pipx_temp_env, caplog):
         ("nox", "https://github.com/wntrblm/nox/archive/2022.1.7.zip"),
     ],
 )
-def test_install_package_specs(capsys, pipx_temp_env, caplog, package_name, package_spec):
+def test_install_package_specs(
+    capsys, pipx_temp_env, caplog, package_name, package_spec
+):
     install_packages(capsys, pipx_temp_env, caplog, [package_spec], [package_name])
 
 
@@ -136,7 +144,10 @@ def test_install_same_package_twice_no_force(pipx_temp_env, capsys):
     assert not run_pipx_cli(["install", "pycowsay"])
     assert not run_pipx_cli(["install", "pycowsay"])
     captured = capsys.readouterr()
-    assert "'pycowsay' already seems to be installed. Not modifying existing installation" in captured.out
+    assert (
+        "'pycowsay' already seems to be installed. Not modifying existing installation"
+        in captured.out
+    )
 
 
 def test_include_deps(pipx_temp_env, capsys):
@@ -151,7 +162,9 @@ def test_include_deps(pipx_temp_env, capsys):
         ("tox-ini-fmt", PKG["tox-ini-fmt"]["spec"]),
     ],
 )
-def test_name_tricky_characters(caplog, capsys, pipx_temp_env, package_name, package_spec):
+def test_name_tricky_characters(
+    caplog, capsys, pipx_temp_env, package_name, package_spec
+):
     install_packages(capsys, pipx_temp_env, caplog, [package_spec], [package_name])
 
 
@@ -162,7 +175,9 @@ def test_extra(pipx_temp_env, capsys):
 
 
 def test_install_local_extra(pipx_temp_env, capsys, monkeypatch, root):
-    assert not run_pipx_cli(["install", str(root / f"{TEST_DATA_PATH}/local_extras[cow]"), "--include-deps"])
+    assert not run_pipx_cli(
+        ["install", str(root / f"{TEST_DATA_PATH}/local_extras[cow]"), "--include-deps"]
+    )
     captured = capsys.readouterr()
     assert f"- {app_name('pycowsay')}\n" in captured.out
     assert f"- {Path('man6/pycowsay.6')}\n" in captured.out
@@ -170,14 +185,18 @@ def test_install_local_extra(pipx_temp_env, capsys, monkeypatch, root):
 
 def test_path_warning(pipx_temp_env, capsys, monkeypatch, caplog):
     assert not run_pipx_cli(["install", "pycowsay"])
-    assert "is not on your PATH environment variable" not in unwrap_log_text(caplog.text)
+    assert "is not on your PATH environment variable" not in unwrap_log_text(
+        caplog.text
+    )
 
     monkeypatch.setenv("PATH", "")
     assert not run_pipx_cli(["install", "pycowsay", "--force"])
     assert "is not on your PATH environment variable" in unwrap_log_text(caplog.text)
 
 
-def test_existing_symlink_points_to_existing_wrong_location_warning(pipx_temp_env, caplog, capsys):
+def test_existing_symlink_points_to_existing_wrong_location_warning(
+    pipx_temp_env, caplog, capsys
+):
     if sys.platform.startswith("win"):
         pytest.skip("pipx does not use symlinks on Windows")
 
@@ -192,7 +211,9 @@ def test_existing_symlink_points_to_existing_wrong_location_warning(pipx_temp_en
     assert "is not on your PATH environment variable" not in captured.err
 
 
-def test_existing_man_page_symlink_points_to_existing_wrong_location_warning(pipx_temp_env, caplog, capsys):
+def test_existing_man_page_symlink_points_to_existing_wrong_location_warning(
+    pipx_temp_env, caplog, capsys
+):
     if sys.platform.startswith("win"):
         pytest.skip("pipx does not use symlinks on Windows")
 
@@ -292,7 +313,9 @@ def test_install_pip_failure(pipx_temp_env, capsys):
 
     assert "Fatal error from pip" in captured.err
 
-    pip_log_file_match = re.search(r"Full pip output in file:\s+(\S.+)$", captured.err, re.MULTILINE)
+    pip_log_file_match = re.search(
+        r"Full pip output in file:\s+(\S.+)$", captured.err, re.MULTILINE
+    )
     assert pip_log_file_match
     assert Path(pip_log_file_match[1]).exists()
 
@@ -309,7 +332,9 @@ def test_install_local_archive(pipx_temp_env, monkeypatch, capsys, root):
 
 
 def test_force_install_changes(pipx_temp_env, capsys):
-    assert not run_pipx_cli(["install", "https://github.com/wntrblm/nox/archive/2022.1.7.zip"])
+    assert not run_pipx_cli(
+        ["install", "https://github.com/wntrblm/nox/archive/2022.1.7.zip"]
+    )
     captured = capsys.readouterr()
     assert "2022.1.7" in captured.out
 
@@ -324,7 +349,9 @@ def test_force_install_changes_editable(pipx_temp_env, root, capsys):
     captured = capsys.readouterr()
     assert "empty-project" in captured.out
 
-    assert not run_pipx_cli(["install", "--editable", empty_project_path_as_string, "--force"])
+    assert not run_pipx_cli(
+        ["install", "--editable", empty_project_path_as_string, "--force"]
+    )
     captured = capsys.readouterr()
     assert "Installing to existing venv 'empty-project'" in captured.out
 
@@ -351,7 +378,9 @@ def test_passed_python_and_force_flag_warning(pipx_temp_env, capsys):
     assert "--python is ignored when --force is passed." not in captured.out
 
 
-def test_install_run_in_separate_directory(caplog, capsys, pipx_temp_env, monkeypatch, tmp_path):
+def test_install_run_in_separate_directory(
+    caplog, capsys, pipx_temp_env, monkeypatch, tmp_path
+):
     monkeypatch.chdir(tmp_path)
     f = Path("argparse.py")
     f.touch()

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -9,7 +9,7 @@ import pytest  # type: ignore
 
 from helpers import app_name, run_pipx_cli, unwrap_log_text
 from package_info import PKG
-from pipx import constants
+from pipx import paths
 
 TEST_DATA_PATH = "./testdata/test_package_specifier"
 
@@ -110,12 +110,6 @@ def test_install_package_specs(capsys, pipx_temp_env, caplog, package_name, pack
     install_packages(capsys, pipx_temp_env, caplog, [package_spec], [package_name])
 
 
-def test_global_install(pipx_temp_env, capsys):
-    run_pipx_cli(["--global", "install", "pycowsay"])
-    captured = capsys.readouterr()
-    assert "installed package" in captured.out
-
-
 def test_force_install(pipx_temp_env, capsys):
     run_pipx_cli(["install", "pycowsay"])
     captured = capsys.readouterr()
@@ -187,8 +181,8 @@ def test_existing_symlink_points_to_existing_wrong_location_warning(pipx_temp_en
     if sys.platform.startswith("win"):
         pytest.skip("pipx does not use symlinks on Windows")
 
-    constants.PIPX_DIRS.BIN_DIR.mkdir(exist_ok=True, parents=True)
-    (constants.PIPX_DIRS.BIN_DIR / "pycowsay").symlink_to(os.devnull)
+    paths.ctx.bin_dir.mkdir(exist_ok=True, parents=True)
+    (paths.ctx.bin_dir / "pycowsay").symlink_to(os.devnull)
     assert not run_pipx_cli(["install", "pycowsay"])
     captured = capsys.readouterr()
     assert "File exists at" in unwrap_log_text(caplog.text)
@@ -214,8 +208,8 @@ def test_existing_symlink_points_to_nothing(pipx_temp_env, capsys):
     if sys.platform.startswith("win"):
         pytest.skip("pipx does not use symlinks on Windows")
 
-    constants.PIPX_DIRS.BIN_DIR.mkdir(exist_ok=True, parents=True)
-    (constants.PIPX_DIRS.BIN_DIR / "pycowsay").symlink_to("/asdf/jkl")
+    paths.ctx.bin_dir.mkdir(exist_ok=True, parents=True)
+    (paths.ctx.bin_dir / "pycowsay").symlink_to("/asdf/jkl")
     assert not run_pipx_cli(["install", "pycowsay"])
     captured = capsys.readouterr()
     # pipx should realize the symlink points to nothing and replace it,
@@ -281,8 +275,8 @@ def test_install_suffix(pipx_temp_env, capsys):
     name_b = app_name(f"{name}{suffix}")
     assert f"- {name_b}" in captured.out
 
-    assert (constants.PIPX_DIRS.BIN_DIR / name_a).exists()
-    assert (constants.PIPX_DIRS.BIN_DIR / name_b).exists()
+    assert (paths.ctx.bin_dir / name_a).exists()
+    assert (paths.ctx.bin_dir / name_b).exists()
 
 
 def test_man_page_install(pipx_temp_env, capsys):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -7,7 +7,7 @@ from unittest import mock
 
 import pytest  # type: ignore
 
-from helpers import app_name, run_pipx_cli, unwrap_log_text
+from helpers import app_name, run_pipx_cli, skip_if_windows, unwrap_log_text
 from package_info import PKG
 from pipx import paths
 
@@ -62,9 +62,8 @@ def test_install_easy_multiple_packages(capsys, pipx_temp_env, caplog):
     "package_name, package_spec",
     [("pycowsay", "pycowsay"), ("black", PKG["black"]["spec"])],
 )
+@skip_if_windows
 def test_install_easy_packages_globally(capsys, pipx_temp_env, caplog, package_name, package_spec):
-    if sys.platform.startswith("win"):
-        pytest.skip("This behavior is undefined on Windows")
     install_packages(capsys, pipx_temp_env, caplog, [package_spec], [package_name])
 
 
@@ -175,10 +174,8 @@ def test_path_warning(pipx_temp_env, capsys, monkeypatch, caplog):
     assert "is not on your PATH environment variable" in unwrap_log_text(caplog.text)
 
 
+@skip_if_windows
 def test_existing_symlink_points_to_existing_wrong_location_warning(pipx_temp_env, caplog, capsys):
-    if sys.platform.startswith("win"):
-        pytest.skip("pipx does not use symlinks on Windows")
-
     paths.ctx.bin_dir.mkdir(exist_ok=True, parents=True)
     (paths.ctx.bin_dir / "pycowsay").symlink_to(os.devnull)
     assert not run_pipx_cli(["install", "pycowsay"])
@@ -190,10 +187,8 @@ def test_existing_symlink_points_to_existing_wrong_location_warning(pipx_temp_en
     assert "is not on your PATH environment variable" not in captured.err
 
 
+@skip_if_windows
 def test_existing_man_page_symlink_points_to_existing_wrong_location_warning(pipx_temp_env, caplog, capsys):
-    if sys.platform.startswith("win"):
-        pytest.skip("pipx does not use symlinks on Windows")
-
     (paths.ctx.man_dir / "man6").mkdir(exist_ok=True, parents=True)
     (paths.ctx.man_dir / "man6" / "pycowsay.6").symlink_to(os.devnull)
     assert not run_pipx_cli(["install", "pycowsay"])
@@ -202,10 +197,8 @@ def test_existing_man_page_symlink_points_to_existing_wrong_location_warning(pip
     assert "symlink missing or pointing to unexpected location" in captured.out
 
 
+@skip_if_windows
 def test_existing_symlink_points_to_nothing(pipx_temp_env, capsys):
-    if sys.platform.startswith("win"):
-        pytest.skip("pipx does not use symlinks on Windows")
-
     paths.ctx.bin_dir.mkdir(exist_ok=True, parents=True)
     (paths.ctx.bin_dir / "pycowsay").symlink_to("/asdf/jkl")
     assert not run_pipx_cli(["install", "pycowsay"])
@@ -215,10 +208,8 @@ def test_existing_symlink_points_to_nothing(pipx_temp_env, capsys):
     assert "symlink missing or pointing to unexpected location" not in captured.out
 
 
+@skip_if_windows
 def test_existing_man_page_symlink_points_to_nothing(pipx_temp_env, capsys):
-    if sys.platform.startswith("win"):
-        pytest.skip("pipx does not use symlinks on Windows")
-
     (paths.ctx.man_dir / "man6").mkdir(exist_ok=True, parents=True)
     (paths.ctx.man_dir / "man6" / "pycowsay.6").symlink_to("/asdf/jkl")
     assert not run_pipx_cli(["install", "pycowsay"])

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -65,6 +65,8 @@ def test_install_easy_multiple_packages(capsys, pipx_temp_env, caplog):
 def test_install_easy_packages_globally(
     capsys, pipx_temp_env, caplog, package_name, package_spec
 ):
+    if sys.platform.startswith("win"):
+        pytest.skip("This behavior is undefined on Windows")
     install_package(capsys, pipx_temp_env, caplog, package_spec, package_name)
 
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -60,6 +60,16 @@ def test_install_easy_multiple_packages(capsys, pipx_temp_env, caplog):
 
 @pytest.mark.parametrize(
     "package_name, package_spec",
+    [("pycowsay", "pycowsay"), ("black", PKG["black"]["spec"])],
+)
+def test_install_easy_packages_globally(
+    capsys, pipx_temp_env, caplog, package_name, package_spec
+):
+    install_package(capsys, pipx_temp_env, caplog, package_spec, package_name)
+
+
+@pytest.mark.parametrize(
+    "package_name, package_spec",
     [
         ("cloudtoken", PKG["cloudtoken"]["spec"]),
         ("awscli", PKG["awscli"]["spec"]),
@@ -96,6 +106,12 @@ def test_install_tricky_multiple_packages(capsys, pipx_temp_env, caplog):
 )
 def test_install_package_specs(capsys, pipx_temp_env, caplog, package_name, package_spec):
     install_packages(capsys, pipx_temp_env, caplog, [package_spec], [package_name])
+
+
+def test_global_install(pipx_temp_env, capsys):
+    run_pipx_cli(["--global", "install", "pycowsay"])
+    captured = capsys.readouterr()
+    assert "installed package" in captured.out
 
 
 def test_force_install(pipx_temp_env, capsys):
@@ -169,8 +185,8 @@ def test_existing_symlink_points_to_existing_wrong_location_warning(pipx_temp_en
     if sys.platform.startswith("win"):
         pytest.skip("pipx does not use symlinks on Windows")
 
-    constants.LOCAL_BIN_DIR.mkdir(exist_ok=True, parents=True)
-    (constants.LOCAL_BIN_DIR / "pycowsay").symlink_to(os.devnull)
+    constants.PIPX_DIRS.BIN_DIR.mkdir(exist_ok=True, parents=True)
+    (constants.PIPX_DIRS.BIN_DIR / "pycowsay").symlink_to(os.devnull)
     assert not run_pipx_cli(["install", "pycowsay"])
     captured = capsys.readouterr()
     assert "File exists at" in unwrap_log_text(caplog.text)
@@ -196,8 +212,8 @@ def test_existing_symlink_points_to_nothing(pipx_temp_env, capsys):
     if sys.platform.startswith("win"):
         pytest.skip("pipx does not use symlinks on Windows")
 
-    constants.LOCAL_BIN_DIR.mkdir(exist_ok=True, parents=True)
-    (constants.LOCAL_BIN_DIR / "pycowsay").symlink_to("/asdf/jkl")
+    constants.PIPX_DIRS.BIN_DIR.mkdir(exist_ok=True, parents=True)
+    (constants.PIPX_DIRS.BIN_DIR / "pycowsay").symlink_to("/asdf/jkl")
     assert not run_pipx_cli(["install", "pycowsay"])
     captured = capsys.readouterr()
     # pipx should realize the symlink points to nothing and replace it,
@@ -263,8 +279,8 @@ def test_install_suffix(pipx_temp_env, capsys):
     name_b = app_name(f"{name}{suffix}")
     assert f"- {name_b}" in captured.out
 
-    assert (constants.LOCAL_BIN_DIR / name_a).exists()
-    assert (constants.LOCAL_BIN_DIR / name_b).exists()
+    assert (constants.PIPX_DIRS.BIN_DIR / name_a).exists()
+    assert (constants.PIPX_DIRS.BIN_DIR / name_b).exists()
 
 
 def test_man_page_install(pipx_temp_env, capsys):

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -6,8 +6,9 @@ from unittest.mock import Mock
 import pytest  # type: ignore
 
 import pipx.interpreter
+import pipx.paths
 import pipx.standalone_python
-from pipx.constants import PIPX_STANDALONE_PYTHON_CACHEDIR, WINDOWS
+from pipx.constants import WINDOWS
 from pipx.interpreter import (
     InterpreterResolutionError,
     _find_default_windows_python,
@@ -190,7 +191,7 @@ def test_fetch_missing_python(monkeypatch, mocked_github_api):
         python_path = find_python_interpreter(target_python, fetch_missing_python=True)
         assert python_path is not None
         assert target_python in python_path
-        assert str(PIPX_STANDALONE_PYTHON_CACHEDIR) in python_path
+        assert str(pipx.paths.ctx.standalone_python_cachedir) in python_path
         if WINDOWS:
             assert python_path.endswith("python.exe")
         else:

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -176,6 +176,8 @@ def test_fetch_missing_python(monkeypatch, mocked_github_api):
     def which(name):
         return None
 
+    pipx.paths.ctx.make_local()
+
     monkeypatch.setattr(shutil, "which", which)
 
     major = sys.version_info.major

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -176,8 +176,6 @@ def test_fetch_missing_python(monkeypatch, mocked_github_api):
     def which(name):
         return None
 
-    pipx.paths.ctx.make_local()
-
     monkeypatch.setattr(shutil, "which", which)
 
     major = sys.version_info.major

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -28,6 +28,8 @@ def test_cli(pipx_temp_env, monkeypatch, capsys):
 
 
 def test_cli_global(pipx_temp_env, monkeypatch, capsys):
+    if sys.platform.startswith("win"):
+        pytest.skip("This behavior is undefined on Windows")
     assert not run_pipx_cli(["--global", "list"])
     captured = capsys.readouterr()
     assert "nothing has been installed with pipx" in captured.err
@@ -101,7 +103,9 @@ def test_list_json(pipx_temp_env, capsys):
     assert sorted(json_parsed["venvs"].keys()) == ["pycowsay", "pylint"]
 
     # pycowsay venv
-    pycowsay_package_ref = create_package_info_ref("pycowsay", "pycowsay", pipx_venvs_dir)
+    pycowsay_package_ref = create_package_info_ref(
+        "pycowsay", "pycowsay", pipx_venvs_dir
+    )
     assert_package_metadata(
         PackageInfo(**json_parsed["venvs"]["pycowsay"]["metadata"]["main_package"]),
         pycowsay_package_ref,
@@ -113,18 +117,32 @@ def test_list_json(pipx_temp_env, capsys):
         "pylint",
         "pylint",
         pipx_venvs_dir,
-        **{"app_paths_of_dependencies": {"isort": [pipx_venvs_dir / "pylint" / venv_bin_dir / app_name("isort")]}},
+        **{
+            "app_paths_of_dependencies": {
+                "isort": [pipx_venvs_dir / "pylint" / venv_bin_dir / app_name("isort")]
+            }
+        },
     )
     assert_package_metadata(
         PackageInfo(**json_parsed["venvs"]["pylint"]["metadata"]["main_package"]),
         pylint_package_ref,
     )
-    assert sorted(json_parsed["venvs"]["pylint"]["metadata"]["injected_packages"].keys()) == ["isort"]
-    isort_package_ref = create_package_info_ref("pylint", "isort", pipx_venvs_dir, include_apps=False)
+    assert sorted(
+        json_parsed["venvs"]["pylint"]["metadata"]["injected_packages"].keys()
+    ) == ["isort"]
+    isort_package_ref = create_package_info_ref(
+        "pylint", "isort", pipx_venvs_dir, include_apps=False
+    )
     print(isort_package_ref)
-    print(PackageInfo(**json_parsed["venvs"]["pylint"]["metadata"]["injected_packages"]["isort"]))
+    print(
+        PackageInfo(
+            **json_parsed["venvs"]["pylint"]["metadata"]["injected_packages"]["isort"]
+        )
+    )
     assert_package_metadata(
-        PackageInfo(**json_parsed["venvs"]["pylint"]["metadata"]["injected_packages"]["isort"]),
+        PackageInfo(
+            **json_parsed["venvs"]["pylint"]["metadata"]["injected_packages"]["isort"]
+        ),
         isort_package_ref,
     )
 
@@ -141,7 +159,9 @@ def test_list_short(pipx_temp_env, monkeypatch, capsys):
     assert "pylint 2.3.1" in captured.out
 
 
-def test_list_standalone_interpreter(pipx_temp_env, monkeypatch, mocked_github_api, capsys):
+def test_list_standalone_interpreter(
+    pipx_temp_env, monkeypatch, mocked_github_api, capsys
+):
     def which(name):
         return None
 

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -27,6 +27,12 @@ def test_cli(pipx_temp_env, monkeypatch, capsys):
     assert "nothing has been installed with pipx" in captured.err
 
 
+def test_cli_global(pipx_temp_env, monkeypatch, capsys):
+    assert not run_pipx_cli(["--global", "list"])
+    captured = capsys.readouterr()
+    assert "nothing has been installed with pipx" in captured.err
+
+
 def test_missing_interpreter(pipx_temp_env, monkeypatch, capsys):
     assert not run_pipx_cli(["install", "pycowsay"])
 
@@ -77,7 +83,7 @@ def test_list_suffix_legacy_venv(pipx_temp_env, monkeypatch, capsys, metadata_ve
 
 
 def test_list_json(pipx_temp_env, capsys):
-    pipx_venvs_dir = constants.PIPX_HOME / "venvs"
+    pipx_venvs_dir = constants.PIPX_DIRS.HOME / "venvs"
     venv_bin_dir = "Scripts" if constants.WINDOWS else "bin"
 
     assert not run_pipx_cli(["install", PKG["pycowsay"]["spec"]])

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -30,6 +30,10 @@ def test_cli(pipx_temp_env, monkeypatch, capsys):
 
 @skip_if_windows
 def test_cli_global(pipx_temp_env, monkeypatch, capsys):
+    assert not run_pipx_cli(["install", "pycowsay"])
+    captured = capsys.readouterr()
+    assert "installed package" in captured.out
+
     assert not run_pipx_cli(["--global", "list"])
     captured = capsys.readouterr()
     assert "nothing has been installed with pipx" in captured.err

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -38,6 +38,9 @@ def test_cli_global(pipx_temp_env, monkeypatch, capsys):
     captured = capsys.readouterr()
     assert "nothing has been installed with pipx" in captured.err
 
+    # reset to local to avoid side effects
+    paths.ctx.make_local()
+
 
 def test_missing_interpreter(pipx_temp_env, monkeypatch, capsys):
     assert not run_pipx_cli(["install", "pycowsay"])

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -15,6 +15,7 @@ from helpers import (
     mock_legacy_venv,
     remove_venv_interpreter,
     run_pipx_cli,
+    skip_if_windows,
 )
 from package_info import PKG
 from pipx import constants, paths, shared_libs
@@ -27,9 +28,8 @@ def test_cli(pipx_temp_env, monkeypatch, capsys):
     assert "nothing has been installed with pipx" in captured.err
 
 
+@skip_if_windows
 def test_cli_global(pipx_temp_env, monkeypatch, capsys):
-    if sys.platform.startswith("win"):
-        pytest.skip("This behavior is undefined on Windows")
     assert not run_pipx_cli(["--global", "list"])
     captured = capsys.readouterr()
     assert "nothing has been installed with pipx" in captured.err

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -38,9 +38,6 @@ def test_cli_global(pipx_temp_env, monkeypatch, capsys):
     captured = capsys.readouterr()
     assert "nothing has been installed with pipx" in captured.err
 
-    # reset to local to avoid side effects
-    paths.ctx.make_local()
-
 
 def test_missing_interpreter(pipx_temp_env, monkeypatch, capsys):
     assert not run_pipx_cli(["install", "pycowsay"])

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -103,9 +103,7 @@ def test_list_json(pipx_temp_env, capsys):
     assert sorted(json_parsed["venvs"].keys()) == ["pycowsay", "pylint"]
 
     # pycowsay venv
-    pycowsay_package_ref = create_package_info_ref(
-        "pycowsay", "pycowsay", pipx_venvs_dir
-    )
+    pycowsay_package_ref = create_package_info_ref("pycowsay", "pycowsay", pipx_venvs_dir)
     assert_package_metadata(
         PackageInfo(**json_parsed["venvs"]["pycowsay"]["metadata"]["main_package"]),
         pycowsay_package_ref,
@@ -117,32 +115,18 @@ def test_list_json(pipx_temp_env, capsys):
         "pylint",
         "pylint",
         pipx_venvs_dir,
-        **{
-            "app_paths_of_dependencies": {
-                "isort": [pipx_venvs_dir / "pylint" / venv_bin_dir / app_name("isort")]
-            }
-        },
+        **{"app_paths_of_dependencies": {"isort": [pipx_venvs_dir / "pylint" / venv_bin_dir / app_name("isort")]}},
     )
     assert_package_metadata(
         PackageInfo(**json_parsed["venvs"]["pylint"]["metadata"]["main_package"]),
         pylint_package_ref,
     )
-    assert sorted(
-        json_parsed["venvs"]["pylint"]["metadata"]["injected_packages"].keys()
-    ) == ["isort"]
-    isort_package_ref = create_package_info_ref(
-        "pylint", "isort", pipx_venvs_dir, include_apps=False
-    )
+    assert sorted(json_parsed["venvs"]["pylint"]["metadata"]["injected_packages"].keys()) == ["isort"]
+    isort_package_ref = create_package_info_ref("pylint", "isort", pipx_venvs_dir, include_apps=False)
     print(isort_package_ref)
-    print(
-        PackageInfo(
-            **json_parsed["venvs"]["pylint"]["metadata"]["injected_packages"]["isort"]
-        )
-    )
+    print(PackageInfo(**json_parsed["venvs"]["pylint"]["metadata"]["injected_packages"]["isort"]))
     assert_package_metadata(
-        PackageInfo(
-            **json_parsed["venvs"]["pylint"]["metadata"]["injected_packages"]["isort"]
-        ),
+        PackageInfo(**json_parsed["venvs"]["pylint"]["metadata"]["injected_packages"]["isort"]),
         isort_package_ref,
     )
 
@@ -159,9 +143,7 @@ def test_list_short(pipx_temp_env, monkeypatch, capsys):
     assert "pylint 2.3.1" in captured.out
 
 
-def test_list_standalone_interpreter(
-    pipx_temp_env, monkeypatch, mocked_github_api, capsys
-):
+def test_list_standalone_interpreter(pipx_temp_env, monkeypatch, mocked_github_api, capsys):
     def which(name):
         return None
 

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -17,7 +17,7 @@ from helpers import (
     run_pipx_cli,
 )
 from package_info import PKG
-from pipx import constants, shared_libs
+from pipx import constants, paths, shared_libs
 from pipx.pipx_metadata_file import PackageInfo, _json_decoder_object_hook
 
 
@@ -85,7 +85,7 @@ def test_list_suffix_legacy_venv(pipx_temp_env, monkeypatch, capsys, metadata_ve
 
 
 def test_list_json(pipx_temp_env, capsys):
-    pipx_venvs_dir = constants.PIPX_DIRS.HOME / "venvs"
+    pipx_venvs_dir = paths.ctx.home / "venvs"
     venv_bin_dir = "Scripts" if constants.WINDOWS else "bin"
 
     assert not run_pipx_cli(["install", PKG["pycowsay"]["spec"]])

--- a/tests/test_pipx_metadata_file.py
+++ b/tests/test_pipx_metadata_file.py
@@ -3,9 +3,9 @@ from pathlib import Path
 
 import pytest  # type: ignore
 
-import pipx.constants
 from helpers import assert_package_metadata, create_package_info_ref, run_pipx_cli
 from package_info import PKG
+from pipx import paths
 from pipx.pipx_metadata_file import PackageInfo, PipxMetadata
 from pipx.util import PipxError
 
@@ -89,7 +89,7 @@ def test_pipx_metadata_file_validation(tmp_path, test_package):
 
 
 def test_package_install(monkeypatch, tmp_path, pipx_temp_env):
-    pipx_venvs_dir = pipx.constants.PIPX_DIRS.HOME / "venvs"
+    pipx_venvs_dir = paths.ctx.home / "venvs"
 
     run_pipx_cli(["install", PKG["pycowsay"]["spec"]])
     assert (pipx_venvs_dir / "pycowsay" / "pipx_metadata.json").is_file()
@@ -101,7 +101,7 @@ def test_package_install(monkeypatch, tmp_path, pipx_temp_env):
 
 
 def test_package_inject(monkeypatch, tmp_path, pipx_temp_env):
-    pipx_venvs_dir = pipx.constants.PIPX_DIRS.HOME / "venvs"
+    pipx_venvs_dir = paths.ctx.home / "venvs"
 
     run_pipx_cli(["install", PKG["pycowsay"]["spec"]])
     run_pipx_cli(["inject", "pycowsay", PKG["black"]["spec"]])

--- a/tests/test_pipx_metadata_file.py
+++ b/tests/test_pipx_metadata_file.py
@@ -89,7 +89,7 @@ def test_pipx_metadata_file_validation(tmp_path, test_package):
 
 
 def test_package_install(monkeypatch, tmp_path, pipx_temp_env):
-    pipx_venvs_dir = pipx.constants.PIPX_HOME / "venvs"
+    pipx_venvs_dir = pipx.constants.PIPX_DIRS.HOME / "venvs"
 
     run_pipx_cli(["install", PKG["pycowsay"]["spec"]])
     assert (pipx_venvs_dir / "pycowsay" / "pipx_metadata.json").is_file()
@@ -101,7 +101,7 @@ def test_package_install(monkeypatch, tmp_path, pipx_temp_env):
 
 
 def test_package_inject(monkeypatch, tmp_path, pipx_temp_env):
-    pipx_venvs_dir = pipx.constants.PIPX_HOME / "venvs"
+    pipx_venvs_dir = pipx.constants.PIPX_DIRS.HOME / "venvs"
 
     run_pipx_cli(["install", PKG["pycowsay"]["spec"]])
     run_pipx_cli(["inject", "pycowsay", PKG["black"]["spec"]])

--- a/tests/test_reinstall.py
+++ b/tests/test_reinstall.py
@@ -11,6 +11,8 @@ def test_reinstall(pipx_temp_env, capsys):
 
 
 def test_reinstall_global(pipx_temp_env, capsys):
+    if sys.platform.startswith("win"):
+        pytest.skip("This behavior is undefined on Windows")
     assert not run_pipx_cli(["--global", "install", "pycowsay"])
     assert not run_pipx_cli(
         ["--global", "reinstall", "--python", sys.executable, "pycowsay"]

--- a/tests/test_reinstall.py
+++ b/tests/test_reinstall.py
@@ -10,6 +10,13 @@ def test_reinstall(pipx_temp_env, capsys):
     assert not run_pipx_cli(["reinstall", "--python", sys.executable, "pycowsay"])
 
 
+def test_reinstall_global(pipx_temp_env, capsys):
+    assert not run_pipx_cli(["--global", "install", "pycowsay"])
+    assert not run_pipx_cli(
+        ["--global", "reinstall", "--python", sys.executable, "pycowsay"]
+    )
+
+
 def test_reinstall_nonexistent(pipx_temp_env, capsys):
     assert run_pipx_cli(["reinstall", "--python", sys.executable, "nonexistent"])
     assert "Nothing to reinstall for nonexistent" in capsys.readouterr().out

--- a/tests/test_reinstall.py
+++ b/tests/test_reinstall.py
@@ -3,6 +3,7 @@ import sys
 import pytest  # type: ignore
 
 from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli, skip_if_windows
+from pipx import paths
 
 
 def test_reinstall(pipx_temp_env, capsys):
@@ -14,6 +15,8 @@ def test_reinstall(pipx_temp_env, capsys):
 def test_reinstall_global(pipx_temp_env, capsys):
     assert not run_pipx_cli(["--global", "install", "pycowsay"])
     assert not run_pipx_cli(["--global", "reinstall", "--python", sys.executable, "pycowsay"])
+    # reset to local to avoid side effects
+    paths.ctx.make_local()
 
 
 def test_reinstall_nonexistent(pipx_temp_env, capsys):

--- a/tests/test_reinstall.py
+++ b/tests/test_reinstall.py
@@ -2,7 +2,7 @@ import sys
 
 import pytest  # type: ignore
 
-from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli
+from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli, skip_if_windows
 
 
 def test_reinstall(pipx_temp_env, capsys):
@@ -10,9 +10,8 @@ def test_reinstall(pipx_temp_env, capsys):
     assert not run_pipx_cli(["reinstall", "--python", sys.executable, "pycowsay"])
 
 
+@skip_if_windows
 def test_reinstall_global(pipx_temp_env, capsys):
-    if sys.platform.startswith("win"):
-        pytest.skip("This behavior is undefined on Windows")
     assert not run_pipx_cli(["--global", "install", "pycowsay"])
     assert not run_pipx_cli(["--global", "reinstall", "--python", sys.executable, "pycowsay"])
 

--- a/tests/test_reinstall.py
+++ b/tests/test_reinstall.py
@@ -3,7 +3,6 @@ import sys
 import pytest  # type: ignore
 
 from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli, skip_if_windows
-from pipx import paths
 
 
 def test_reinstall(pipx_temp_env, capsys):
@@ -15,8 +14,6 @@ def test_reinstall(pipx_temp_env, capsys):
 def test_reinstall_global(pipx_temp_env, capsys):
     assert not run_pipx_cli(["--global", "install", "pycowsay"])
     assert not run_pipx_cli(["--global", "reinstall", "--python", sys.executable, "pycowsay"])
-    # reset to local to avoid side effects
-    paths.ctx.make_local()
 
 
 def test_reinstall_nonexistent(pipx_temp_env, capsys):

--- a/tests/test_reinstall.py
+++ b/tests/test_reinstall.py
@@ -14,9 +14,7 @@ def test_reinstall_global(pipx_temp_env, capsys):
     if sys.platform.startswith("win"):
         pytest.skip("This behavior is undefined on Windows")
     assert not run_pipx_cli(["--global", "install", "pycowsay"])
-    assert not run_pipx_cli(
-        ["--global", "reinstall", "--python", sys.executable, "pycowsay"]
-    )
+    assert not run_pipx_cli(["--global", "reinstall", "--python", sys.executable, "pycowsay"])
 
 
 def test_reinstall_nonexistent(pipx_temp_env, capsys):

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -63,7 +63,7 @@ def test_cache(pipx_temp_env, monkeypatch, capsys, caplog):
 
 @mock.patch("os.execvpe", new=execvpe_mock)
 def test_cachedir_tag(pipx_ultra_temp_env, monkeypatch, capsys, caplog):
-    tag_path = constants.PIPX_VENV_CACHEDIR / "CACHEDIR.TAG"
+    tag_path = constants.PIPX_DIRS.VENV_CACHEDIR / "CACHEDIR.TAG"
     assert not tag_path.exists()
 
     # Run pipx to create tag

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -11,7 +11,7 @@ import pipx.main
 import pipx.util
 from helpers import run_pipx_cli
 from package_info import PKG
-from pipx import constants
+from pipx import paths
 
 
 def test_help_text(pipx_temp_env, monkeypatch, capsys):
@@ -63,7 +63,7 @@ def test_cache(pipx_temp_env, monkeypatch, capsys, caplog):
 
 @mock.patch("os.execvpe", new=execvpe_mock)
 def test_cachedir_tag(pipx_ultra_temp_env, monkeypatch, capsys, caplog):
-    tag_path = constants.PIPX_DIRS.VENV_CACHEDIR / "CACHEDIR.TAG"
+    tag_path = paths.ctx.venv_cache / "CACHEDIR.TAG"
     assert not tag_path.exists()
 
     # Run pipx to create tag

--- a/tests/test_runpip.py
+++ b/tests/test_runpip.py
@@ -4,3 +4,8 @@ from helpers import run_pipx_cli
 def test_runpip(pipx_temp_env, monkeypatch, capsys):
     assert not run_pipx_cli(["install", "pycowsay"])
     assert not run_pipx_cli(["runpip", "pycowsay", "list"])
+
+
+def test_runpip_global(pipx_temp_env, monkeypatch, capsys):
+    assert not run_pipx_cli(["--global", "install", "pycowsay"])
+    assert not run_pipx_cli(["--global", "runpip", "pycowsay", "list"])

--- a/tests/test_runpip.py
+++ b/tests/test_runpip.py
@@ -1,3 +1,7 @@
+import sys
+
+import pytest  # type: ignore
+
 from helpers import run_pipx_cli
 
 
@@ -7,5 +11,7 @@ def test_runpip(pipx_temp_env, monkeypatch, capsys):
 
 
 def test_runpip_global(pipx_temp_env, monkeypatch, capsys):
+    if sys.platform.startswith("win"):
+        pytest.skip("This behavior is undefined on Windows")
     assert not run_pipx_cli(["--global", "install", "pycowsay"])
     assert not run_pipx_cli(["--global", "runpip", "pycowsay", "list"])

--- a/tests/test_runpip.py
+++ b/tests/test_runpip.py
@@ -1,8 +1,4 @@
-import sys
-
-import pytest  # type: ignore
-
-from helpers import run_pipx_cli
+from helpers import run_pipx_cli, skip_if_windows
 
 
 def test_runpip(pipx_temp_env, monkeypatch, capsys):
@@ -10,8 +6,7 @@ def test_runpip(pipx_temp_env, monkeypatch, capsys):
     assert not run_pipx_cli(["runpip", "pycowsay", "list"])
 
 
+@skip_if_windows
 def test_runpip_global(pipx_temp_env, monkeypatch, capsys):
-    if sys.platform.startswith("win"):
-        pytest.skip("This behavior is undefined on Windows")
     assert not run_pipx_cli(["--global", "install", "pycowsay"])
     assert not run_pipx_cli(["--global", "runpip", "pycowsay", "list"])

--- a/tests/test_runpip.py
+++ b/tests/test_runpip.py
@@ -1,5 +1,4 @@
 from helpers import run_pipx_cli, skip_if_windows
-from pipx import paths
 
 
 def test_runpip(pipx_temp_env, monkeypatch, capsys):
@@ -11,5 +10,3 @@ def test_runpip(pipx_temp_env, monkeypatch, capsys):
 def test_runpip_global(pipx_temp_env, monkeypatch, capsys):
     assert not run_pipx_cli(["--global", "install", "pycowsay"])
     assert not run_pipx_cli(["--global", "runpip", "pycowsay", "list"])
-    # reset to local to avoid side effects
-    paths.ctx.make_local()

--- a/tests/test_runpip.py
+++ b/tests/test_runpip.py
@@ -1,4 +1,5 @@
 from helpers import run_pipx_cli, skip_if_windows
+from pipx import paths
 
 
 def test_runpip(pipx_temp_env, monkeypatch, capsys):
@@ -10,3 +11,5 @@ def test_runpip(pipx_temp_env, monkeypatch, capsys):
 def test_runpip_global(pipx_temp_env, monkeypatch, capsys):
     assert not run_pipx_cli(["--global", "install", "pycowsay"])
     assert not run_pipx_cli(["--global", "runpip", "pycowsay", "list"])
+    # reset to local to avoid side effects
+    paths.ctx.make_local()

--- a/tests/test_uninject.py
+++ b/tests/test_uninject.py
@@ -1,3 +1,7 @@
+import sys
+
+import pytest  # type: ignore
+
 from helpers import run_pipx_cli
 from package_info import PKG
 
@@ -9,6 +13,19 @@ def test_uninject_simple(pipx_temp_env, capsys):
     captured = capsys.readouterr()
     assert "Uninjected package black" in captured.out
     assert not run_pipx_cli(["list", "--include-injected"])
+    captured = capsys.readouterr()
+    assert "black" not in captured.out
+
+
+def test_uninject_simple_global(pipx_temp_env, capsys):
+    if sys.platform.startswith("win"):
+        pytest.skip("This behavior is undefined on Windows")
+    assert not run_pipx_cli(["--global", "install", "pycowsay"])
+    assert not run_pipx_cli(["--global", "inject", "pycowsay", PKG["black"]["spec"]])
+    assert not run_pipx_cli(["--global", "uninject", "pycowsay", "black"])
+    captured = capsys.readouterr()
+    assert "Uninjected package black" in captured.out
+    assert not run_pipx_cli(["--global", "list", "--include-injected"])
     captured = capsys.readouterr()
     assert "black" not in captured.out
 

--- a/tests/test_uninject.py
+++ b/tests/test_uninject.py
@@ -1,8 +1,4 @@
-import sys
-
-import pytest  # type: ignore
-
-from helpers import run_pipx_cli
+from helpers import run_pipx_cli, skip_if_windows
 from package_info import PKG
 
 
@@ -17,9 +13,8 @@ def test_uninject_simple(pipx_temp_env, capsys):
     assert "black" not in captured.out
 
 
+@skip_if_windows
 def test_uninject_simple_global(pipx_temp_env, capsys):
-    if sys.platform.startswith("win"):
-        pytest.skip("This behavior is undefined on Windows")
     assert not run_pipx_cli(["--global", "install", "pycowsay"])
     assert not run_pipx_cli(["--global", "inject", "pycowsay", PKG["black"]["spec"]])
     assert not run_pipx_cli(["--global", "uninject", "pycowsay", "black"])

--- a/tests/test_uninject.py
+++ b/tests/test_uninject.py
@@ -1,6 +1,5 @@
 from helpers import run_pipx_cli, skip_if_windows
 from package_info import PKG
-from pipx import paths
 
 
 def test_uninject_simple(pipx_temp_env, capsys):
@@ -24,8 +23,6 @@ def test_uninject_simple_global(pipx_temp_env, capsys):
     assert not run_pipx_cli(["--global", "list", "--include-injected"])
     captured = capsys.readouterr()
     assert "black" not in captured.out
-    # reset to local to avoid side effects
-    paths.ctx.make_local()
 
 
 def test_uninject_with_include_apps(pipx_temp_env, capsys, caplog):

--- a/tests/test_uninject.py
+++ b/tests/test_uninject.py
@@ -1,5 +1,6 @@
 from helpers import run_pipx_cli, skip_if_windows
 from package_info import PKG
+from pipx import paths
 
 
 def test_uninject_simple(pipx_temp_env, capsys):
@@ -23,6 +24,8 @@ def test_uninject_simple_global(pipx_temp_env, capsys):
     assert not run_pipx_cli(["--global", "list", "--include-injected"])
     captured = capsys.readouterr()
     assert "black" not in captured.out
+    # reset to local to avoid side effects
+    paths.ctx.make_local()
 
 
 def test_uninject_with_include_apps(pipx_temp_env, capsys, caplog):

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -23,6 +23,8 @@ def test_uninstall(pipx_temp_env):
 
 
 def test_uninstall_global(pipx_temp_env):
+    if sys.platform.startswith("win"):
+        pytest.skip("This behavior is undefined on Windows")
     assert not run_pipx_cli(["--global", "install", "pycowsay"])
     assert not run_pipx_cli(["--global", "uninstall", "pycowsay"])
 

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -33,6 +33,8 @@ def test_uninstall(pipx_temp_env):
 def test_uninstall_global(pipx_temp_env):
     assert not run_pipx_cli(["--global", "install", "pycowsay"])
     assert not run_pipx_cli(["--global", "uninstall", "pycowsay"])
+    # reset to local to avoid side effects
+    paths.ctx.make_local()
 
 
 def test_uninstall_circular_deps(pipx_temp_env):

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -8,6 +8,7 @@ from helpers import (
     mock_legacy_venv,
     remove_venv_interpreter,
     run_pipx_cli,
+    skip_if_windows,
 )
 from package_info import PKG
 from pipx import paths
@@ -28,9 +29,8 @@ def test_uninstall(pipx_temp_env):
     assert not run_pipx_cli(["uninstall", "pycowsay"])
 
 
+@skip_if_windows
 def test_uninstall_global(pipx_temp_env):
-    if sys.platform.startswith("win"):
-        pytest.skip("This behavior is undefined on Windows")
     assert not run_pipx_cli(["--global", "install", "pycowsay"])
     assert not run_pipx_cli(["--global", "uninstall", "pycowsay"])
 

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -4,7 +4,7 @@ import pytest  # type: ignore
 
 from helpers import PIPX_METADATA_LEGACY_VERSIONS, app_name, mock_legacy_venv, remove_venv_interpreter, run_pipx_cli
 from package_info import PKG
-from pipx import constants
+from pipx import paths
 
 
 def file_or_symlink(filepath):
@@ -36,7 +36,7 @@ def test_uninstall_circular_deps(pipx_temp_env):
 
 @pytest.mark.parametrize("metadata_version", PIPX_METADATA_LEGACY_VERSIONS)
 def test_uninstall_legacy_venv(pipx_temp_env, metadata_version):
-    executable_path = constants.PIPX_DIRS.BIN_DIR / app_name("pycowsay")
+    executable_path = paths.ctx.bin_dir / app_name("pycowsay")
 
     assert not run_pipx_cli(["install", "pycowsay"])
     assert executable_path.exists()
@@ -49,7 +49,7 @@ def test_uninstall_legacy_venv(pipx_temp_env, metadata_version):
 def test_uninstall_suffix(pipx_temp_env):
     name = "pbr"
     suffix = "_a"
-    executable_path = constants.PIPX_DIRS.BIN_DIR / app_name(f"{name}{suffix}")
+    executable_path = paths.ctx.bin_dir / app_name(f"{name}{suffix}")
 
     assert not run_pipx_cli(["install", PKG[name]["spec"], f"--suffix={suffix}"])
     assert executable_path.exists()
@@ -67,9 +67,9 @@ def test_uninstall_man_page(pipx_temp_env):
 
 
 def test_uninstall_injected(pipx_temp_env):
-    pycowsay_app_paths = [constants.PIPX_DIRS.BIN_DIR / app for app in PKG["pycowsay"]["apps"]]
-    pycowsay_man_page_paths = [constants.PIPX_DIRS.MAN_DIR / man_page for man_page in PKG["pycowsay"]["man_pages"]]
-    pylint_app_paths = [constants.PIPX_DIRS.BIN_DIR / app for app in PKG["pylint"]["apps"]]
+    pycowsay_app_paths = [paths.ctx.bin_dir / app for app in PKG["pycowsay"]["apps"]]
+    pycowsay_man_page_paths = [paths.ctx.man_dir / man_page for man_page in PKG["pycowsay"]["man_pages"]]
+    pylint_app_paths = [paths.ctx.bin_dir / app for app in PKG["pylint"]["apps"]]
     app_paths = pycowsay_app_paths + pylint_app_paths
     man_page_paths = pycowsay_man_page_paths
 
@@ -97,7 +97,7 @@ def test_uninstall_suffix_legacy_venv(pipx_temp_env, metadata_version):
     # legacy uninstall on Windows only works with "canonical name characters"
     #   in suffix
     suffix = "-a"
-    executable_path = constants.PIPX_DIRS.BIN_DIR / app_name(f"{name}{suffix}")
+    executable_path = paths.ctx.bin_dir / app_name(f"{name}{suffix}")
 
     assert not run_pipx_cli(["install", PKG[name]["spec"], f"--suffix={suffix}"])
     mock_legacy_venv(f"{name}{suffix}", metadata_version=metadata_version)
@@ -109,7 +109,7 @@ def test_uninstall_suffix_legacy_venv(pipx_temp_env, metadata_version):
 
 @pytest.mark.parametrize("metadata_version", PIPX_METADATA_LEGACY_VERSIONS)
 def test_uninstall_with_missing_interpreter(pipx_temp_env, metadata_version):
-    executable_path = constants.PIPX_DIRS.BIN_DIR / app_name("pycowsay")
+    executable_path = paths.ctx.bin_dir / app_name("pycowsay")
 
     assert not run_pipx_cli(["install", "pycowsay"])
     assert executable_path.exists()
@@ -127,12 +127,8 @@ def test_uninstall_with_missing_interpreter(pipx_temp_env, metadata_version):
 def test_uninstall_proper_dep_behavior(pipx_temp_env, metadata_version):
     # isort is a dependency of pylint.  Make sure that uninstalling pylint
     #   does not also uninstall isort app in LOCAL_BIN_DIR
-    isort_app_paths = [
-        constants.PIPX_DIRS.BIN_DIR / app for app in PKG["isort"]["apps"]
-    ]
-    pylint_app_paths = [
-        constants.PIPX_DIRS.BIN_DIR / app for app in PKG["pylint"]["apps"]
-    ]
+    isort_app_paths = [paths.ctx.bin_dir / app for app in PKG["isort"]["apps"]]
+    pylint_app_paths = [paths.ctx.bin_dir / app for app in PKG["pylint"]["apps"]]
 
     assert not run_pipx_cli(["install", PKG["pylint"]["spec"]])
     assert not run_pipx_cli(["install", PKG["isort"]["spec"]])
@@ -156,12 +152,8 @@ def test_uninstall_proper_dep_behavior(pipx_temp_env, metadata_version):
 def test_uninstall_proper_dep_behavior_missing_interpreter(pipx_temp_env, metadata_version):
     # isort is a dependency of pylint.  Make sure that uninstalling pylint
     #   does not also uninstall isort app in LOCAL_BIN_DIR
-    isort_app_paths = [
-        constants.PIPX_DIRS.BIN_DIR / app for app in PKG["isort"]["apps"]
-    ]
-    pylint_app_paths = [
-        constants.PIPX_DIRS.BIN_DIR / app for app in PKG["pylint"]["apps"]
-    ]
+    isort_app_paths = [paths.ctx.bin_dir / app for app in PKG["isort"]["apps"]]
+    pylint_app_paths = [paths.ctx.bin_dir / app for app in PKG["pylint"]["apps"]]
 
     assert not run_pipx_cli(["install", PKG["pylint"]["spec"]])
     assert not run_pipx_cli(["install", PKG["isort"]["spec"]])

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -2,7 +2,13 @@ import sys
 
 import pytest  # type: ignore
 
-from helpers import PIPX_METADATA_LEGACY_VERSIONS, app_name, mock_legacy_venv, remove_venv_interpreter, run_pipx_cli
+from helpers import (
+    PIPX_METADATA_LEGACY_VERSIONS,
+    app_name,
+    mock_legacy_venv,
+    remove_venv_interpreter,
+    run_pipx_cli,
+)
 from package_info import PKG
 from pipx import paths
 
@@ -59,7 +65,7 @@ def test_uninstall_suffix(pipx_temp_env):
 
 
 def test_uninstall_man_page(pipx_temp_env):
-    man_page_path = constants.LOCAL_MAN_DIR / "man6" / "pycowsay.6"
+    man_page_path = paths.ctx.man_dir / "man6" / "pycowsay.6"
     assert not run_pipx_cli(["install", "pycowsay"])
     assert man_page_path.exists()
     assert not run_pipx_cli(["uninstall", "pycowsay"])

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -33,8 +33,6 @@ def test_uninstall(pipx_temp_env):
 def test_uninstall_global(pipx_temp_env):
     assert not run_pipx_cli(["--global", "install", "pycowsay"])
     assert not run_pipx_cli(["--global", "uninstall", "pycowsay"])
-    # reset to local to avoid side effects
-    paths.ctx.make_local()
 
 
 def test_uninstall_circular_deps(pipx_temp_env):

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -22,6 +22,11 @@ def test_uninstall(pipx_temp_env):
     assert not run_pipx_cli(["uninstall", "pycowsay"])
 
 
+def test_uninstall_global(pipx_temp_env):
+    assert not run_pipx_cli(["--global", "install", "pycowsay"])
+    assert not run_pipx_cli(["--global", "uninstall", "pycowsay"])
+
+
 def test_uninstall_circular_deps(pipx_temp_env):
     assert not run_pipx_cli(["install", PKG["cloudtoken"]["spec"]])
     assert not run_pipx_cli(["uninstall", "cloudtoken"])
@@ -29,7 +34,7 @@ def test_uninstall_circular_deps(pipx_temp_env):
 
 @pytest.mark.parametrize("metadata_version", PIPX_METADATA_LEGACY_VERSIONS)
 def test_uninstall_legacy_venv(pipx_temp_env, metadata_version):
-    executable_path = constants.LOCAL_BIN_DIR / app_name("pycowsay")
+    executable_path = constants.PIPX_DIRS.BIN_DIR / app_name("pycowsay")
 
     assert not run_pipx_cli(["install", "pycowsay"])
     assert executable_path.exists()
@@ -42,7 +47,7 @@ def test_uninstall_legacy_venv(pipx_temp_env, metadata_version):
 def test_uninstall_suffix(pipx_temp_env):
     name = "pbr"
     suffix = "_a"
-    executable_path = constants.LOCAL_BIN_DIR / app_name(f"{name}{suffix}")
+    executable_path = constants.PIPX_DIRS.BIN_DIR / app_name(f"{name}{suffix}")
 
     assert not run_pipx_cli(["install", PKG[name]["spec"], f"--suffix={suffix}"])
     assert executable_path.exists()
@@ -60,9 +65,9 @@ def test_uninstall_man_page(pipx_temp_env):
 
 
 def test_uninstall_injected(pipx_temp_env):
-    pycowsay_app_paths = [constants.LOCAL_BIN_DIR / app for app in PKG["pycowsay"]["apps"]]
-    pycowsay_man_page_paths = [constants.LOCAL_MAN_DIR / man_page for man_page in PKG["pycowsay"]["man_pages"]]
-    pylint_app_paths = [constants.LOCAL_BIN_DIR / app for app in PKG["pylint"]["apps"]]
+    pycowsay_app_paths = [constants.PIPX_DIRS.BIN_DIR / app for app in PKG["pycowsay"]["apps"]]
+    pycowsay_man_page_paths = [constants.PIPX_DIRS.MAN_DIR / man_page for man_page in PKG["pycowsay"]["man_pages"]]
+    pylint_app_paths = [constants.PIPX_DIRS.BIN_DIR / app for app in PKG["pylint"]["apps"]]
     app_paths = pycowsay_app_paths + pylint_app_paths
     man_page_paths = pycowsay_man_page_paths
 
@@ -90,7 +95,7 @@ def test_uninstall_suffix_legacy_venv(pipx_temp_env, metadata_version):
     # legacy uninstall on Windows only works with "canonical name characters"
     #   in suffix
     suffix = "-a"
-    executable_path = constants.LOCAL_BIN_DIR / app_name(f"{name}{suffix}")
+    executable_path = constants.PIPX_DIRS.BIN_DIR / app_name(f"{name}{suffix}")
 
     assert not run_pipx_cli(["install", PKG[name]["spec"], f"--suffix={suffix}"])
     mock_legacy_venv(f"{name}{suffix}", metadata_version=metadata_version)
@@ -102,7 +107,7 @@ def test_uninstall_suffix_legacy_venv(pipx_temp_env, metadata_version):
 
 @pytest.mark.parametrize("metadata_version", PIPX_METADATA_LEGACY_VERSIONS)
 def test_uninstall_with_missing_interpreter(pipx_temp_env, metadata_version):
-    executable_path = constants.LOCAL_BIN_DIR / app_name("pycowsay")
+    executable_path = constants.PIPX_DIRS.BIN_DIR / app_name("pycowsay")
 
     assert not run_pipx_cli(["install", "pycowsay"])
     assert executable_path.exists()
@@ -120,8 +125,12 @@ def test_uninstall_with_missing_interpreter(pipx_temp_env, metadata_version):
 def test_uninstall_proper_dep_behavior(pipx_temp_env, metadata_version):
     # isort is a dependency of pylint.  Make sure that uninstalling pylint
     #   does not also uninstall isort app in LOCAL_BIN_DIR
-    isort_app_paths = [constants.LOCAL_BIN_DIR / app for app in PKG["isort"]["apps"]]
-    pylint_app_paths = [constants.LOCAL_BIN_DIR / app for app in PKG["pylint"]["apps"]]
+    isort_app_paths = [
+        constants.PIPX_DIRS.BIN_DIR / app for app in PKG["isort"]["apps"]
+    ]
+    pylint_app_paths = [
+        constants.PIPX_DIRS.BIN_DIR / app for app in PKG["pylint"]["apps"]
+    ]
 
     assert not run_pipx_cli(["install", PKG["pylint"]["spec"]])
     assert not run_pipx_cli(["install", PKG["isort"]["spec"]])
@@ -145,8 +154,12 @@ def test_uninstall_proper_dep_behavior(pipx_temp_env, metadata_version):
 def test_uninstall_proper_dep_behavior_missing_interpreter(pipx_temp_env, metadata_version):
     # isort is a dependency of pylint.  Make sure that uninstalling pylint
     #   does not also uninstall isort app in LOCAL_BIN_DIR
-    isort_app_paths = [constants.LOCAL_BIN_DIR / app for app in PKG["isort"]["apps"]]
-    pylint_app_paths = [constants.LOCAL_BIN_DIR / app for app in PKG["pylint"]["apps"]]
+    isort_app_paths = [
+        constants.PIPX_DIRS.BIN_DIR / app for app in PKG["isort"]["apps"]
+    ]
+    pylint_app_paths = [
+        constants.PIPX_DIRS.BIN_DIR / app for app in PKG["pylint"]["apps"]
+    ]
 
     assert not run_pipx_cli(["install", PKG["pylint"]["spec"]])
     assert not run_pipx_cli(["install", PKG["isort"]["spec"]])

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -2,7 +2,6 @@ import pytest  # type: ignore
 
 from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli, skip_if_windows
 from package_info import PKG
-from pipx import paths
 
 
 def test_upgrade(pipx_temp_env, capsys):
@@ -32,9 +31,6 @@ def test_upgrade_global(pipx_temp_env, capsys):
     assert not run_pipx_cli(["--global", "upgrade", "pycowsay"])
     captured = capsys.readouterr()
     assert "pycowsay is already at latest version" in captured.out
-
-    # reset to local to avoid side effects
-    paths.ctx.make_local()
 
 
 @pytest.mark.parametrize("metadata_version", PIPX_METADATA_LEGACY_VERSIONS)

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -10,6 +10,12 @@ def test_upgrade(pipx_temp_env, capsys):
     assert not run_pipx_cli(["upgrade", "pycowsay"])
 
 
+def test_upgrade_global(pipx_temp_env, capsys):
+    assert run_pipx_cli(["--global", "upgrade", "pycowsay"])
+    assert not run_pipx_cli(["--global", "install", "pycowsay"])
+    assert not run_pipx_cli(["--global", "upgrade", "pycowsay"])
+
+
 @pytest.mark.parametrize("metadata_version", PIPX_METADATA_LEGACY_VERSIONS)
 def test_upgrade_legacy_venv(pipx_temp_env, capsys, metadata_version):
     assert not run_pipx_cli(["install", "pycowsay"])
@@ -18,7 +24,10 @@ def test_upgrade_legacy_venv(pipx_temp_env, capsys, metadata_version):
     if metadata_version is None:
         assert run_pipx_cli(["upgrade", "pycowsay"])
         captured = capsys.readouterr()
-        assert "Not upgrading pycowsay. It has missing internal pipx metadata." in captured.err
+        assert (
+            "Not upgrading pycowsay. It has missing internal pipx metadata."
+            in captured.err
+        )
     else:
         assert not run_pipx_cli(["upgrade", "pycowsay"])
         captured = capsys.readouterr()

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -28,10 +28,7 @@ def test_upgrade_legacy_venv(pipx_temp_env, capsys, metadata_version):
     if metadata_version is None:
         assert run_pipx_cli(["upgrade", "pycowsay"])
         captured = capsys.readouterr()
-        assert (
-            "Not upgrading pycowsay. It has missing internal pipx metadata."
-            in captured.err
-        )
+        assert "Not upgrading pycowsay. It has missing internal pipx metadata." in captured.err
     else:
         assert not run_pipx_cli(["upgrade", "pycowsay"])
         captured = capsys.readouterr()

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,8 +1,6 @@
-import sys
-
 import pytest  # type: ignore
 
-from helpers import mock_legacy_venv, run_pipx_cli
+from helpers import mock_legacy_venv, run_pipx_cli, skip_if_windows
 from package_info import PKG
 
 
@@ -12,9 +10,8 @@ def test_upgrade(pipx_temp_env, capsys):
     assert not run_pipx_cli(["upgrade", "pycowsay"])
 
 
+@skip_if_windows
 def test_upgrade_global(pipx_temp_env, capsys):
-    if sys.platform.startswith("win"):
-        pytest.skip("This behavior is undefined on Windows")
     assert run_pipx_cli(["--global", "upgrade", "pycowsay"])
     assert not run_pipx_cli(["--global", "install", "pycowsay"])
     assert not run_pipx_cli(["--global", "upgrade", "pycowsay"])

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -2,7 +2,7 @@ import sys
 
 import pytest  # type: ignore
 
-from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli
+from helpers import mock_legacy_venv, run_pipx_cli
 from package_info import PKG
 
 
@@ -20,7 +20,7 @@ def test_upgrade_global(pipx_temp_env, capsys):
     assert not run_pipx_cli(["--global", "upgrade", "pycowsay"])
 
 
-@pytest.mark.parametrize("metadata_version", PIPX_METADATA_LEGACY_VERSIONS)
+@pytest.mark.parametrize("metadata_version", [None, "0.1"])
 def test_upgrade_legacy_venv(pipx_temp_env, capsys, metadata_version):
     assert not run_pipx_cli(["install", "pycowsay"])
     mock_legacy_venv("pycowsay", metadata_version=metadata_version)

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,23 +1,39 @@
 import pytest  # type: ignore
 
-from helpers import mock_legacy_venv, run_pipx_cli, skip_if_windows
+from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli, skip_if_windows
 from package_info import PKG
 
 
 def test_upgrade(pipx_temp_env, capsys):
     assert run_pipx_cli(["upgrade", "pycowsay"])
+    captured = capsys.readouterr()
+    assert "Package is not installed" in captured.err
+
     assert not run_pipx_cli(["install", "pycowsay"])
+    captured = capsys.readouterr()
+    assert "installed package pycowsay" in captured.out
+
     assert not run_pipx_cli(["upgrade", "pycowsay"])
+    captured = capsys.readouterr()
+    assert "pycowsay is already at latest version" in captured.out
 
 
 @skip_if_windows
 def test_upgrade_global(pipx_temp_env, capsys):
     assert run_pipx_cli(["--global", "upgrade", "pycowsay"])
+    captured = capsys.readouterr()
+    assert "Package is not installed" in captured.err
+
     assert not run_pipx_cli(["--global", "install", "pycowsay"])
+    captured = capsys.readouterr()
+    assert "installed package pycowsay" in captured.out
+
     assert not run_pipx_cli(["--global", "upgrade", "pycowsay"])
+    captured = capsys.readouterr()
+    assert "pycowsay is already at latest version" in captured.out
 
 
-@pytest.mark.parametrize("metadata_version", [None, "0.1"])
+@pytest.mark.parametrize("metadata_version", PIPX_METADATA_LEGACY_VERSIONS)
 def test_upgrade_legacy_venv(pipx_temp_env, capsys, metadata_version):
     assert not run_pipx_cli(["install", "pycowsay"])
     mock_legacy_venv("pycowsay", metadata_version=metadata_version)

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -2,6 +2,7 @@ import pytest  # type: ignore
 
 from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli, skip_if_windows
 from package_info import PKG
+from pipx import paths
 
 
 def test_upgrade(pipx_temp_env, capsys):
@@ -31,6 +32,9 @@ def test_upgrade_global(pipx_temp_env, capsys):
     assert not run_pipx_cli(["--global", "upgrade", "pycowsay"])
     captured = capsys.readouterr()
     assert "pycowsay is already at latest version" in captured.out
+
+    # reset to local to avoid side effects
+    paths.ctx.make_local()
 
 
 @pytest.mark.parametrize("metadata_version", PIPX_METADATA_LEGACY_VERSIONS)

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest  # type: ignore
 
 from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli
@@ -11,6 +13,8 @@ def test_upgrade(pipx_temp_env, capsys):
 
 
 def test_upgrade_global(pipx_temp_env, capsys):
+    if sys.platform.startswith("win"):
+        pytest.skip("This behavior is undefined on Windows")
     assert run_pipx_cli(["--global", "upgrade", "pycowsay"])
     assert not run_pipx_cli(["--global", "install", "pycowsay"])
     assert not run_pipx_cli(["--global", "upgrade", "pycowsay"])


### PR DESCRIPTION
- [x] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

Adds a `--global` option to perform actions for all users. This is a resubmission of PR  https://github.com/pypa/pipx/pull/1088 by https://github.com/haxwithaxe which I rebased on the latest `main`.

## Test plan

Passes your CI process on github (via your unaltered actions in my fork) apart from MacOS test which needs to be investigated. Help from your side is highly appreciated. Test run from my fork: https://github.com/Jendker/pipx/actions/runs/8182365101

To verify the changes do what they are supposed to

```
python3 src/pipx --global environment
```

To test all the relevant commands for regressions.

```
python3 src/pipx --global ensurepath
sudo python3 src/pipx --global install pycowsay
sudo python3 src/pipx --global reinstall pycowsay
sudo python3 src/pipx --global inject pycowsay black
sudo python3 src/pipx --global uninject pycowsay black
sudo python3 src/pipx --global runpip pycowsay freeze
sudo python3 src/pipx --global list
sudo python3 src/pipx --global uninstall pycowsay
python3 src/pipx environment
python3 src/pipx ensurepath
python3 src/pipx install pycowsay
python3 src/pipx reinstall pycowsay
python3 src/pipx inject pycowsay black
python3 src/pipx uninject pycowsay black
python3 src/pipx runpip pycowsay freeze
python3 src/pipx list
python3 src/pipx uninstall pycowsay
```