### PR TITLE
fix: support python3.8 for standalone python builds

### DIFF
--- a/changelog.d/1375.bugfix.md
+++ b/changelog.d/1375.bugfix.md
@@ -1,0 +1,1 @@
+Support python3.8 for standalone python builds

--- a/src/pipx/standalone_python.py
+++ b/src/pipx/standalone_python.py
@@ -33,8 +33,8 @@ MACHINE_SUFFIX: Dict[str, Dict[str, Any]] = {
             # musl doesn't exist
         },
         "x86_64": {
-            "glibc": "x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
-            "musl": "x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+            "glibc": "x86_64-unknown-linux-gnu-install_only.tar.gz",
+            "musl": "x86_64-unknown-linux-musl-install_only.tar.gz",
         },
     },
     "Windows": {"AMD64": "x86_64-pc-windows-msvc-shared-install_only.tar.gz"},

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -190,18 +190,12 @@ def test_fetch_missing_python(monkeypatch, mocked_github_api):
     minor = sys.version_info.minor
     target_python = f"{major}.{minor}"
 
-    if target_python == "3.8":
-        # 3.8 is not available in the standalone python project
-        with pytest.raises(InterpreterResolutionError) as e:
-            find_python_interpreter(target_python, fetch_missing_python=True)
-            assert "not found" in str(e)
+    python_path = find_python_interpreter(target_python, fetch_missing_python=True)
+    assert python_path is not None
+    assert target_python in python_path
+    assert str(pipx.paths.ctx.standalone_python_cachedir) in python_path
+    if WINDOWS:
+        assert python_path.endswith("python.exe")
     else:
-        python_path = find_python_interpreter(target_python, fetch_missing_python=True)
-        assert python_path is not None
-        assert target_python in python_path
-        assert str(pipx.paths.ctx.standalone_python_cachedir) in python_path
-        if WINDOWS:
-            assert python_path.endswith("python.exe")
-        else:
-            assert python_path.endswith("python3")
-        subprocess.run([python_path, "-c", "import sys; print(sys.executable)"], check=True)
+        assert python_path.endswith("python3")
+    subprocess.run([python_path, "-c", "import sys; print(sys.executable)"], check=True)

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -164,8 +164,7 @@ def test_list_standalone_interpreter(pipx_temp_env, monkeypatch, mocked_github_a
     monkeypatch.setattr(shutil, "which", which)
 
     major = sys.version_info.major
-    # Minor version 3.8 is not supported for fetching standalone versions
-    minor = sys.version_info.minor if sys.version_info.minor != 8 else 9
+    minor = sys.version_info.minor
     target_python = f"{major}.{minor}"
 
     assert not run_pipx_cli(

--- a/tests/test_standalone_interpreter.py
+++ b/tests/test_standalone_interpreter.py
@@ -9,8 +9,7 @@ from package_info import PKG
 from pipx import standalone_python
 
 MAJOR_PYTHON_VERSION = sys.version_info.major
-# Minor version 3.8 is not supported for fetching standalone versions
-MINOR_PYTHON_VERSION = sys.version_info.minor if sys.version_info.minor != 8 else 9
+MINOR_PYTHON_VERSION = sys.version_info.minor
 TARGET_PYTHON_VERSION = f"{MAJOR_PYTHON_VERSION}.{MINOR_PYTHON_VERSION}"
 
 original_which = shutil.which


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [ ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

Fix #1375

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
# command(s) to exercise these changes
nox -s tests
pipx install --verbose --python 3.8 --fetch-missing-python black
```

BTW, the tests on macos-latest is failed and I am trying to fix it in #1373 where I need python 3.8 interpreter for testing.

