### PR TITLE
fix: fix release tag creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           custom_tag: "${{ steps.get-version.outputs.version }}"
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag_prefix: ""
 
   pypi-publish:
     name: Publish pipx to PyPI


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [ ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

Fix release tag creation, the `mathieudutour/github-tag-action` will create `v1.6.0` rather than `1.6.0` which causes the broken of [release workflow](https://github.com/pypa/pipx/actions/runs/9333711234/job/25691014546)

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
# command(s) to exercise these changes
```
