### PR TITLE
Apply ruff/pygrep-hooks rule PGH003

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ lint.extend-select = [
   "C9",
   "I",
   "ISC",
+  "PGH",
   "PLC",
   "PLE",
   "PLW",

--- a/scripts/generate_man.py
+++ b/scripts/generate_man.py
@@ -5,7 +5,7 @@ import sys
 import textwrap
 from typing import cast
 
-from build_manpages.manpage import Manpage  # type: ignore
+from build_manpages.manpage import Manpage  # type: ignore[import-not-found]
 
 from pipx.main import get_command_parser
 

--- a/src/pipx/colors.py
+++ b/src/pipx/colors.py
@@ -2,7 +2,7 @@ import sys
 from typing import Callable
 
 try:
-    import colorama  # type: ignore
+    import colorama  # type: ignore[import-untyped]
 except ImportError:  # Colorama is Windows only package
     colorama = None
 

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -10,7 +10,7 @@ from shutil import which
 from tempfile import TemporaryDirectory
 from typing import Dict, List, Optional, Set, Tuple
 
-import userpath  # type: ignore
+import userpath  # type: ignore[import-not-found]
 from packaging.utils import canonicalize_name
 
 from pipx import paths

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 from typing import Optional, Tuple
 
-import userpath  # type: ignore
+import userpath  # type: ignore[import-not-found]
 
 from pipx import paths
 from pipx.constants import EXIT_CODE_OK, ExitCode

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -905,7 +905,7 @@ def get_command_parser() -> Tuple[argparse.ArgumentParser, Dict[str, argparse.Ar
         description=PIPX_DESCRIPTION,
         parents=[shared_parser],
     )
-    parser.man_short_description = PIPX_DESCRIPTION.splitlines()[1]  # type: ignore
+    parser.man_short_description = PIPX_DESCRIPTION.splitlines()[1]  # type: ignore[attr-defined]
 
     subparsers = parser.add_subparsers(dest="command", description="Get help for commands with pipx COMMAND --help")
 

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -10,7 +10,7 @@ from typing import Dict, Generator, List, NoReturn, Optional, Set
 try:
     from importlib.metadata import Distribution, EntryPoint
 except ImportError:
-    from importlib_metadata import Distribution, EntryPoint  # type: ignore
+    from importlib_metadata import Distribution, EntryPoint  # type: ignore[import-not-found,no-redef]
 
 from packaging.utils import canonicalize_name
 

--- a/src/pipx/venv_inspect.py
+++ b/src/pipx/venv_inspect.py
@@ -10,7 +10,7 @@ from packaging.utils import canonicalize_name
 try:
     from importlib import metadata
 except ImportError:
-    import importlib_metadata as metadata  # type: ignore
+    import importlib_metadata as metadata  # type: ignore[import-not-found,no-redef]
 
 from pipx.constants import MAN_SECTIONS, WINDOWS
 from pipx.util import PipxError, run_subprocess

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from typing import Iterator
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 
-import pytest  # type: ignore
+import pytest  # type: ignore[import-not-found]
 
 from helpers import WIN
 from pipx import commands, interpreter, paths, shared_libs, standalone_python, venv

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 from unittest import mock
 
-import pytest  # type: ignore
+import pytest  # type: ignore[import-not-found]
 from packaging.utils import canonicalize_name
 
 from package_info import PKG

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -1,6 +1,6 @@
 import time
 
-import pytest  # type: ignore
+import pytest  # type: ignore[import-not-found]
 
 import pipx.animate
 from pipx.animate import (

--- a/tests/test_emojis.py
+++ b/tests/test_emojis.py
@@ -2,7 +2,7 @@ import sys
 from io import BytesIO, TextIOWrapper
 from unittest import mock
 
-import pytest  # type: ignore
+import pytest  # type: ignore[import-not-found]
 
 from pipx.emojis import use_emojis
 

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -2,7 +2,7 @@ import logging
 import re
 import textwrap
 
-import pytest  # type: ignore
+import pytest  # type: ignore[import-not-found]
 
 from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli, skip_if_windows
 from package_info import PKG

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -5,7 +5,7 @@ import sys
 from pathlib import Path
 from unittest import mock
 
-import pytest  # type: ignore
+import pytest  # type: ignore[import-not-found]
 
 from helpers import app_name, run_pipx_cli, skip_if_windows, unwrap_log_text
 from package_info import PKG

--- a/tests/test_install_all_packages.py
+++ b/tests/test_install_all_packages.py
@@ -24,7 +24,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import List, Optional, Tuple
 
-import pytest  # type: ignore
+import pytest  # type: ignore[import-not-found]
 
 from helpers import run_pipx_cli
 from package_info import PKG

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 from unittest.mock import Mock
 
-import pytest  # type: ignore
+import pytest  # type: ignore[import-not-found]
 
 import pipx.interpreter
 import pipx.paths

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -5,7 +5,7 @@ import shutil
 import sys
 import time
 
-import pytest  # type: ignore
+import pytest  # type: ignore[import-not-found]
 
 from helpers import (
     PIPX_METADATA_LEGACY_VERSIONS,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,7 @@
 import sys
 from unittest import mock
 
-import pytest  # type: ignore
+import pytest  # type: ignore[import-not-found]
 
 from helpers import run_pipx_cli
 from pipx import main

--- a/tests/test_package_specifier.py
+++ b/tests/test_package_specifier.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-import pytest  # type: ignore
+import pytest  # type: ignore[import-not-found]
 
 from pipx.package_specifier import (
     fix_package_name,

--- a/tests/test_pipx_metadata_file.py
+++ b/tests/test_pipx_metadata_file.py
@@ -1,7 +1,7 @@
 import sys
 from pathlib import Path
 
-import pytest  # type: ignore
+import pytest  # type: ignore[import-not-found]
 
 from helpers import assert_package_metadata, create_package_info_ref, run_pipx_cli
 from package_info import PKG

--- a/tests/test_reinstall.py
+++ b/tests/test_reinstall.py
@@ -1,6 +1,6 @@
 import sys
 
-import pytest  # type: ignore
+import pytest  # type: ignore[import-not-found]
 
 from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli, skip_if_windows
 

--- a/tests/test_reinstall_all.py
+++ b/tests/test_reinstall_all.py
@@ -1,6 +1,6 @@
 import sys
 
-import pytest  # type: ignore
+import pytest  # type: ignore[import-not-found]
 
 from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli
 from pipx import shared_libs

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -5,7 +5,7 @@ import sys
 import textwrap
 from unittest import mock
 
-import pytest  # type: ignore
+import pytest  # type: ignore[import-not-found]
 
 import pipx.main
 import pipx.util

--- a/tests/test_shared_libs.py
+++ b/tests/test_shared_libs.py
@@ -1,7 +1,7 @@
 import os
 import time
 
-import pytest  # type: ignore
+import pytest  # type: ignore[import-not-found]
 
 from pipx import shared_libs
 

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -1,6 +1,6 @@
 import sys
 
-import pytest  # type: ignore
+import pytest  # type: ignore[import-not-found]
 
 from helpers import (
     PIPX_METADATA_LEGACY_VERSIONS,

--- a/tests/test_uninstall_all.py
+++ b/tests/test_uninstall_all.py
@@ -1,4 +1,4 @@
-import pytest  # type: ignore
+import pytest  # type: ignore[import-not-found]
 
 from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli
 

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,4 +1,4 @@
-import pytest  # type: ignore
+import pytest  # type: ignore[import-not-found]
 
 from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli, skip_if_windows
 from package_info import PKG

--- a/tests/test_upgrade_all.py
+++ b/tests/test_upgrade_all.py
@@ -1,4 +1,4 @@
-import pytest  # type: ignore
+import pytest  # type: ignore[import-not-found]
 
 from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli
 

--- a/tests/test_upgrade_shared.py
+++ b/tests/test_upgrade_shared.py
@@ -1,6 +1,6 @@
 import subprocess
 
-import pytest  # type: ignore
+import pytest  # type: ignore[import-not-found]
 
 from helpers import run_pipx_cli
 


### PR DESCRIPTION
- [ ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

Apply ruff/pygrep-hooks rule `PGH`
```
PGH003 Use specific rule codes when ignoring type issues
```

## Test plan

Tested by running

```
$ ruff check --extend-select PGH
All checks passed!
$ 
```
