### PR TITLE
Apply ruff rule RUF100

### DIFF
--- a/changelog.d/1400.misc.md
+++ b/changelog.d/1400.misc.md
@@ -1,0 +1,1 @@
+Enable and apply ruff rule `RUF100`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ lint.extend-select = [
   "PLE",
   "PLW",
   "RSE",
+  "RUF100",
   "W",
 ]
 lint.isort = {known-first-party = ["helpers", "package_info", "pipx"]}

--- a/src/pipx/__main__.py
+++ b/src/pipx/__main__.py
@@ -8,7 +8,7 @@ if not __package__:
     pipx_package_source_path = os.path.dirname(os.path.dirname(__file__))
     sys.path.insert(0, pipx_package_source_path)
 
-from pipx.main import cli  # noqa
+from pipx.main import cli
 
 if __name__ == "__main__":
     sys.exit(cli())

--- a/src/pipx/interpreter.py
+++ b/src/pipx/interpreter.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 def has_venv() -> bool:
     try:
-        import venv  # noqa
+        import venv  # noqa: F401
 
         return True
     except ImportError:

--- a/src/pipx/venv_inspect.py
+++ b/src/pipx/venv_inspect.py
@@ -108,7 +108,7 @@ def get_resources_from_inst_files(dist: metadata.Distribution, bin_path: Path, m
     # not sure what is found here
     inst_files = dist.read_text("installed-files.txt") or ""
     for line in inst_files.splitlines():
-        entry = line.split(",")[0]  # noqa: T484
+        entry = line.split(",")[0]
         inst_file_path = Path(str(dist.locate_file(entry))).resolve()
         try:
             if inst_file_path.parent.samefile(bin_path):


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [x] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

Apply ruff rule `RUF100`.

Note that `T484` is a [flake8-mypy](https://pypi.org/project/flake8-mypy/) warning, not part of [ruff rules](https://docs.astral.sh/ruff/rules/).

Fixes #1400.

## Test plan

Tested by running

``` console
$ ruff check --extend-select RUF100
All checks passed!
$ 
```
