### PR TITLE
Avoid reinstalling injected package without --force

### DIFF
--- a/changelog.d/1300.bugfix.md
+++ b/changelog.d/1300.bugfix.md
@@ -1,1 +1,1 @@
-Avoid installing existed injected package without --force
+Do not reinstall already injected packages without `--force` being passed.

--- a/changelog.d/1300.bugfix.md
+++ b/changelog.d/1300.bugfix.md
@@ -1,0 +1,1 @@
+Avoid installing existed injected package without --force

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -7,7 +7,7 @@ from pipx import paths
 from pipx.colors import bold
 from pipx.commands.common import package_name_from_spec, run_post_install_actions
 from pipx.constants import EXIT_CODE_INJECT_ERROR, EXIT_CODE_OK, ExitCode
-from pipx.emojis import stars
+from pipx.emojis import hazard, stars
 from pipx.util import PipxError, pipx_wrap
 from pipx.venv import Venv
 

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -7,7 +7,7 @@ from pipx import paths
 from pipx.colors import bold
 from pipx.commands.common import package_name_from_spec, run_post_install_actions
 from pipx.constants import EXIT_CODE_INJECT_ERROR, EXIT_CODE_OK, ExitCode
-from pipx.emojis import hazard, stars
+from pipx.emojis import stars
 from pipx.util import PipxError, pipx_wrap
 from pipx.venv import Venv
 

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -60,7 +60,7 @@ def inject_dep(
         print(
             pipx_wrap(
                 f"""
-                {package_name} already seems to be injected in {venv.name!r}.
+                {hazard} {package_name} already seems to be injected in {venv.name!r}.
                 Not modifying existing installation in '{venv_dir}'.
                 Pass '--force' to force installation.
                 """

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -8,7 +8,7 @@ from pipx.colors import bold
 from pipx.commands.common import package_name_from_spec, run_post_install_actions
 from pipx.constants import EXIT_CODE_INJECT_ERROR, EXIT_CODE_OK, ExitCode
 from pipx.emojis import stars
-from pipx.util import PipxError
+from pipx.util import PipxError, pipx_wrap
 from pipx.venv import Venv
 
 
@@ -55,6 +55,19 @@ def inject_dep(
             pip_args=pip_args,
             verbose=verbose,
         )
+
+    if not force and venv.has_package(package_name):
+        print(
+            pipx_wrap(
+                f"""
+                {package_name} already seems to be injected in {venv.name!r}.
+                Not modifying existing installation in '{venv_dir}'.
+                Pass '--force' to force installation.
+                """
+            )
+        )
+        return True
+
     if suffix:
         venv_suffix = venv.package_metadata[venv.main_package_name].suffix
     else:

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -424,6 +424,9 @@ class Venv:
             return True
         return (self.bin_path / filename).is_file()
 
+    def has_package(self, package_name: str) -> bool:
+        return bool(list(Distribution.discover(name=package_name, path=[str(get_site_packages(self.python_path))])))
+
     def upgrade_package_no_metadata(self, package_name: str, pip_args: List[str]) -> None:
         with animate(
             f"upgrading {full_package_description(package_name, package_name)}",

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -94,7 +94,7 @@ def test_list_json(pipx_temp_env, capsys):
 
     assert not run_pipx_cli(["install", PKG["pycowsay"]["spec"]])
     assert not run_pipx_cli(["install", PKG["pylint"]["spec"]])
-    assert not run_pipx_cli(["inject", "pylint", PKG["isort"]["spec"]])
+    assert not run_pipx_cli(["inject", "pylint", PKG["black"]["spec"]])
     captured = capsys.readouterr()
 
     assert not run_pipx_cli(["list", "--json"])
@@ -125,13 +125,13 @@ def test_list_json(pipx_temp_env, capsys):
         PackageInfo(**json_parsed["venvs"]["pylint"]["metadata"]["main_package"]),
         pylint_package_ref,
     )
-    assert sorted(json_parsed["venvs"]["pylint"]["metadata"]["injected_packages"].keys()) == ["isort"]
-    isort_package_ref = create_package_info_ref("pylint", "isort", pipx_venvs_dir, include_apps=False)
-    print(isort_package_ref)
-    print(PackageInfo(**json_parsed["venvs"]["pylint"]["metadata"]["injected_packages"]["isort"]))
+    assert sorted(json_parsed["venvs"]["pylint"]["metadata"]["injected_packages"].keys()) == ["black"]
+    black_package_ref = create_package_info_ref("pylint", "black", pipx_venvs_dir, include_apps=False)
+    print(black_package_ref)
+    print(PackageInfo(**json_parsed["venvs"]["pylint"]["metadata"]["injected_packages"]["black"]))
     assert_package_metadata(
-        PackageInfo(**json_parsed["venvs"]["pylint"]["metadata"]["injected_packages"]["isort"]),
-        isort_package_ref,
+        PackageInfo(**json_parsed["venvs"]["pylint"]["metadata"]["injected_packages"]["black"]),
+        black_package_ref,
     )
 
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [x] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

Fix #1300

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
> pipx install pycowsay
  installed package pycowsay 0.0.0.2, installed using Python 3.10.12
  These apps are now globally available
    - pycowsay
  These manual pages are now globally available
    - man6/pycowsay.6
done! ✨ 🌟 ✨
> pipx inject pycowsay cowsay
  injected package cowsay into venv pycowsay
done! ✨ 🌟 ✨
> pipx inject pycowsay cowsay
cowsay already seems to be injected in 'pycowsay'. Not modifying existing installation in '/usr/local/pipx/venvs/pycowsay'. Pass '--force' to force installation.
> pipx inject pycowsay cowsay --force
  injected package cowsay into venv pycowsay
done! ✨ 🌟 ✨
```
