### PR TITLE
Add support for listing packages from pyproject.toml files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     - "packaging>=20"
     - "platformdirs>=2.1"
     - "tomli; python_version < '3.11'"
-    - "toml"
+    - "types-toml"
 # Configuration for codespell is in pyproject.toml
 - repo: https://github.com/codespell-project/codespell
   rev: v2.2.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,7 @@ repos:
     - "packaging>=20"
     - "platformdirs>=2.1"
     - "tomli; python_version < '3.11'"
+    - "toml"
 # Configuration for codespell is in pyproject.toml
 - repo: https://github.com/codespell-project/codespell
   rev: v2.2.6

--- a/changelog.d/1302.feature.md
+++ b/changelog.d/1302.feature.md
@@ -1,0 +1,1 @@
+Support list packages in toml format.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
   "platformdirs>=2.1",
   'tomli; python_version < "3.11"',
   "userpath!=1.9.0,>=1.6",
+  "toml>=0.10.2"
 ]
 urls."Bug Tracker" = "https://github.com/pypa/pipx/issues"
 urls.Documentation = "https://pipx.pypa.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,9 +38,9 @@ dependencies = [
   'colorama>=0.4.4; sys_platform == "win32"',
   "packaging>=20",
   "platformdirs>=2.1",
+  "toml>=0.10.2",
   'tomli; python_version < "3.11"',
   "userpath!=1.9.0,>=1.6",
-  "toml>=0.10.2"
 ]
 urls."Bug Tracker" = "https://github.com/pypa/pipx/issues"
 urls.Documentation = "https://pipx.pypa.io"

--- a/src/pipx/commands/list_packages.py
+++ b/src/pipx/commands/list_packages.py
@@ -17,7 +17,6 @@ from pipx.venv import Venv, VenvContainer
 logger = logging.getLogger(__name__)
 
 PIPX_SPEC_VERSION = "0.1"
-dependencies = []
 
 
 def generate_package_spec(dependencies):

--- a/src/pipx/commands/list_packages.py
+++ b/src/pipx/commands/list_packages.py
@@ -1,9 +1,10 @@
 import json
 import logging
 import sys
-import toml
 from pathlib import Path
 from typing import Any, Collection, Dict, Tuple
+
+import toml
 
 from pipx import paths
 from pipx.colors import bold
@@ -20,15 +21,10 @@ dependencies = []
 
 
 def generate_package_spec(dependencies):
-    package_spec = {
-        "tool": {
-            "pipx": {
-                "dependencies": dependencies
-            }
-        }
-    }
+    package_spec = {"tool": {"pipx": {"dependencies": dependencies}}}
 
     return package_spec
+
 
 def list_pyproject(venv_dirs: Collection[Path]) -> VenvProblems:
     all_venv_problems = VenvProblems()
@@ -37,9 +33,7 @@ def list_pyproject(venv_dirs: Collection[Path]) -> VenvProblems:
         if venv_problems.any_():
             logger.warning(warning_str)
         else:
-            package_spec = generate_package_spec(
-                venv_metadata.main_package.package
-            )
+            package_spec = generate_package_spec(venv_metadata.main_package.package)
             print(toml.dumps(package_spec))
         all_venv_problems.or_(venv_problems)
 

--- a/src/pipx/commands/list_packages.py
+++ b/src/pipx/commands/list_packages.py
@@ -1,9 +1,10 @@
 import json
 import logging
 import sys
-import toml
 from pathlib import Path
 from typing import Any, Collection, Dict, Tuple
+
+import toml
 
 from pipx import paths
 from pipx.colors import bold

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -291,6 +291,7 @@ def run_pipx_command(args: argparse.Namespace, subparsers: Dict[str, argparse.Ar
             args.include_injected,
             args.json,
             args.short,
+            args.pyproject,
         )
     elif args.command == "interpreter":
         if args.interpreter_command == "list":

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -611,7 +611,7 @@ def _add_list(subparsers: argparse._SubParsersAction, shared_parser: argparse.Ar
     g.add_argument("--json", action="store_true", help="Output rich data in json format.")
     g.add_argument("--short", action="store_true", help="List packages only.")
     g.add_argument("--skip-maintenance", action="store_true", help="(deprecated) No-op")
-    g.add_argument('--pyproject', action="store_true", help="List packages from pyproject.toml files.")
+    g.add_argument("--pyproject", action="store_true", help="List packages from pyproject.toml files.")
 
 
 def _add_interpreter(

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -611,6 +611,7 @@ def _add_list(subparsers: argparse._SubParsersAction, shared_parser: argparse.Ar
     g.add_argument("--json", action="store_true", help="Output rich data in json format.")
     g.add_argument("--short", action="store_true", help="List packages only.")
     g.add_argument("--skip-maintenance", action="store_true", help="(deprecated) No-op")
+    g.add_argument('--pyproject', action="store_true", help="List packages from pyproject.toml files.")
 
 
 def _add_interpreter(


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [x] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes
Adds a new argument to copy as a toml file for pyproject.toml.

Fix #1302 

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
# command(s) to exercise these changes
pipx list --help
pipx list --pyproject
```
