### PR TITLE
Fix `pipx reinstall` crash with absolute path

### DIFF
--- a/changelog.d/1324.bugfix.md
+++ b/changelog.d/1324.bugfix.md
@@ -1,0 +1,1 @@
+Don't allow paths to be passed into `pipx reinstall`, as this might wreak havoc.

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -202,7 +202,8 @@ def run_pipx_command(args: argparse.Namespace, subparsers: Dict[str, argparse.Ar
                     pipx_wrap(
                         f"""
                         Error: Path '{package}' given as
-                        package name.
+                        package. Expected the name of
+                        an installed package.
                         """
                     )
                 )

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -185,7 +185,8 @@ def run_pipx_command(args: argparse.Namespace, subparsers: Dict[str, argparse.Ar
 
     if "package" in args:
         package = args.package
-        if urllib.parse.urlparse(package).scheme:
+        url_parse_package = urllib.parse.urlparse(package)
+        if url_parse_package.scheme and url_parse_package.netloc:
             raise PipxError("Package cannot be a url")
 
         if "spec" in args and args.spec is not None:

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -193,6 +193,19 @@ def run_pipx_command(args: argparse.Namespace, subparsers: Dict[str, argparse.Ar
                 if "#egg=" not in args.spec:
                     args.spec = args.spec + f"#egg={package}"
 
+        if args.command == "reinstall":
+            # Passing paths into `reinstall` might have unintended
+            # side effects.
+            if Path(package).is_absolute() or Path(package).exists():
+                raise PipxError(
+                    pipx_wrap(
+                        f"""
+                        Error: Path '{package}' given as
+                        package name.
+                        """
+                    )
+                )
+
         venv_dir = venv_container.get_venv_dir(package)
         logger.info(f"Virtual Environment location is {venv_dir}")
 

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -75,16 +75,6 @@ class VenvContainer:
 
     def get_venv_dir(self, package_name: str) -> Path:
         """Return the expected venv path for given `package_name`."""
-        if Path(package_name).is_absolute():
-            # An absolute path given would be returned as venv dir
-            raise PipxError(
-                pipx_wrap(
-                    f"""
-                    Error: Path '{package_name}' given as
-                    package name.
-                    """
-                )
-            )
         return self._root.joinpath(canonicalize_name(package_name))
 
 

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -75,6 +75,16 @@ class VenvContainer:
 
     def get_venv_dir(self, package_name: str) -> Path:
         """Return the expected venv path for given `package_name`."""
+        if Path(package_name).is_absolute():
+            # An absolute path given would be returned as venv dir
+            raise PipxError(
+                pipx_wrap(
+                    f"""
+                    Error: Path '{package_name}' given as
+                    package name.
+                    """
+                )
+            )
         return self._root.joinpath(canonicalize_name(package_name))
 
 

--- a/tests/test_reinstall.py
+++ b/tests/test_reinstall.py
@@ -62,9 +62,9 @@ def test_reinstall_with_path(pipx_temp_env, capsys, tmp_path):
     assert run_pipx_cli(["reinstall", str(path)])
     captured = capsys.readouterr()
 
-    assert f"Path '{str(path)}' given as package" in captured.err.replace("\n", " ")
+    assert "Expected the name of an installed package" in captured.err.replace("\n", " ")
 
     assert run_pipx_cli(["reinstall", str(path.resolve())])
     captured = capsys.readouterr()
 
-    assert f"Path '{str(path.resolve())}' given as package" in captured.err.replace("\n", " ")
+    assert "Expected the name of an installed package" in captured.err.replace("\n", " ")

--- a/tests/test_reinstall.py
+++ b/tests/test_reinstall.py
@@ -1,5 +1,4 @@
 import sys
-from pathlib import Path
 
 import pytest  # type: ignore
 

--- a/tests/test_reinstall.py
+++ b/tests/test_reinstall.py
@@ -1,4 +1,5 @@
 import sys
+from pathlib import Path
 
 import pytest  # type: ignore
 
@@ -54,3 +55,20 @@ def test_reinstall_specifier(pipx_temp_env, capsys):
     assert not run_pipx_cli(["reinstall", "--python", sys.executable, "pylint"])
     captured = capsys.readouterr()
     assert "installed package pylint 2.3.1" in captured.out
+
+
+linux_paths = ["/opt/path/file", "rel/path/", "~/tilde-path"]
+windows_paths = ["C:\\Program Files\\PATH", "D:\\TEST\\DIR", "REL\\PATH"]
+
+
+@pytest.mark.parametrize("path", windows_paths if sys.platform.startswith("win") else linux_paths)
+def test_reinstall_with_path(pipx_temp_env, capsys, path):
+    try:
+        Path(path).mkdir(parents=True, exist_ok=True)
+    except PermissionError:
+        pass
+
+    assert run_pipx_cli(["reinstall", path])
+    captured = capsys.readouterr()
+
+    assert "given as package name" in captured.err

--- a/tests/test_reinstall.py
+++ b/tests/test_reinstall.py
@@ -57,18 +57,15 @@ def test_reinstall_specifier(pipx_temp_env, capsys):
     assert "installed package pylint 2.3.1" in captured.out
 
 
-linux_paths = ["/opt/path/file", "rel/path/", "~/tilde-path"]
-windows_paths = ["C:\\Program Files\\PATH", "D:\\TEST\\DIR", "REL\\PATH"]
+def test_reinstall_with_path(pipx_temp_env, capsys, tmp_path):
+    path = tmp_path / "some" / "path"
 
-
-@pytest.mark.parametrize("path", windows_paths if sys.platform.startswith("win") else linux_paths)
-def test_reinstall_with_path(pipx_temp_env, capsys, path):
-    try:
-        Path(path).mkdir(parents=True, exist_ok=True)
-    except PermissionError:
-        pass
-
-    assert run_pipx_cli(["reinstall", path])
+    assert run_pipx_cli(["reinstall", str(path)])
     captured = capsys.readouterr()
 
-    assert "given as package name" in captured.err
+    assert f"Path '{str(path)}' given as package" in captured.err.replace("\n", " ")
+
+    assert run_pipx_cli(["reinstall", str(path.resolve())])
+    captured = capsys.readouterr()
+
+    assert f"Path '{str(path.resolve())}' given as package" in captured.err.replace("\n", " ")


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [x] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

Closes #1324. This checks whether the argument given as package name inside `VenvContainer.get_venv_dir()` is an absolute path or existing path, raising `PipxError` if so. This is due to the behaviour that an absolute path passed into the `pathlib.PurePath.joinpath()` function to join with another path will return the same. 

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
pipx reinstall /some/absolute/path
mkdir existing_path ; pipx reinstall existing_path
```
