### PR TITLE
pipx --preinstall ignores dependency version specifier #1377

### DIFF
--- a/changelog.d/1377.bugfix.md
+++ b/changelog.d/1377.bugfix.md
@@ -1,0 +1,1 @@
+Install specified version of `--preinstall` dependency instead of latest version

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -91,8 +91,7 @@ def install(
             override_shared = package_name == "pip"
             venv.create_venv(venv_args, pip_args, override_shared)
             for dep in preinstall_packages or []:
-                dep_name = package_name_from_spec(dep, python, pip_args=pip_args, verbose=verbose)
-                venv.upgrade_package_no_metadata(dep_name, [])
+                venv.upgrade_package_no_metadata(dep, [])
             venv.install_package(
                 package_name=package_name,
                 package_or_url=package_spec,

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -344,6 +344,11 @@ def test_preinstall_multiple(pipx_temp_env, caplog):
     assert "colorama" in caplog.text
 
 
+def test_preinstall_specific_version(pipx_temp_env, caplog):
+    assert not run_pipx_cli(["install", "--preinstall", "black==22.8.0", "nox"])
+    assert "black==22.8.0" in caplog.text
+
+
 @pytest.mark.xfail
 def test_do_not_wait_for_input(pipx_temp_env, pipx_session_shared_dir, monkeypatch):
     monkeypatch.setenv("PIP_INDEX_URL", "http://127.0.0.1:8080/simple")


### PR DESCRIPTION
- [x] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

[chrysle](https://github.com/chrysle) found the problem -- commands/install.py calls `package_name_from_spec` when it shouldn't. I removed that call and passed the dependencies unmodified to `venv.upgrade_package_no_metadata`.

## Test plan

I added this test case to tests/test_install.py:

```python
def test_preinstall_specific_version(pipx_temp_env, caplog):
    assert not run_pipx_cli(["install", "--preinstall", "black==22.8.0", "nox"])
    assert "black==22.8.0" in caplog.text
```

Tested by running

```
pipx install --preinstall black==22.8.0 nox
```