### PR TITLE
Fix `pipx run` entry point discovery with local path

### DIFF
--- a/changelog.d/1422.bugfix.md
+++ b/changelog.d/1422.bugfix.md
@@ -1,0 +1,1 @@
+Fix discovery of a `pipx run` entry point if a local path was given as package.

--- a/testdata/empty_project/pyproject.toml
+++ b/testdata/empty_project/pyproject.toml
@@ -1,7 +1,8 @@
 [build-system]
+build-backend = "setuptools.build_meta"
+
 requires = [
   "setuptools",
-  "wheel",
 ]
 
 [project]
@@ -21,3 +22,4 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 scripts.empty-project = "empty_project.main:cli"
+entry-points."pipx.run".empty-project = "empty_project.main:cli"

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import sys
 import textwrap
+from pathlib import Path
 from unittest import mock
 
 import pytest  # type: ignore[import-not-found]
@@ -401,3 +402,15 @@ def test_run_shared_lib_as_app(pipx_temp_env, monkeypatch, capfd):
     run_pipx_cli_exit(["run", "pip", "--help"])
     captured = capfd.readouterr()
     assert "pip <command> [options]" in captured.out
+
+
+@mock.patch("os.execvpe", new=execvpe_mock)
+def test_run_local_path_entry_point(pipx_temp_env, caplog, root):
+    empty_project_path = (Path("testdata") / "empty_project").as_posix()
+    os.chdir(root)
+
+    caplog.set_level(logging.INFO)
+
+    run_pipx_cli_exit(["run", empty_project_path])
+
+    assert "Using discovered entry point for 'pipx run'" in caplog.text


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [x] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

Resolves https://github.com/pypa/pipx/pull/615#discussion_r1606569053.

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
pipx run -vv testdata/empty_project/
```
