### PR TITLE
ci: restrict main branch for on push tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,8 @@ name: tests
 on:
   workflow_dispatch:
   push:
+    branches:
+      - "main"
   pull_request:
   schedule:
     - cron: "0 8 * * *"


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [ ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

Currently, the workflow `tests` will be triggerred when there is a new push on ALL branches, it will lead to redundant workflow runs when a pull request is created from the current repo rather than forked repo. For example, pre-commit update will lead to two tests workflow runs against same commit, one for push and the other for pull request:

https://github.com/pypa/pipx/actions/runs/8884599944
https://github.com/pypa/pipx/actions/runs/8884599801

![image](https://github.com/pypa/pipx/assets/726061/28c66ec7-e91c-42d0-ace2-b70a6890b997)


## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
# command(s) to exercise these changes
```
