### PR TITLE
Fix `--system-site-packages` for `upgrade --install`

### DIFF
--- a/changelog.d/1344.bugfix.md
+++ b/changelog.d/1344.bugfix.md
@@ -1,1 +1,1 @@
-Make the --system-site-packages option actually work with upgrade --install
+Make the Python `venv` module arguments work with `upgrade --install`

--- a/changelog.d/1344.bugfix.md
+++ b/changelog.d/1344.bugfix.md
@@ -1,0 +1,1 @@
+Make the --system-site-packages option actually work with upgrade --install

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -104,15 +104,18 @@ def _upgrade_venv(
     upgrading_all: bool,
     force: bool,
     install: bool = False,
+    venv_args: Optional[List[str]] = None,
     python: Optional[str] = None,
     python_flag_passed: bool = False,
 ) -> int:
     """Return number of packages with changed versions."""
     if not venv_dir.is_dir():
         if install:
+            if venv_args is None:
+                venv_args = []
             commands.install(
                 venv_dir=None,
-                venv_args=[],
+                venv_args=venv_args,
                 package_names=None,
                 package_specs=[str(venv_dir).split(os.path.sep)[-1]],
                 local_bin_dir=paths.ctx.bin_dir,
@@ -134,6 +137,9 @@ def _upgrade_venv(
                 does not exist.
                 """
             )
+
+    if venv_args and not install:
+        logger.info("Ignoring " + ", ".join(venv_args) + " as not combined with --install")
 
     if python and not install:
         logger.info("Ignoring --python as not combined with --install")
@@ -184,6 +190,7 @@ def upgrade(
     venv_dirs: Dict[str, Path],
     python: Optional[str],
     pip_args: List[str],
+    venv_args: List[str],
     verbose: bool,
     *,
     include_injected: bool,
@@ -202,6 +209,7 @@ def upgrade(
             upgrading_all=False,
             force=force,
             install=install,
+            venv_args=venv_args,
             python=python,
             python_flag_passed=python_flag_passed,
         )

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -318,6 +318,7 @@ def run_pipx_command(args: argparse.Namespace, subparsers: Dict[str, argparse.Ar
             venv_dirs,
             args.python,
             pip_args,
+            venv_args,
             verbose,
             include_injected=args.include_injected,
             force=args.force,


### PR DESCRIPTION
Fix #1344

- [x] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

The `--system-site-package` option currently doesn't do anything when used with `upgrade --install`.
This PR adds `venv_args` to the upgrade command so that it can be passed through to the install command, when the `--install` option is set.

## Test plan

Tested by running

```
pipx upgrade --install --system-site-packages pycowsay
grep system $HOME/.local/share/pipx/venvs/pycowsay/pyvenv.cfg
```

Before the PR this returns:
```
include-system-site-packages = false
```

After applying the PR it returns:
```
include-system-site-packages = true
command = /usr/bin/python3.12 -m venv --without-pip --system-site-packages /home/sadamczyk/.local/share/pipx/venvs/pycowsay
```

Also successfully tested by installing https://github.com/essembeh/gnome-extensions-cli which requires the system site packages to work for the `--dbus` integration. Before this ran into an error because of the missing required 
system dependencies.
```
pipx upgrade --install --system-site-packages gnome-extensions-cli
gext --dbus update --install -y nightthemeswitcher@romainvigier.fr
```