### PR TITLE
limit verbosity to supported range

### DIFF
--- a/changelog.d/1283.bugfix.md
+++ b/changelog.d/1283.bugfix.md
@@ -1,1 +1,1 @@
-Limit the number of possible -q and -v by ignoring exceeding values
+Fix crashes due to superfluous `-q ` flags by discarding exceeding values

--- a/changelog.d/1283.bugfix.md
+++ b/changelog.d/1283.bugfix.md
@@ -1,0 +1,1 @@
+Limit the number of possible -q and -v by ignoring exceeding values

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -758,7 +758,7 @@ def get_command_parser() -> Tuple[argparse.ArgumentParser, Dict[str, argparse.Ar
         default=0,
         help=(
             "Give less output. May be used multiple times corresponding to the"
-            " WARNING, ERROR, and CRITICAL logging levels."
+            " ERROR, and CRITICAL logging levels. Any count > 2 is ignored."
         ),
     )
 
@@ -843,8 +843,8 @@ def setup_logging(verbose: int) -> None:
     pipx_str = bold(green("pipx >")) if sys.stdout.isatty() else "pipx >"
     pipx.constants.pipx_log_file = setup_log_file()
 
-    # Determine logging level
-    level_number = max(0, logging.WARNING - 10 * verbose)
+    # Determine logging level, a value between 0 and 50
+    level_number = min(max(0, logging.WARNING - 10 * verbose), 50)
 
     level = logging.getLevelName(level_number)
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -758,7 +758,7 @@ def get_command_parser() -> Tuple[argparse.ArgumentParser, Dict[str, argparse.Ar
         default=0,
         help=(
             "Give less output. May be used multiple times corresponding to the"
-            " ERROR and CRITICAL logging levels. Any count > 2 is ignored."
+            " ERROR and CRITICAL logging levels. The count maxes out at 2."
         ),
     )
 
@@ -769,7 +769,7 @@ def get_command_parser() -> Tuple[argparse.ArgumentParser, Dict[str, argparse.Ar
         default=0,
         help=(
             "Give more output. May be used multiple times corresponding to the"
-            " INFO, DEBUG and NOTSET logging levels. Any count > 3 is ignored."
+            " INFO, DEBUG and NOTSET logging levels. The count maxes out at 3."
         ),
     )
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -758,11 +758,20 @@ def get_command_parser() -> Tuple[argparse.ArgumentParser, Dict[str, argparse.Ar
         default=0,
         help=(
             "Give less output. May be used multiple times corresponding to the"
-            " ERROR, and CRITICAL logging levels. Any count > 2 is ignored."
+            " ERROR and CRITICAL logging levels. Any count > 2 is ignored."
         ),
     )
 
-    shared_parser.add_argument("--verbose", "-v", action="count", default=0, help=("Give more output."))
+    shared_parser.add_argument(
+        "--verbose",
+        "-v",
+        action="count",
+        default=0,
+        help=(
+            "Give more output. May be used multiple times corresponding to the"
+            " INFO, DEBUG and NOTSET logging levels. Any count > 3 is ignored."
+        ),
+    )
 
     parser = argparse.ArgumentParser(
         prog=prog_name(),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -35,3 +35,15 @@ def test_prog_name(monkeypatch, argv, executable, expected):
     monkeypatch.setattr("pipx.main.sys.argv", [argv])
     monkeypatch.setattr("pipx.main.sys.executable", executable)
     assert main.prog_name() == expected
+
+
+def test_limit_verbosity():
+    mock_exit = mock.Mock(side_effect=ValueError("raised in test to exit early"))
+    with mock.patch.object(sys, "exit", mock_exit), pytest.raises(ValueError, match="raised in test to exit early"):
+        assert not run_pipx_cli(["--version", "-qqq"])
+    mock_exit.assert_called_with(0)
+
+    mock_exit = mock.Mock(side_effect=ValueError("raised in test to exit early"))
+    with mock.patch.object(sys, "exit", mock_exit), pytest.raises(ValueError, match="raised in test to exit early"):
+        assert not run_pipx_cli(["--version", "-vvv"])
+    mock_exit.assert_called_with(0)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -39,4 +39,4 @@ def test_prog_name(monkeypatch, argv, executable, expected):
 
 def test_limit_verbosity():
     assert not run_pipx_cli(["list", "-qqq"])
-    assert not run_pipx_cli(["list", "-vvv"])
+    assert not run_pipx_cli(["list", "-vvvv"])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -38,12 +38,5 @@ def test_prog_name(monkeypatch, argv, executable, expected):
 
 
 def test_limit_verbosity():
-    mock_exit = mock.Mock(side_effect=ValueError("raised in test to exit early"))
-    with mock.patch.object(sys, "exit", mock_exit), pytest.raises(ValueError, match="raised in test to exit early"):
-        assert not run_pipx_cli(["--version", "-qqq"])
-    mock_exit.assert_called_with(0)
-
-    mock_exit = mock.Mock(side_effect=ValueError("raised in test to exit early"))
-    with mock.patch.object(sys, "exit", mock_exit), pytest.raises(ValueError, match="raised in test to exit early"):
-        assert not run_pipx_cli(["--version", "-vvv"])
-    mock_exit.assert_called_with(0)
+    assert not run_pipx_cli(["list", "-qqq"])
+    assert not run_pipx_cli(["list", "-vvv"])


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [x] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes
Fixes #1283 by clamping the possible verbosity value.

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
pipx list -qqq
pipx list -vvv
```
