### PR TITLE
feat: support Python version for `--python` arg when py launcher is n…

### DIFF
--- a/changelog.d/1342.feature.md
+++ b/changelog.d/1342.feature.md
@@ -1,0 +1,1 @@
+Support Python version for `--python` arg when py launcher is not available

--- a/src/pipx/interpreter.py
+++ b/src/pipx/interpreter.py
@@ -51,7 +51,7 @@ class InterpreterResolutionError(PipxError):
         super().__init__(message, wrap_message)
 
 
-def find_python_command(python_version: str) -> Optional[str]:
+def find_unix_command_python(python_version: str) -> Optional[str]:
     try:
         parsed_python_version = version.parse(python_version)
     except version.InvalidVersion:
@@ -73,7 +73,7 @@ def find_python_command(python_version: str) -> Optional[str]:
             else f"{parsed_python_version.major}.{parsed_python_version.minor}"
         )
 
-        python_command = f"python{python_command_version}.exe" if WINDOWS else f"python{python_command_version}"
+        python_command = f"python{python_command_version}"
         if not shutil.which(python_command):
             logger.info(f"Command `{python_command}` was not found")
             return None
@@ -101,9 +101,10 @@ def find_python_interpreter(python_version: str, fetch_missing_python: bool = Fa
     if shutil.which(python_version):
         return python_version
 
-    python_command = find_python_command(python_version)
-    if python_command:
-        return python_command
+    if not WINDOWS:
+        python_unix_command = find_unix_command_python(python_version)
+        if python_unix_command:
+            return python_unix_command
 
     try:
         py_executable = find_py_launcher_python(python_version)

--- a/src/pipx/interpreter.py
+++ b/src/pipx/interpreter.py
@@ -55,7 +55,7 @@ def find_unix_command_python(python_version: str) -> Optional[str]:
     try:
         parsed_python_version = version.parse(python_version)
     except version.InvalidVersion:
-        logger.info(f"Invalid python version: {python_version}")
+        logger.info(f"Invalid Python version: {python_version}")
         return None
     else:
         if (
@@ -64,7 +64,7 @@ def find_unix_command_python(python_version: str) -> Optional[str]:
             or parsed_python_version.is_postrelease
             or parsed_python_version.is_prerelease
         ):
-            logger.info(f"Unsupported python version: {python_version}")
+            logger.info(f"Unsupported Python version: {python_version}")
             return None
 
         python_command_version = (
@@ -75,7 +75,7 @@ def find_unix_command_python(python_version: str) -> Optional[str]:
 
         python_command = f"python{python_command_version}"
         if not shutil.which(python_command):
-            logger.info(f"Command `{python_command}` was not found")
+            logger.info(f"Command `{python_command}` was not found on the system")
             return None
 
         # Check consistency when micro part is specified
@@ -95,10 +95,7 @@ def find_unix_command_python(python_version: str) -> Optional[str]:
 
 
 def find_python_interpreter(python_version: str, fetch_missing_python: bool = False) -> str:
-    if Path(python_version).is_file():
-        return python_version
-
-    if shutil.which(python_version):
+    if Path(python_version).is_file() or shutil.which(python_version):
         return python_version
 
     if not WINDOWS:

--- a/src/pipx/interpreter.py
+++ b/src/pipx/interpreter.py
@@ -57,31 +57,31 @@ def find_unix_command_python(python_version: str) -> Optional[str]:
     except version.InvalidVersion:
         logger.info(f"Invalid Python version: {python_version}")
         return None
-    else:
-        if (
-            parsed_python_version.epoch != 0
-            or parsed_python_version.is_devrelease
-            or parsed_python_version.is_postrelease
-            or parsed_python_version.is_prerelease
-        ):
-            logger.info(f"Unsupported Python version: {python_version}")
-            return None
 
-        # Python command could be `python3` or `python3.x` without micro version component
-        python_command = f"python{'.'.join(python_version.split('.')[:2])}"
+    if (
+        parsed_python_version.epoch != 0
+        or parsed_python_version.is_devrelease
+        or parsed_python_version.is_postrelease
+        or parsed_python_version.is_prerelease
+    ):
+        logger.info(f"Unsupported Python version: {python_version}")
+        return None
 
-        python_path = shutil.which(python_command)
-        if not python_path:
-            logger.info(f"Command `{python_command}` was not found on the system")
-            return None
+    # Python command could be `python3` or `python3.x` without micro version component
+    python_command = f"python{'.'.join(python_version.split('.')[:2])}"
 
-        if parsed_python_version.micro != 0:
-            logger.warning(
-                f"The command '{python_command}' located at '{python_path}' will be used. "
-                f"It may not match the specified version {python_version} at the micro/patch level."
-            )
+    python_path = shutil.which(python_command)
+    if not python_path:
+        logger.info(f"Command `{python_command}` was not found on the system")
+        return None
 
-        return python_path
+    if parsed_python_version.micro != 0:
+        logger.warning(
+            f"The command '{python_command}' located at '{python_path}' will be used. "
+            f"It may not match the specified version {python_version} at the micro/patch level."
+        )
+
+    return python_path
 
 
 def find_python_interpreter(python_version: str, fetch_missing_python: bool = False) -> str:

--- a/src/pipx/interpreter.py
+++ b/src/pipx/interpreter.py
@@ -74,17 +74,18 @@ def find_unix_command_python(python_version: str) -> Optional[str]:
         )
 
         python_command = f"python{python_command_version}"
-        if not shutil.which(python_command):
+        python_path = shutil.which(python_command)
+        if not python_path:
             logger.info(f"Command `{python_command}` was not found on the system")
             return None
 
         if parsed_python_version.micro != 0:
             logger.warning(
-                f"The command `{python_command}` will be used and "
-                f"may not match the specified version {python_version} at the micro/patch level"
+                f"The command `{python_command}` located at `{python_path}` will be used. "
+                f"It may not match the specified version {python_version} at the micro/patch level."
             )
 
-        return python_command
+        return python_path
 
 
 def find_python_interpreter(python_version: str, fetch_missing_python: bool = False) -> str:

--- a/src/pipx/interpreter.py
+++ b/src/pipx/interpreter.py
@@ -78,18 +78,11 @@ def find_unix_command_python(python_version: str) -> Optional[str]:
             logger.info(f"Command `{python_command}` was not found on the system")
             return None
 
-        # Check consistency when micro part is specified
         if parsed_python_version.micro != 0:
-            command = [python_command, "-c", "import sys; print('.'.join(map(str,sys.version_info[:3])))"]
-            python_command_full_version = subprocess.run(
-                command, text=True, capture_output=True, check=True
-            ).stdout.strip()
-            if parsed_python_version != version.Version(python_command_full_version):
-                logger.info(
-                    f"The command `{python_command}` is at version {python_command_full_version}, "
-                    f"which does not match the requested version {python_version} in patch level"
-                )
-                return None
+            logger.warning(
+                f"The command `{python_command}` will be used and "
+                f"may not match the specified version {python_version} at the micro/patch level"
+            )
 
         return python_command
 

--- a/src/pipx/interpreter.py
+++ b/src/pipx/interpreter.py
@@ -77,7 +77,7 @@ def find_unix_command_python(python_version: str) -> Optional[str]:
 
         if parsed_python_version.micro != 0:
             logger.warning(
-                f"The command `{python_command}` located at `{python_path}` will be used. "
+                f"The command '{python_command}' located at '{python_path}' will be used. "
                 f"It may not match the specified version {python_version} at the micro/patch level."
             )
 

--- a/src/pipx/interpreter.py
+++ b/src/pipx/interpreter.py
@@ -67,13 +67,9 @@ def find_unix_command_python(python_version: str) -> Optional[str]:
             logger.info(f"Unsupported Python version: {python_version}")
             return None
 
-        python_command_version = (
-            str(parsed_python_version.major)
-            if parsed_python_version.minor == 0
-            else f"{parsed_python_version.major}.{parsed_python_version.minor}"
-        )
+        # Python command could be `python3` or `python3.x` without micro version
+        python_command = f"python{'.'.join(python_version.split('.')[:2])}"
 
-        python_command = f"python{python_command_version}"
         python_path = shutil.which(python_command)
         if not python_path:
             logger.info(f"Command `{python_command}` was not found on the system")

--- a/src/pipx/interpreter.py
+++ b/src/pipx/interpreter.py
@@ -67,12 +67,13 @@ def find_python_command(python_version: str) -> Optional[str]:
             logger.info(f"Unsupported python version: {python_version}")
             return None
 
-        if parsed_python_version.minor == 0:
-            python_command_version = str(parsed_python_version.major)
-        else:
-            python_command_version = f"{parsed_python_version.major}.{parsed_python_version.minor}"
+        python_command_version = (
+            str(parsed_python_version.major)
+            if parsed_python_version.minor == 0
+            else f"{parsed_python_version.major}.{parsed_python_version.minor}"
+        )
 
-        python_command = f"python{python_command_version}"
+        python_command = f"python{python_command_version}.exe" if WINDOWS else f"python{python_command_version}"
         if not shutil.which(python_command):
             logger.info(f"Command `{python_command}` was not found")
             return None
@@ -97,19 +98,19 @@ def find_python_interpreter(python_version: str, fetch_missing_python: bool = Fa
     if Path(python_version).is_file():
         return python_version
 
-    try:
-        py_executable = find_py_launcher_python(python_version)
-        if py_executable:
-            return py_executable
-    except (subprocess.CalledProcessError, FileNotFoundError) as e:
-        raise InterpreterResolutionError(source="py launcher", version=python_version) from e
-
     if shutil.which(python_version):
         return python_version
 
     python_command = find_python_command(python_version)
     if python_command:
         return python_command
+
+    try:
+        py_executable = find_py_launcher_python(python_version)
+        if py_executable:
+            return py_executable
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        raise InterpreterResolutionError(source="py launcher", version=python_version) from e
 
     if fetch_missing_python or FETCH_MISSING_PYTHON:
         try:

--- a/src/pipx/interpreter.py
+++ b/src/pipx/interpreter.py
@@ -67,7 +67,7 @@ def find_unix_command_python(python_version: str) -> Optional[str]:
             logger.info(f"Unsupported Python version: {python_version}")
             return None
 
-        # Python command could be `python3` or `python3.x` without micro version
+        # Python command could be `python3` or `python3.x` without micro version component
         python_command = f"python{'.'.join(python_version.split('.')[:2])}"
 
         python_path = shutil.which(python_command)

--- a/src/pipx/interpreter.py
+++ b/src/pipx/interpreter.py
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+from packaging import version
+
 from pipx.constants import FETCH_MISSING_PYTHON, WINDOWS
 from pipx.standalone_python import download_python_build_standalone
 from pipx.util import PipxError
@@ -41,11 +43,54 @@ class InterpreterResolutionError(PipxError):
                 message += "The provided version looks like a path, but no executable was found there."
             if potentially_pylauncher:
                 message += (
-                    "The provided version looks like a version for Python Launcher, " "but `py` was not found on PATH."
+                    "The provided version looks like a version, "
+                    "but both the python command and the Python Launcher were not found on PATH."
                 )
         if source == "the python-build-standalone project":
             message += "listed in https://github.com/indygreg/python-build-standalone/releases/latest."
         super().__init__(message, wrap_message)
+
+
+def find_python_command(python_version: str) -> Optional[str]:
+    try:
+        parsed_python_version = version.parse(python_version)
+    except version.InvalidVersion:
+        logger.info(f"Invalid python version: {python_version}")
+        return None
+    else:
+        if (
+            parsed_python_version.epoch != 0
+            or parsed_python_version.is_devrelease
+            or parsed_python_version.is_postrelease
+            or parsed_python_version.is_prerelease
+        ):
+            logger.info(f"Unsupported python version: {python_version}")
+            return None
+
+        if parsed_python_version.minor == 0:
+            python_command_version = str(parsed_python_version.major)
+        else:
+            python_command_version = f"{parsed_python_version.major}.{parsed_python_version.minor}"
+
+        python_command = f"python{python_command_version}"
+        if not shutil.which(python_command):
+            logger.info(f"Command `{python_command}` was not found")
+            return None
+
+        # Check consistency when micro part is specified
+        if parsed_python_version.micro != 0:
+            command = [python_command, "-c", "import sys; print('.'.join(map(str,sys.version_info[:3])))"]
+            python_command_full_version = subprocess.run(
+                command, text=True, capture_output=True, check=True
+            ).stdout.strip()
+            if parsed_python_version != version.Version(python_command_full_version):
+                logger.info(
+                    f"The command `{python_command}` is at version {python_command_full_version}, "
+                    f"which does not match the requested version {python_version} in patch level"
+                )
+                return None
+
+        return python_command
 
 
 def find_python_interpreter(python_version: str, fetch_missing_python: bool = False) -> str:
@@ -61,6 +106,10 @@ def find_python_interpreter(python_version: str, fetch_missing_python: bool = Fa
 
     if shutil.which(python_version):
         return python_version
+
+    python_command = find_python_command(python_version)
+    if python_command:
+        return python_command
 
     if fetch_missing_python or FETCH_MISSING_PYTHON:
         try:

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -428,7 +428,7 @@ def add_python_options(parser: argparse.ArgumentParser) -> None:
         "--python",
         help=(
             "Python to install with. Possible values can be the executable name (python3.11), "
-            "the version to construct python command or to pass to py launcher (3.11), "
+            "the version of an available system Python or to pass to py launcher (3.11), "
             f"or the full path to the executable. Requires Python {MINIMUM_PYTHON_VERSION} or above."
         ),
     )

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -428,8 +428,8 @@ def add_python_options(parser: argparse.ArgumentParser) -> None:
         "--python",
         help=(
             "Python to install with. Possible values can be the executable name (python3.11), "
-            "the version to pass to py launcher (3.11), or the full path to the executable."
-            f"Requires Python {MINIMUM_PYTHON_VERSION} or above."
+            "the version to construct python command or to pass to py launcher (3.11), "
+            f"or the full path to the executable. Requires Python {MINIMUM_PYTHON_VERSION} or above."
         ),
     )
     parser.add_argument(

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -405,7 +405,7 @@ def test_install_python_command_version_invalid(pipx_temp_env, capsys):
     python_version = "3.x"
     assert run_pipx_cli(["install", "--python", python_version, "--verbose", "pycowsay"])
     captured = capsys.readouterr()
-    assert f"Invalid python version: {python_version}" in captured.err
+    assert f"Invalid Python version: {python_version}" in captured.err
 
 
 @skip_if_windows
@@ -413,7 +413,7 @@ def test_install_python_command_version_unsupported(pipx_temp_env, capsys):
     python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}.dev"
     assert run_pipx_cli(["install", "--python", python_version, "--verbose", "pycowsay"])
     captured = capsys.readouterr()
-    assert f"Unsupported python version: {python_version}" in captured.err
+    assert f"Unsupported Python version: {python_version}" in captured.err
 
 
 @skip_if_windows

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -434,4 +434,4 @@ def test_install_python_command_version_micro_mismatch(pipx_temp_env, monkeypatc
     python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro + 1}"
     assert not run_pipx_cli(["install", "--python", python_version, "--verbose", "pycowsay"])
     captured = capsys.readouterr()
-    assert f"may not match the specified version {python_version} at the micro/patch level" in captured.err
+    assert f"It may not match the specified version {python_version} at the micro/patch level" in captured.err

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -387,6 +387,7 @@ def test_install_run_in_separate_directory(caplog, capsys, pipx_temp_env, monkey
     install_packages(capsys, pipx_temp_env, caplog, ["pycowsay"], ["pycowsay"])
 
 
+@skip_if_windows
 @pytest.mark.parametrize(
     "python_version",
     [
@@ -395,32 +396,33 @@ def test_install_run_in_separate_directory(caplog, capsys, pipx_temp_env, monkey
         f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
     ],
 )
-def test_install_valid_python_command_version(capsys, python_version):
+def test_install_python_command_version(python_version):
     assert not run_pipx_cli(["install", "--python", python_version, "--verbose", "pycowsay"])
 
 
-def test_install_invalid_python_command_version(pipx_temp_env, capsys):
+@skip_if_windows
+def test_install_python_command_version_invalid(pipx_temp_env, capsys):
     python_version = "3.x"
     assert run_pipx_cli(["install", "--python", python_version, "--verbose", "pycowsay"])
     captured = capsys.readouterr()
     assert f"Invalid python version: {python_version}" in captured.err
 
-
-def test_install_unsupported_python_command_version(pipx_temp_env, capsys):
+@skip_if_windows
+def test_install_python_command_version_unsupported(pipx_temp_env, capsys):
     python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}.dev"
     assert run_pipx_cli(["install", "--python", python_version, "--verbose", "pycowsay"])
     captured = capsys.readouterr()
     assert f"Unsupported python version: {python_version}" in captured.err
 
-
-def test_install_non_exist_python_command_version(pipx_temp_env, capsys):
+@skip_if_windows
+def test_install_python_command_version_non_exist(pipx_temp_env, capsys):
     python_version = f"{sys.version_info.major + 99}.{sys.version_info.minor}"
     assert run_pipx_cli(["install", "--python", python_version, "--verbose", "pycowsay"])
     captured = capsys.readouterr()
     assert f"Command `python{python_version}` was not found" in captured.err
 
-
-def test_install_mismatch_macro_python_command_version(capsys):
+@skip_if_windows
+def test_install_python_command_version_micro_mismatch(capsys):
     python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro + 1}"
     assert run_pipx_cli(["install", "--python", python_version, "--verbose", "pycowsay"])
     captured = capsys.readouterr()

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -396,8 +396,11 @@ def test_install_run_in_separate_directory(caplog, capsys, pipx_temp_env, monkey
         f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
     ],
 )
-def test_install_python_command_version(python_version):
+def test_install_python_command_version(pipx_temp_env, monkeypatch, capsys, python_version):
+    monkeypatch.setenv("PATH", os.getenv("PATH_ORIG"))
     assert not run_pipx_cli(["install", "--python", python_version, "--verbose", "pycowsay"])
+    captured = capsys.readouterr()
+    assert python_version in captured.out
 
 
 @skip_if_windows
@@ -417,7 +420,8 @@ def test_install_python_command_version_unsupported(pipx_temp_env, capsys):
 
 
 @skip_if_windows
-def test_install_python_command_version_non_exist(pipx_temp_env, capsys):
+def test_install_python_command_version_non_exist(pipx_temp_env, monkeypatch, capsys):
+    monkeypatch.setenv("PATH", os.getenv("PATH_ORIG"))
     python_version = f"{sys.version_info.major + 99}.{sys.version_info.minor}"
     assert run_pipx_cli(["install", "--python", python_version, "--verbose", "pycowsay"])
     captured = capsys.readouterr()
@@ -425,7 +429,8 @@ def test_install_python_command_version_non_exist(pipx_temp_env, capsys):
 
 
 @skip_if_windows
-def test_install_python_command_version_micro_mismatch(capsys):
+def test_install_python_command_version_micro_mismatch(pipx_temp_env, monkeypatch, capsys):
+    monkeypatch.setenv("PATH", os.getenv("PATH_ORIG"))
     python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro + 1}"
     assert run_pipx_cli(["install", "--python", python_version, "--verbose", "pycowsay"])
     captured = capsys.readouterr()

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -407,6 +407,7 @@ def test_install_python_command_version_invalid(pipx_temp_env, capsys):
     captured = capsys.readouterr()
     assert f"Invalid python version: {python_version}" in captured.err
 
+
 @skip_if_windows
 def test_install_python_command_version_unsupported(pipx_temp_env, capsys):
     python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}.dev"
@@ -414,12 +415,14 @@ def test_install_python_command_version_unsupported(pipx_temp_env, capsys):
     captured = capsys.readouterr()
     assert f"Unsupported python version: {python_version}" in captured.err
 
+
 @skip_if_windows
 def test_install_python_command_version_non_exist(pipx_temp_env, capsys):
     python_version = f"{sys.version_info.major + 99}.{sys.version_info.minor}"
     assert run_pipx_cli(["install", "--python", python_version, "--verbose", "pycowsay"])
     captured = capsys.readouterr()
     assert f"Command `python{python_version}` was not found" in captured.err
+
 
 @skip_if_windows
 def test_install_python_command_version_micro_mismatch(capsys):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -386,15 +386,15 @@ def test_install_run_in_separate_directory(caplog, capsys, pipx_temp_env, monkey
 
     install_packages(capsys, pipx_temp_env, caplog, ["pycowsay"], ["pycowsay"])
 
-
-def test_install_valid_python_command_version(capsys):
-    python_version = "3"
-    assert not run_pipx_cli(["install", "--python", python_version, "--verbose", "pycowsay"])
-
-    python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
-    assert not run_pipx_cli(["install", "--python", python_version, "--verbose", "pycowsay"])
-
-    python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+@pytest.mark.parametrize(
+    "python_version",
+    [
+        str(sys.version_info.major),
+        f"{sys.version_info.major}.{sys.version_info.minor}",
+        f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+    ]
+)
+def test_install_valid_python_command_version(capsys, python_version):
     assert not run_pipx_cli(["install", "--python", python_version, "--verbose", "pycowsay"])
 
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -432,6 +432,6 @@ def test_install_python_command_version_non_exist(pipx_temp_env, monkeypatch, ca
 def test_install_python_command_version_micro_mismatch(pipx_temp_env, monkeypatch, capsys):
     monkeypatch.setenv("PATH", os.getenv("PATH_ORIG"))
     python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro + 1}"
-    assert run_pipx_cli(["install", "--python", python_version, "--verbose", "pycowsay"])
+    assert not run_pipx_cli(["install", "--python", python_version, "--verbose", "pycowsay"])
     captured = capsys.readouterr()
-    assert f"which does not match the requested version {python_version} in patch level" in captured.err
+    assert f"may not match the specified version {python_version} at the micro/patch level" in captured.err

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -420,7 +420,7 @@ def test_install_python_command_version_unsupported(pipx_temp_env, capsys):
 
 
 @skip_if_windows
-def test_install_python_command_version_non_exist(pipx_temp_env, monkeypatch, capsys):
+def test_install_python_command_version_missing(pipx_temp_env, monkeypatch, capsys):
     monkeypatch.setenv("PATH", os.getenv("PATH_ORIG"))
     python_version = f"{sys.version_info.major + 99}.{sys.version_info.minor}"
     assert run_pipx_cli(["install", "--python", python_version, "--verbose", "pycowsay"])

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -386,13 +386,14 @@ def test_install_run_in_separate_directory(caplog, capsys, pipx_temp_env, monkey
 
     install_packages(capsys, pipx_temp_env, caplog, ["pycowsay"], ["pycowsay"])
 
+
 @pytest.mark.parametrize(
     "python_version",
     [
         str(sys.version_info.major),
         f"{sys.version_info.major}.{sys.version_info.minor}",
         f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
-    ]
+    ],
 )
 def test_install_valid_python_command_version(capsys, python_version):
     assert not run_pipx_cli(["install", "--python", python_version, "--verbose", "pycowsay"])

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -416,7 +416,7 @@ def test_install_non_exist_python_command_version(pipx_temp_env, capsys):
     python_version = f"{sys.version_info.major + 99}.{sys.version_info.minor}"
     assert run_pipx_cli(["install", "--python", python_version, "--verbose", "pycowsay"])
     captured = capsys.readouterr()
-    assert f"Command `{python_version}` was not found" in captured.err
+    assert f"Command `python{python_version}` was not found" in captured.err
 
 
 def test_install_mismatch_macro_python_command_version(capsys):

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -23,7 +23,8 @@ from pipx.util import PipxError
 @pytest.mark.parametrize("venv", [True, False])
 def test_windows_python_with_version(monkeypatch, venv):
     def which(name):
-        return "py"
+        if name == "py":
+            return "py"
 
     major = sys.version_info.major
     minor = sys.version_info.minor
@@ -39,7 +40,8 @@ def test_windows_python_with_version(monkeypatch, venv):
 @pytest.mark.parametrize("venv", [True, False])
 def test_windows_python_with_python_and_version(monkeypatch, venv):
     def which(name):
-        return "py"
+        if name == "py":
+            return "py"
 
     major = sys.version_info.major
     minor = sys.version_info.minor
@@ -55,7 +57,8 @@ def test_windows_python_with_python_and_version(monkeypatch, venv):
 @pytest.mark.parametrize("venv", [True, False])
 def test_windows_python_with_python_and_unavailable_version(monkeypatch, venv):
     def which(name):
-        return "py"
+        if name == "py":
+            return "py"
 
     major = sys.version_info.major + 99
     minor = sys.version_info.minor
@@ -73,6 +76,8 @@ def test_windows_python_no_version_with_venv(monkeypatch):
 
 def test_windows_python_no_version_no_venv_with_py(monkeypatch):
     def which(name):
+        if name == "py":
+            return "py"
         return "py"
 
     monkeypatch.setattr(pipx.interpreter, "has_venv", lambda: False)

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -76,8 +76,6 @@ def test_windows_python_no_version_with_venv(monkeypatch):
 
 def test_windows_python_no_version_no_venv_with_py(monkeypatch):
     def which(name):
-        if name == "py":
-            return "py"
         return "py"
 
     monkeypatch.setattr(pipx.interpreter, "has_venv", lambda: False)

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -16,6 +16,7 @@ from pipx.interpreter import (
     find_python_interpreter,
 )
 from pipx.util import PipxError
+from helpers import skip_if_windows
 
 
 @pytest.mark.skipif(not sys.platform.startswith("win"), reason="Looks for Python.exe")
@@ -199,6 +200,7 @@ def test_fetch_missing_python(monkeypatch, mocked_github_api):
         subprocess.run([python_path, "-c", "import sys; print(sys.executable)"], check=True)
 
 
+@skip_if_windows
 @pytest.mark.parametrize(
     "python_version",
     [
@@ -206,41 +208,46 @@ def test_fetch_missing_python(monkeypatch, mocked_github_api):
         f"{sys.version_info.major}.{sys.version_info.minor}",
     ],
 )
-def test_valid_python_command_version(python_version):
+def test_find_unix_command_python_valid(python_version):
     python_path = find_python_interpreter(python_version)
     assert python_path is not None
     assert python_path.endswith(f"python{python_version}")
 
 
-def test_valid_micro_python_command_version():
+@skip_if_windows
+def test_find_unix_command_python_micro():
     python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
     python_path = find_python_interpreter(python_version)
     assert python_path is not None
     assert python_path.endswith(f"python{sys.version_info.major}.{sys.version_info.minor}")
 
 
-def test_invalid_python_command_version():
+@skip_if_windows
+def test_find_unix_command_python_invalid():
     python_version = f"{sys.version_info.major}.x"
     with pytest.raises(InterpreterResolutionError) as e:
         find_python_interpreter(python_version)
     assert "the python command" in str(e)
 
 
-def test_unsupported_python_command_version():
+@skip_if_windows
+def test_find_unix_command_python_unsupported():
     python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}.dev"
     with pytest.raises(InterpreterResolutionError) as e:
         find_python_interpreter(python_version)
     assert "the python command" in str(e)
 
 
-def test_non_exist_python_command_version():
+@skip_if_windows
+def test_find_unix_command_python_no_exist():
     python_version = f"{sys.version_info.major + 99}.{sys.version_info.minor}"
     with pytest.raises(InterpreterResolutionError) as e:
         find_python_interpreter(python_version)
     assert "the python command" in str(e)
 
 
-def test_mismatch_macro_python_command_version():
+@skip_if_windows
+def test_find_unix_command_python_micro_mismatch():
     python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro + 1}"
     with pytest.raises(InterpreterResolutionError) as e:
         find_python_interpreter(python_version)

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -252,6 +252,6 @@ def test_find_unix_command_python_no_exist():
 @skip_if_windows
 def test_find_unix_command_python_micro_mismatch():
     python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro + 1}"
-    with pytest.raises(InterpreterResolutionError) as e:
-        find_python_interpreter(python_version)
-    assert "the python command" in str(e)
+    python_path = find_python_interpreter(python_version)
+    assert python_path is not None
+    assert f"{sys.version_info.major}.{sys.version_info.minor}" in python_path

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -198,12 +198,13 @@ def test_fetch_missing_python(monkeypatch, mocked_github_api):
             assert python_path.endswith("python3")
         subprocess.run([python_path, "-c", "import sys; print(sys.executable)"], check=True)
 
+
 @pytest.mark.parametrize(
     "python_version",
     [
         str(sys.version_info.major),
         f"{sys.version_info.major}.{sys.version_info.minor}",
-    ]
+    ],
 )
 def test_valid_python_command_version(python_version):
     python_path = find_python_interpreter(python_version)

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -8,6 +8,7 @@ import pytest  # type: ignore
 import pipx.interpreter
 import pipx.paths
 import pipx.standalone_python
+from helpers import skip_if_windows
 from pipx.constants import WINDOWS
 from pipx.interpreter import (
     InterpreterResolutionError,
@@ -16,7 +17,6 @@ from pipx.interpreter import (
     find_python_interpreter,
 )
 from pipx.util import PipxError
-from helpers import skip_if_windows
 
 
 @pytest.mark.skipif(not sys.platform.startswith("win"), reason="Looks for Python.exe")

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -17,7 +17,6 @@ from pipx.interpreter import (
 )
 from pipx.util import PipxError
 
-
 original_which = shutil.which
 
 

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -198,26 +198,24 @@ def test_fetch_missing_python(monkeypatch, mocked_github_api):
             assert python_path.endswith("python3")
         subprocess.run([python_path, "-c", "import sys; print(sys.executable)"], check=True)
 
-
-def test_valid_python_command_version():
-    major = sys.version_info.major
-    minor = sys.version_info.minor
-    micro = sys.version_info.micro
-
-    python_version = str(major)
+@pytest.mark.parametrize(
+    "python_version",
+    [
+        str(sys.version_info.major),
+        f"{sys.version_info.major}.{sys.version_info.minor}",
+    ]
+)
+def test_valid_python_command_version(python_version):
     python_path = find_python_interpreter(python_version)
     assert python_path is not None
-    assert python_path.endswith(f"python{major}")
+    assert python_path.endswith(f"python{python_version}")
 
-    python_version = f"{major}.{minor}"
+
+def test_valid_micro_python_command_version():
+    python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
     python_path = find_python_interpreter(python_version)
     assert python_path is not None
-    assert python_path.endswith(f"python{major}.{minor}")
-
-    python_version = f"{major}.{minor}.{micro}"
-    python_path = find_python_interpreter(python_version)
-    assert python_path is not None
-    assert python_path.endswith(f"python{major}.{minor}")
+    assert python_path.endswith(f"python{sys.version_info.major}.{sys.version_info.minor}")
 
 
 def test_invalid_python_command_version():

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -197,3 +197,52 @@ def test_fetch_missing_python(monkeypatch, mocked_github_api):
         else:
             assert python_path.endswith("python3")
         subprocess.run([python_path, "-c", "import sys; print(sys.executable)"], check=True)
+
+
+def test_valid_python_command_version():
+    major = sys.version_info.major
+    minor = sys.version_info.minor
+    micro = sys.version_info.micro
+
+    python_version = str(major)
+    python_path = find_python_interpreter(python_version)
+    assert python_path is not None
+    assert python_path.endswith(f"python{major}")
+
+    python_version = f"{major}.{minor}"
+    python_path = find_python_interpreter(python_version)
+    assert python_path is not None
+    assert python_path.endswith(f"python{major}.{minor}")
+
+    python_version = f"{major}.{minor}.{micro}"
+    python_path = find_python_interpreter(python_version)
+    assert python_path is not None
+    assert python_path.endswith(f"python{major}.{minor}")
+
+
+def test_invalid_python_command_version():
+    python_version = f"{sys.version_info.major}.x"
+    with pytest.raises(InterpreterResolutionError) as e:
+        find_python_interpreter(python_version)
+    assert "the python command" in str(e)
+
+
+def test_unsupported_python_command_version():
+    python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}.dev"
+    with pytest.raises(InterpreterResolutionError) as e:
+        find_python_interpreter(python_version)
+    assert "the python command" in str(e)
+
+
+def test_non_exist_python_command_version():
+    python_version = f"{sys.version_info.major + 99}.{sys.version_info.minor}"
+    with pytest.raises(InterpreterResolutionError) as e:
+        find_python_interpreter(python_version)
+    assert "the python command" in str(e)
+
+
+def test_mismatch_macro_python_command_version():
+    python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro + 1}"
+    with pytest.raises(InterpreterResolutionError) as e:
+        find_python_interpreter(python_version)
+    assert "the python command" in str(e)


### PR DESCRIPTION
…ot available

<!-- add an 'x' in the brackets below -->

- [x] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

Close #1342

1. Add `find_python_command()` to find python command according to provided python version.
2. Add corresponding tests for `pipx install` and `find_python_interpreter()`.

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
# command(s) to exercise these changes
nox -s tests
```

BTW, I am a little confused about the fixture `pipx_temp_env`, seems `shutil.which(python_command)` will always return empty result when it is enabled. So I removed it in some related test cases. Please help me to double confirm whether it is used as expected.
