### PR TITLE
ci: macos-latest now points at macos-14

### DIFF
--- a/.github/workflows/exhaustive_package_test.yml
+++ b/.github/workflows/exhaustive_package_test.yml
@@ -11,8 +11,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.12", "3.11", "3.10", "3.9", "3.8"]
+        include:
+          - os: macos-13
+            python-version: "3.8"
+          - os: macos-13
+            python-version: "3.9"
+          - os: macos-14
+            python-version: "3.10"
+          - os: macos-14
+            python-version: "3.11"
+          - os: macos-14
+            python-version: "3.12"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
ARM is fine, but no Python 3.8 or 3.9 is not.

Before change trigger: https://github.com/pypa/pipx/actions/runs/8810668602

(latest hasn't switched here yet, it's a rollout)

Edit: looks like they are preparing 3.8 and 3.9 for ARM.