### PR TITLE
Add Arch installation and fix flags order

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ sudo pipx ensurepath --global # optional to allow pipx actions with --global arg
 ```
 sudo pacman -S python-pipx
 pipx ensurepath
-sudo pipx --global ensurepath # optional to allow pipx actions with --global argument
+sudo pipx ensurepath --global # optional to allow pipx actions with --global argument
 ```
 
 - Using `pip` on other distributions:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ pipx ensurepath
 sudo pipx ensurepath --global # optional to allow pipx actions with --global argument
 ```
 
+- Arch:
+
+```
+sudo pacman -S python-pipx
+pipx ensurepath
+sudo pipx --global ensurepath # optional to allow pipx actions with --global argument
+```
+
 - Using `pip` on other distributions:
 
 ```


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [x] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

- Add Arch as Linux option on installation steps