### PR TITLE
fix: resolve the DEFAULT_PYTHON to the actual absolute path

### DIFF
--- a/changelog.d/965.bugfix.md
+++ b/changelog.d/965.bugfix.md
@@ -1,0 +1,1 @@
+Resolve the `DEFAULT_PYTHON` to the actual absolute path

--- a/src/pipx/interpreter.py
+++ b/src/pipx/interpreter.py
@@ -129,7 +129,7 @@ def _get_sys_executable() -> str:
     if WINDOWS:
         return _find_default_windows_python()
     else:
-        return sys.executable
+        return str(Path(sys.executable).resolve())
 
 
 def _get_absolute_python_interpreter(env_python: str) -> str:


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [x] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

Fix #965 

Use the resolved absolute path for `DEFAULT_PYTHON` can change the default python of pipx-managed pipx from `/usr/local/pipx/venvs/pipx/bin/python` to `/usr/bin/python3.10`. In this way, `pipx reinstall-all` will work for pipx-managed pipx.

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
# command(s) to exercise these changes
pipx install pipx
pipx reinstall-all
```
