### PR TITLE
ci: clean up auto changelog on releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,3 +3,4 @@ changelog:
     authors:
       - dependabot
       - pre-commit-ci
+      - github-actions

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci


### PR DESCRIPTION
I noticed on the last release that the auto generated changelog included some bot entries. Those can be cleaned out with a config file like this.
