### PR TITLE
Fix using run with file descriptors

### DIFF
--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -42,16 +42,18 @@ Available executable scripts:
     {app_lines}"""
 
 
-def maybe_script_content(app: str, is_path: bool) -> Optional[Union[str, Path]]:
+def maybe_script_content(app: str, is_path: bool) -> Optional[str]:
     # If the app is a script, return its content.
     # Return None if it should be treated as a package name.
+    # Look for a local file first
+    try:
+        return Path(app).read_text(encoding="utf-8")
+    except (FileNotFoundError, IsADirectoryError):
+        pass
 
-    # Look for a local file first.
-    app_path = Path(app)
-    if app_path.is_file():
-        return app_path
-    elif is_path:
+    if is_path:
         raise PipxError(f"The specified path {app} does not exist")
+
 
     # Check for a URL
     if urllib.parse.urlparse(app).scheme:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -354,6 +354,32 @@ def test_run_script_by_relative_name(caplog, pipx_temp_env, monkeypatch, tmp_pat
         run_pipx_cli_exit(["run", "test.py"])
     assert out.read_text() == test_str
 
+@mock.patch("os.execvpe", new=execvpe_mock)
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="uses file descriptor")
+def test_run_script_by_file_descriptor(caplog, pipx_temp_env, monkeypatch, tmp_path):
+    read_fd, write_fd = os.pipe()
+    out = tmp_path / "output.txt"
+    test_str = "Hello, world!"
+
+    os.write(
+        write_fd,
+        textwrap.dedent(
+            f"""
+                from pathlib import Path
+                Path({repr(str(out))}).write_text({repr(test_str)})
+            """
+        ).strip().encode("utf-8")
+    )
+    os.close(write_fd)
+    
+    with monkeypatch.context() as m:
+        m.chdir(tmp_path)
+        try:
+            run_pipx_cli_exit(["run", f'/dev/fd/{read_fd}'])        
+        finally:
+            os.close(read_fd)
+    assert out.read_text() == test_str
+
 
 @pytest.mark.skipif(not sys.platform.startswith("win"), reason="uses windows version format")
 @mock.patch("os.execvpe", new=execvpe_mock)


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [ ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

Fixes #1292

## Summary of changes
Remove `Path(app).is_file()` check and ask for forgiveness instead.

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running
```bash
python -m pipx run <(echo 'print("Hello world!")')
```
