### PR TITLE
Proper `ruff` / `ruff format` sequence

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,9 +13,9 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.4.3
   hooks:
-  - id: ruff-format
   - id: ruff
     args: [ "--fix", "--unsafe-fixes", "--exit-non-zero-on-fix"]
+  - id: ruff-format
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.10.0
   hooks:


### PR DESCRIPTION
- [ ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

Proper `ruff` / `ruff format` sequence.

Does this simple fix require a changelog entry?

Fixes #1404.

## Test plan

CI jobs still succeed.