### PR TITLE
Mock GH API return of standalone Python index file

### DIFF
--- a/tests/test_standalone_interpreter.py
+++ b/tests/test_standalone_interpreter.py
@@ -134,7 +134,7 @@ def test_upgrade_standalone_interpreter(pipx_temp_env, root, monkeypatch, capsys
     assert not run_pipx_cli(["interpreter", "upgrade"])
 
 
-def test_upgrade_standalone_interpreter_nothing_to_upgrade(pipx_temp_env, capsys):
+def test_upgrade_standalone_interpreter_nothing_to_upgrade(pipx_temp_env, capsys, mocked_github_api):
     assert not run_pipx_cli(["interpreter", "upgrade"])
     captured = capsys.readouterr()
     assert "Nothing to upgrade" in captured.out


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [ ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

Adding the `mocked_github_api` fixture was forgotten in #1351, it failed the tests.

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
nox -s tests-3.9
```
