### PR TITLE
docs: change --global parameter position on ensurepath command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ _For comparison to other tools including pipsi, see
 ```
 brew install pipx
 pipx ensurepath
-sudo pipx ensurepath --global # optional to allow pipx actions with --global argument
+sudo pipx --global ensurepath # optional to allow pipx actions with --global argument
 ```
 
 Upgrade pipx with `brew update && brew upgrade pipx`.
@@ -50,7 +50,7 @@ Upgrade pipx with `brew update && brew upgrade pipx`.
 sudo apt update
 sudo apt install pipx
 pipx ensurepath
-sudo pipx ensurepath --global # optional to allow pipx actions with --global argument
+sudo pipx --global ensurepath # optional to allow pipx actions with --global argument
 ```
 
 - Fedora:
@@ -58,7 +58,7 @@ sudo pipx ensurepath --global # optional to allow pipx actions with --global arg
 ```
 sudo dnf install pipx
 pipx ensurepath
-sudo pipx ensurepath --global # optional to allow pipx actions with --global argument
+sudo pipx --global ensurepath # optional to allow pipx actions with --global argument
 ```
 
 - Using `pip` on other distributions:
@@ -66,7 +66,7 @@ sudo pipx ensurepath --global # optional to allow pipx actions with --global arg
 ```
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath
-sudo pipx ensurepath --global # optional to allow pipx actions with --global argument
+sudo pipx --global ensurepath # optional to allow pipx actions with --global argument
 ```
 
 Upgrade pipx with `python3 -m pip install --user --upgrade pipx`.

--- a/changelog.d/1337.doc.md
+++ b/changelog.d/1337.doc.md
@@ -1,0 +1,1 @@
+Change --global parameter position on ensurepath command

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,7 +19,7 @@ pipx works on macOS, linux, and Windows.
 ```
 brew install pipx
 pipx ensurepath
-sudo pipx ensurepath --global # optional to allow pipx actions in global scope. See "Global installation" section below.
+sudo pipx --global ensurepath # optional to allow pipx actions in global scope. See "Global installation" section below.
 ```
 
 ### On Linux:
@@ -30,7 +30,7 @@ sudo pipx ensurepath --global # optional to allow pipx actions in global scope. 
 sudo apt update
 sudo apt install pipx
 pipx ensurepath
-sudo pipx ensurepath --global # optional to allow pipx actions in global scope. See "Global installation" section below.
+sudo pipx --global ensurepath # optional to allow pipx actions in global scope. See "Global installation" section below.
 ```
 
 - Fedora:
@@ -38,7 +38,7 @@ sudo pipx ensurepath --global # optional to allow pipx actions in global scope. 
 ```
 sudo dnf install pipx
 pipx ensurepath
-sudo pipx ensurepath --global # optional to allow pipx actions in global scope. See "Global installation" section below.
+sudo pipx --global ensurepath # optional to allow pipx actions in global scope. See "Global installation" section below.
 ```
 
 - Using `pip` on other distributions:
@@ -46,7 +46,7 @@ sudo pipx ensurepath --global # optional to allow pipx actions in global scope. 
 ```
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath
-sudo pipx ensurepath --global # optional to allow pipx actions in global scope. See "Global installation" section below.
+sudo pipx --global ensurepath # optional to allow pipx actions in global scope. See "Global installation" section below.
 ```
 
 
@@ -166,7 +166,7 @@ Pipx also comes with a `--global` argument which helps to execute actions in glo
 all system users. By default the global binary location is set to `/usr/local/bin` and can be overridden with the
 environment variable `PIPX_GLOBAL_BIN_DIR`. Default global manual page location is `/usr/local/share/man`. This
 can be overridden with environment variable `PIPX_GLOBAL_MAN_DIR`. Finally, default global virtual environment location
-is `/opt/pipx`, can be overridden with environment variable `PIPX_GLOBAL_HOME`. Make sure to run `sudo pipx ensurepath --global`
+is `/opt/pipx`, can be overridden with environment variable `PIPX_GLOBAL_HOME`. Make sure to run `sudo pipx --global ensurepath`
 if you intend to use this feature.
 
 Note that the `--global` argument is not supported on Windows.


### PR DESCRIPTION
…tation

<!-- add an 'x' in the brackets below -->

- [x] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

Change --global parameter position on ensurepath command

## Test plan

Tested by running

```
➜  ~ sudo pipx ensurepath --global
Password:
usage: pipx [-h] [--quiet] [--verbose] [--global] [--version]
            {install,uninject,inject,upgrade,upgrade-all,uninstall,uninstall-all,reinstall,reinstall-all,list,interpreter,run,runpip,ensurepath,environment,completions} ...
pipx: error: unrecognized arguments: --global

➜  ~ sudo pipx --global ensurepath
/usr/local/bin is already in PATH.

⚠️  All pipx binary directories have been added to PATH. If you are sure you want to proceed, try again with the '--force' flag.

Otherwise pipx is ready to go! ✨ 🌟 ✨
➜  ~
```
