### PR TITLE
fix order of --global flag for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ _For comparison to other tools including pipsi, see
 ```
 brew install pipx
 pipx ensurepath
-sudo pipx ensurepath --global # optional to allow pipx actions with --global argument
+sudo pipx --global ensurepath # optional to allow pipx actions with --global argument
 ```
 
 Upgrade pipx with `brew update && brew upgrade pipx`.


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [ ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes
This fixes issue #1429, the last step in the process of installing pipx for MacOS where it fails due to the `--global` flag being in the wrong order. 

## Test plan

1. uninstall pipx
2. install pipx in MacOS
3. use `sudo pipx --global ensurepath` instead of `sudo pipx ensurepath --global`

Tested by running

```
sudo pipx --global ensurepath
```
