### PR TITLE
Prepare news fragments for 1.6.0

### DIFF
--- a/changelog.d/1316.feature.md
+++ b/changelog.d/1316.feature.md
@@ -1,7 +1,1 @@
-Add `pipx upgrade-shared` command.
-
-This allows to create/upgrade shared libraries as a standalone command.
-
-It might be useful to initialize shared libraries with a pinned version of pip in order to create e.g. reproducible docker images using a constraint file.
-
-It also allows for different `--pip-args` that one would get with the `install` command.
+Add `pipx upgrade-shared` command, to create/upgrade shared libraries as a standalone command.

--- a/changelog.d/1400.misc.md
+++ b/changelog.d/1400.misc.md
@@ -1,1 +1,0 @@
-Enable and apply ruff rule `RUF100`.

--- a/changelog.d/891.feature.1.md
+++ b/changelog.d/891.feature.1.md
@@ -1,0 +1,1 @@
+Add a new option `--pinned` to `pipx list` command for listing pinned packages only.

--- a/changelog.d/891.feature.md
+++ b/changelog.d/891.feature.md
@@ -1,4 +1,2 @@
 Introduce `pipx pin` and `pipx unpin` commands, which can be used to pin or unpin the version
 of an installed package, so it will not be upgraded by `pipx upgrade` or `pipx upgrade-all`.
-
-In addition, a new option `--pinned` is added to `pipx list` command for listing pinned packages only.


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [ ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes
Fixed the news fragments so they no longer break the formatting of the changelog.

Will create a release PR after this is merged.

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
# command(s) to exercise these changes
nox -s watch_docs
```
