### PR TITLE
Fix error log overwrite for "-all" batch operations.

### DIFF
--- a/changelog.d/1132.bugfix.md
+++ b/changelog.d/1132.bugfix.md
@@ -1,0 +1,1 @@
+Fix error log overwrite for "-all" batch operations.

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -333,7 +333,7 @@ def subprocess_post_check_handle_pip_error(
         if paths.ctx.log_file is None:
             raise PipxError("Pipx internal error: No log_file present.")
         pip_error_file = paths.ctx.log_file.parent / (paths.ctx.log_file.stem + "_pip_errors.log")
-        with pip_error_file.open("w", encoding="utf-8") as pip_error_fh:
+        with pip_error_file.open("a", encoding="utf-8") as pip_error_fh:
             print("PIP STDOUT", file=pip_error_fh)
             print("----------", file=pip_error_fh)
             if completed_process.stdout is not None:

--- a/tests/test_install_all.py
+++ b/tests/test_install_all.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from helpers import run_pipx_cli
+from pipx import paths
 
 
 def test_install_all(pipx_temp_env, tmp_path, capsys):
@@ -28,3 +29,8 @@ def test_install_all_multiple_errors(pipx_temp_env, root, capsys):
     captured = capsys.readouterr()
     assert "The following package(s) failed to install: dotenv, weblate" in captured.err
     assert f"No packages installed after running 'pipx install-all {pipx_metadata_path}'" in captured.out
+    if paths.ctx.log_file:
+        with open(paths.ctx.log_file.parent / (paths.ctx.log_file.stem + "_pip_errors.log")) as log_fh:
+            log_contents = log_fh.read()
+            assert "dotenv" in log_contents
+            assert "weblate" in log_contents


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [x] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

Fix #1132 

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
# command(s) to exercise these changes
nox -s tests
```
