### PR TITLE
feature: make install-all gather errors in batch

### DIFF
--- a/changelog.d/1348.feature.md
+++ b/changelog.d/1348.feature.md
@@ -1,0 +1,1 @@
+make `install-all` gather errors in batch

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -10,6 +10,7 @@ from pipx.constants import (
     EXIT_CODE_OK,
     ExitCode,
 )
+from pipx.emojis import sleep
 from pipx.interpreter import DEFAULT_PYTHON
 from pipx.pipx_metadata_file import PackageInfo, PipxMetadata, _json_decoder_object_hook
 from pipx.util import PipxError, pipx_wrap
@@ -188,6 +189,7 @@ def install_all(
     """Return pipx exit code."""
     venv_container = VenvContainer(paths.ctx.venvs)
     failed: List[str] = []
+    installed: List[str] = []
 
     for venv_metadata in extract_venv_metadata(spec_metadata_file):
         # Install the main package
@@ -227,6 +229,10 @@ def install_all(
         except PipxError as e:
             print(e, file=sys.stderr)
             failed.append(venv_dir.name)
+        else:
+            installed.append(venv_dir.name)
+    if len(installed) == 0:
+        print(f"No packages installed after running 'pipx install-all {spec_metadata_file}' {sleep}")
     if len(failed) > 0:
         raise PipxError(f"The following package(s) failed to install: {', '.join(failed)}")
     # Any failure to install will raise PipxError, otherwise success

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -232,7 +232,7 @@ def install_all(
         else:
             installed.append(venv_dir.name)
     if len(installed) == 0:
-        print(f"No packages installed after running 'pipx install-all {spec_metadata_file}' {sleep}")
+        print(f"{sleep} No packages installed after running 'pipx install-all {spec_metadata_file}'")
     if len(failed) > 0:
         raise PipxError(f"The following package(s) failed to install: {', '.join(failed)}")
     # Any failure to install will raise PipxError, otherwise success

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -186,16 +186,15 @@ def install_all(
     force: bool,
 ) -> ExitCode:
     """Return pipx exit code."""
-    failed: List[str] = []
     venv_container = VenvContainer(paths.ctx.venvs)
+    failed: List[str] = []
 
     for venv_metadata in extract_venv_metadata(spec_metadata_file):
         # Install the main package
         main_package = venv_metadata.main_package
         venv_dir = venv_container.get_venv_dir(f"{main_package.package}{main_package.suffix}")
         try:
-            package_exit = 0
-            package_exit |= install(
+            install(
                 venv_dir,
                 None,
                 [generate_package_spec(main_package)],
@@ -214,7 +213,7 @@ def install_all(
 
             # Install the injected packages
             for inject_package in venv_metadata.injected_packages.values():
-                package_exit |= commands.inject(
+                commands.inject(
                     venv_dir,
                     None,
                     [generate_package_spec(inject_package)],

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -228,9 +228,6 @@ def install_all(
         except PipxError as e:
             print(e, file=sys.stderr)
             failed.append(venv_dir.name)
-        else:
-            if package_exit != 0:
-                failed.append(venv_dir.name)
     if len(failed) > 0:
         raise PipxError(f"The following package(s) failed to install: {', '.join(failed)}")
     # Any failure to install will raise PipxError, otherwise success

--- a/testdata/pipx_metadata_multiple_errors.json
+++ b/testdata/pipx_metadata_multiple_errors.json
@@ -1,0 +1,65 @@
+{
+    "pipx_spec_version": "0.1",
+    "venvs": {
+        "dotenv": {
+            "metadata": {
+                "injected_packages": {},
+                "main_package": {
+                    "app_paths": [
+                    ],
+                    "app_paths_of_dependencies": {},
+                    "apps": [
+                    ],
+                    "apps_of_dependencies": [],
+                    "include_apps": true,
+                    "include_dependencies": false,
+                    "man_pages": [],
+                    "man_pages_of_dependencies": [],
+                    "man_paths": [],
+                    "man_paths_of_dependencies": {},
+                    "package": "dotenv",
+                    "package_or_url": "dotenv",
+                    "package_version": "0.0.5",
+                    "pip_args": [],
+                    "suffix": ""
+                },
+                "pipx_metadata_version": "0.4",
+                "python_version": "Python 3.10.12",
+                "source_interpreter": {
+                },
+                "venv_args": []
+            }
+        },
+        "weblate": {
+            "metadata": {
+                "injected_packages": {},
+                "main_package": {
+                    "app_paths": [
+                    ],
+                    "app_paths_of_dependencies": {},
+                    "apps": [
+                    ],
+                    "apps_of_dependencies": [],
+                    "include_apps": true,
+                    "include_dependencies": false,
+                    "man_pages": [
+                    ],
+                    "man_pages_of_dependencies": [],
+                    "man_paths": [
+                    ],
+                    "man_paths_of_dependencies": {},
+                    "package": "weblate",
+                    "package_or_url": "weblate",
+                    "package_version": "4.3.1",
+                    "pip_args": [],
+                    "suffix": ""
+                },
+                "pipx_metadata_version": "0.4",
+                "python_version": "Python 3.10.12",
+                "source_interpreter": {
+                },
+                "venv_args": []
+            }
+        }
+    }
+}

--- a/tests/test_install_all.py
+++ b/tests/test_install_all.py
@@ -20,3 +20,10 @@ def test_install_all(pipx_temp_env, tmp_path, capsys):
     captured = capsys.readouterr()
     assert "black" in captured.out
     assert "pycowsay" in captured.out
+
+
+def test_install_all_multiple_errors(pipx_temp_env, root, capsys):
+    pipx_metadata_path = root / "testdata" / "pipx_metadata_multiple_errors.json"
+    assert run_pipx_cli(["install-all", str(pipx_metadata_path)])
+    captured = capsys.readouterr()
+    assert "The following package(s) failed to install: dotenv, weblate" in captured.err

--- a/tests/test_install_all.py
+++ b/tests/test_install_all.py
@@ -27,3 +27,4 @@ def test_install_all_multiple_errors(pipx_temp_env, root, capsys):
     assert run_pipx_cli(["install-all", str(pipx_metadata_path)])
     captured = capsys.readouterr()
     assert "The following package(s) failed to install: dotenv, weblate" in captured.err
+    assert "No packages installed after running 'pipx install-all" in captured.out

--- a/tests/test_install_all.py
+++ b/tests/test_install_all.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from helpers import run_pipx_cli
+
+
+def test_install_all(pipx_temp_env, tmp_path, capsys):
+    assert not run_pipx_cli(["install", "pycowsay"])
+    assert not run_pipx_cli(["install", "black"])
+    _ = capsys.readouterr()
+
+    assert not run_pipx_cli(["list", "--json"])
+    captured = capsys.readouterr()
+
+    pipx_list_path = Path(tmp_path) / "pipx_list.json"
+    with open(pipx_list_path, "w") as pipx_list_fh:
+        pipx_list_fh.write(captured.out)
+
+    assert not run_pipx_cli(["install-all", str(pipx_list_path)])

--- a/tests/test_install_all.py
+++ b/tests/test_install_all.py
@@ -16,3 +16,7 @@ def test_install_all(pipx_temp_env, tmp_path, capsys):
         pipx_list_fh.write(captured.out)
 
     assert not run_pipx_cli(["install-all", str(pipx_list_path)])
+    
+    captured = capsys.readouterr()
+    assert "black" in captured.out
+    assert "pycowsay" in captured.out

--- a/tests/test_install_all.py
+++ b/tests/test_install_all.py
@@ -27,4 +27,4 @@ def test_install_all_multiple_errors(pipx_temp_env, root, capsys):
     assert run_pipx_cli(["install-all", str(pipx_metadata_path)])
     captured = capsys.readouterr()
     assert "The following package(s) failed to install: dotenv, weblate" in captured.err
-    assert "No packages installed after running 'pipx install-all" in captured.out
+    assert f"No packages installed after running 'pipx install-all {pipx_metadata_path}'" in captured.out

--- a/tests/test_install_all.py
+++ b/tests/test_install_all.py
@@ -16,7 +16,7 @@ def test_install_all(pipx_temp_env, tmp_path, capsys):
         pipx_list_fh.write(captured.out)
 
     assert not run_pipx_cli(["install-all", str(pipx_list_path)])
-    
+
     captured = capsys.readouterr()
     assert "black" in captured.out
     assert "pycowsay" in captured.out


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [x] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

As discussed in https://github.com/pypa/pipx/issues/1132#issuecomment-2053680533, `install-all` needs a more robust strategy to deal with failed packages, so almost the same logic as `reinstall-all` is copied here. Besides, a test case for `install-all` is added.

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
# command(s) to exercise these changes
nox -s tests
```

<del>BTW, this pull request is a refactor, so no news is added and there is also no referenced issue. Let me know if it is necessary.</del>