### PR TITLE
Added --extra-index-url and --use-input options to be available in pipx install.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) for keeping t
 
 <!-- towncrier release notes start -->
 
+## [Unreleased] - 2024-03-10
+
+### Features
+
+- Add `--extra-index-url` options for the `pipx` subcommands
+- Add `--use-input` options for the `pipx install` subcommand:
+  The `--use-input` option was being forced by pipx install when installing from the Google Artifact Registry, causing the package to fail to install because `--no-input` was enforced by pipx install, so the `--use-input` option enabled the `--no-input` option to be the default but temporarily disabled. We covered this in https://github.com/pypa/pipx/discussions/1280#discussion-6329294.
+
+
 ## [1.4.3](https://github.com/pypa/pipx/tree/1.4.3) - 2024-01-16
 
 

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -28,6 +28,7 @@ def install(
     reinstall: bool,
     include_dependencies: bool,
     preinstall_packages: Optional[List[str]],
+    use_input: bool,
     suffix: str = "",
 ) -> ExitCode:
     """Returns pipx exit code."""
@@ -95,6 +96,7 @@ def install(
                 include_dependencies=include_dependencies,
                 include_apps=True,
                 is_main_package=True,
+                use_input=use_input,
                 suffix=suffix,
             )
             run_post_install_actions(

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -352,7 +352,12 @@ def add_pip_venv_args(parser: argparse.ArgumentParser) -> None:
         help="Give the virtual environment access to the system site-packages dir.",
     )
     parser.add_argument("--index-url", "-i", help="Base URL of Python Package Index")
-    parser.add_argument("--extra-index-url", help=("Extra URLs of package indexes to use in addition to --index-url. Should follow the same rules as --index-url."))
+    parser.add_argument(
+        "--extra-index-url",
+        help=(
+            "Extra URLs of package indexes to use in addition to --index-url. Should follow the same rules as --index-url."
+        ),
+    )
     parser.add_argument(
         "--editable",
         "-e",
@@ -418,11 +423,7 @@ def _add_install(subparsers: argparse._SubParsersAction, shared_parser: argparse
         action="append",
         help=("Optional packages to be installed into the Virtual Environment before " "installing the main package."),
     )
-    p.add_argument(
-        "--use-input",
-        action="store_true",
-        help="Enable prompting for input."
-    )
+    p.add_argument("--use-input", action="store_true", help="Enable prompting for input.")
     add_pip_venv_args(p)
 
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -158,6 +158,9 @@ def get_pip_args(parsed_args: Dict[str, str]) -> List[str]:
     if parsed_args.get("index_url"):
         pip_args += ["--index-url", parsed_args["index_url"]]
 
+    if parsed_args.get("extra_index_url"):
+        pip_args += ["--extra-index-url", parsed_args["extra_index_url"]]
+
     if parsed_args.get("pip_args"):
         pip_args += shlex.split(parsed_args.get("pip_args", ""), posix=not WINDOWS)
 
@@ -242,6 +245,7 @@ def run_pipx_command(args: argparse.Namespace, subparsers: Dict[str, argparse.Ar
             reinstall=False,
             include_dependencies=args.include_deps,
             preinstall_packages=args.preinstall,
+            use_input=args.use_input,
             suffix=args.suffix,
         )
     elif args.command == "inject":
@@ -348,6 +352,7 @@ def add_pip_venv_args(parser: argparse.ArgumentParser) -> None:
         help="Give the virtual environment access to the system site-packages dir.",
     )
     parser.add_argument("--index-url", "-i", help="Base URL of Python Package Index")
+    parser.add_argument("--extra-index-url", help=("Extra URLs of package indexes to use in addition to --index-url. Should follow the same rules as --index-url."))
     parser.add_argument(
         "--editable",
         "-e",
@@ -412,6 +417,11 @@ def _add_install(subparsers: argparse._SubParsersAction, shared_parser: argparse
         "--preinstall",
         action="append",
         help=("Optional packages to be installed into the Virtual Environment before " "installing the main package."),
+    )
+    p.add_argument(
+        "--use-input",
+        action="store_true",
+        help="Enable prompting for input."
     )
     add_pip_venv_args(p)
 

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -227,6 +227,7 @@ class Venv:
         include_dependencies: bool,
         include_apps: bool,
         is_main_package: bool,
+        use_input: bool,
         suffix: str = "",
     ) -> None:
         # package_name in package specifier can mismatch URL due to user error
@@ -250,6 +251,11 @@ class Venv:
                 *pip_args,
                 package_or_url,
             ]
+
+            # An error occurred when installing the Google Artifact Registry package locally, adding the
+            if use_input:
+                cmd.remove("--no-input")
+
             # no logging because any errors will be specially logged by
             #   subprocess_post_check_handle_pip_error()
             pip_process = run_subprocess(cmd, log_stdout=False, log_stderr=False, run_dir=str(self.root))


### PR DESCRIPTION
Add --extra-index-url as PIPX install default option to use --extra-index-url=https://domain/simple instead of * --pip-args="--extra-index-url=https://domain/simple"
* Added --use-input option to temporarily disable the --no-input option when using PYPI from Google Artifact Registry, as the --no-input option was being enforced and preventing packages from being installed.

- [X ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

When using `pipx install`, specifying `--index-url` as the private repo and `https://pypi.org/simple` as the `--pip-args` option didn't seem to be very efficient, so we fixed it to accept `--extra-index-url` separately.

In addition, the `--no-input` option was enforced when installing packages from the google artifact registry, which prevented installation using the methods discussed in the discussion, so we added the `--use-input` option to prevent the `--no-input` option from being enforced only when this option is used.

## Test plan

```
pipx install --extra-index-url=https://asia-northeast3-python.pkg.dev/myproject/my-repo/simple --use-input --verbose my_package
```

Tested by running

```
pyenv exec pipx install \
  --extra-index-url=https://asia-northeast3-python.pkg.dev/myproject/my-repo/simple \
  --preinstall=keyrings.google-artifactregistry-auth \
  --use-input \
  my_package
⚠️  Note: my_package was already on your PATH at /Users/user_name/.pyenv/shims/gcloud_changer
  installed package my_package 0.1, installed using Python 3.10.6
  These apps are now globally available
    - my_command
done! ✨ 🌟 ✨
```
