### PR TITLE
Update Instructions for zsh in `pipx completions` Output

### DIFF
--- a/changelog.d/1296.misc.md
+++ b/changelog.d/1296.misc.md
@@ -1,0 +1,1 @@
+Update screen output provided by `pipx completions` for zsh/argcomplete v3

--- a/src/pipx/constants.py
+++ b/src/pipx/constants.py
@@ -58,19 +58,18 @@ zsh:
 
     autoload -U compinit && compinit
 
-    Afterwards you can enable completion for pipx:
+    Afterwards you can enable completions for pipx:
 
     eval "$(register-python-argcomplete pipx)"
 
-    NOTE: If your version of argcomplete is earlier than v3, you may need to
+    > [!NOTE]
+    >
+    > If your version of argcomplete is earlier than v3, you may need to
     have bashcompinit enabled in zsh by running:
+    >
+    > autoload -U bashcompinit
+    > bashcompinit
 
-    autoload -U bashcompinit
-    bashcompinit
-
-    and then following with:
-
-    eval "$(register-python-argcomplete pipx)"
 
 tcsh:
     eval `register-python-argcomplete --shell tcsh pipx`

--- a/src/pipx/constants.py
+++ b/src/pipx/constants.py
@@ -38,7 +38,7 @@ MINGW: bool = is_mingw()
 
 completion_instructions = dedent(
     """
-If you do not already have argcomplete installed,
+If you encountered register-python-argcomplete command not found error,
 or if you are using zipapp, run
 
     pipx install argcomplete

--- a/src/pipx/constants.py
+++ b/src/pipx/constants.py
@@ -38,8 +38,12 @@ MINGW: bool = is_mingw()
 
 completion_instructions = dedent(
     """
-If you are using zipapp, run `pipx install argcomplete` before
-running any of the following commands.
+If you do not already have argcomplete installed,
+or if you are using zipapp, run
+
+    pipx install argcomplete
+
+before running any of the following commands.
 
 Add the appropriate command to your shell's config file
 so that it is run on startup. You will likely have to restart
@@ -49,13 +53,22 @@ bash:
     eval "$(register-python-argcomplete pipx)"
 
 zsh:
-    To activate completions for zsh you need to have
-    bashcompinit enabled in zsh:
+    To activate completions in zsh, first make sure compinit is marked for
+    autoload and run autoload:
+
+    autoload -U compinit && compinit
+
+    Afterwards you can enable completion for pipx:
+
+    eval "$(register-python-argcomplete pipx)"
+
+    NOTE: If your version of argcomplete is earlier than v3, you may need to
+    have bashcompinit enabled in zsh by running:
 
     autoload -U bashcompinit
     bashcompinit
 
-    Afterwards you can enable completion for pipx:
+    and then following with:
 
     eval "$(register-python-argcomplete pipx)"
 

--- a/src/pipx/constants.py
+++ b/src/pipx/constants.py
@@ -64,7 +64,7 @@ zsh:
 
     NOTE: If your version of argcomplete is earlier than v3, you may need to
     have bashcompinit enabled in zsh by running:
-    
+
     autoload -U bashcompinit
     bashcompinit
 

--- a/src/pipx/constants.py
+++ b/src/pipx/constants.py
@@ -62,13 +62,11 @@ zsh:
 
     eval "$(register-python-argcomplete pipx)"
 
-    > [!NOTE]
-    >
-    > If your version of argcomplete is earlier than v3, you may need to
+    NOTE: If your version of argcomplete is earlier than v3, you may need to
     have bashcompinit enabled in zsh by running:
-    >
-    > autoload -U bashcompinit
-    > bashcompinit
+    
+    autoload -U bashcompinit
+    bashcompinit
 
 
 tcsh:


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [x] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

(Note: change does not affect _usage_ by users, so I haven't added to `changelog.d/`)

## Summary of changes

The output of `pipx completions` (`[constants.py](https://github.com/pypa/pipx/blob/master/src/pipx/constants.py#L39):39`) has been modified to reflect the current capability of `argcomplete` as of v3 ([changelog](https://github.com/kislyuk/argcomplete/blob/9077be97459abab129d02ad937eff1618cf67e57/Changes.rst#changes-for-v300-2023-03-19)), namely that [zsh is fully supported](https://stackoverflow.com/a/75791863/6031795), so there is no need for `bashcompinit`. However, `argcomplete` < v3 is accounted for by referencing the former workflow.

Additionally, I've added to the top of the output to indicate that one must **_first_** install `argcomplete`, if not already installed or if using zipapp. This is due to the fact that, in setting up completions for myself, I had to first install `argcomplete`, and am running zsh on macOS 14.4.

## Test plan

N/A