### PR TITLE
Add a `--prepend` option to the `pipx ensurepath` command

### DIFF
--- a/changelog.d/1451.feature.md
+++ b/changelog.d/1451.feature.md
@@ -1,0 +1,1 @@
+Add a `--prepend` option to the `pipx ensurepath` command to allow prepending `pipx`'s location to `PATH` rather than appending to it. This is useful when you want to prioritize `pipx`'s executables over other executables in your `PATH`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,8 +19,19 @@ pipx works on macOS, linux, and Windows.
 ```
 brew install pipx
 pipx ensurepath
-sudo pipx ensurepath --global # optional to allow pipx actions in global scope. See "Customising your installation" section below.
-sudo pipx ensurepath --prepend # optional to prepend the pipx bin directory to PATH instead of appending it. See "Customising your installation" section below.
+```
+
+#### Additional (optional) commands
+
+To allow pipx actions in global scope. See "Customising your installation" section below.
+```
+sudo pipx ensurepath --global
+```
+
+To prepend the pipx bin directory to PATH instead of appending it. See "Customising your installation" section below.
+
+```
+sudo pipx ensurepath --prepend
 ```
 
 ### On Linux:
@@ -31,8 +42,6 @@ sudo pipx ensurepath --prepend # optional to prepend the pipx bin directory to P
 sudo apt update
 sudo apt install pipx
 pipx ensurepath
-sudo pipx ensurepath --global # optional to allow pipx actions in global scope. See "Customising your installation" section below.
-sudo pipx ensurepath --prepend # optional to prepend the pipx bin directory to PATH instead of appending it. See "Customising your installation" section below.
 ```
 
 - Fedora:
@@ -40,8 +49,6 @@ sudo pipx ensurepath --prepend # optional to prepend the pipx bin directory to P
 ```
 sudo dnf install pipx
 pipx ensurepath
-sudo pipx ensurepath --global # optional to allow pipx actions in global scope. See "Customising your installation" section below.
-sudo pipx ensurepath --prepend # optional to prepend the pipx bin directory to PATH instead of appending it. See "Customising your installation" section below.
 ```
 
 - Using `pip` on other distributions:
@@ -49,10 +56,21 @@ sudo pipx ensurepath --prepend # optional to prepend the pipx bin directory to P
 ```
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath
-sudo pipx ensurepath --global # optional to allow pipx actions in global scope. See "Customising your installation" section below.
-sudo pipx ensurepath --prepend # optional to prepend the pipx bin directory to PATH instead of appending it. See "Customising your installation" section below.
 ```
 
+#### Additional (optional) commands
+
+To allow pipx actions in global scope. See "Customising your installation" section below.
+
+```
+sudo pipx ensurepath --global
+```
+
+To prepend the pipx bin directory to PATH instead of appending it. See "Customising your installation" section below.
+
+```
+sudo pipx ensurepath --prepend
+```
 
 ### On Windows:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,16 +23,18 @@ pipx ensurepath
 
 #### Additional (optional) commands
 
-To allow pipx actions in global scope. See "Customising your installation" section below.
+To allow pipx actions in global scope.
 ```
 sudo pipx ensurepath --global
 ```
 
-To prepend the pipx bin directory to PATH instead of appending it. See "Customising your installation" section below.
+To prepend the pipx bin directory to PATH instead of appending it.
 
 ```
 sudo pipx ensurepath --prepend
 ```
+
+For more details, refer to [Customising your installation](#customising-your-installation).
 
 ### On Linux:
 
@@ -60,17 +62,19 @@ python3 -m pipx ensurepath
 
 #### Additional (optional) commands
 
-To allow pipx actions in global scope. See "Customising your installation" section below.
+To allow pipx actions in global scope.
 
 ```
 sudo pipx ensurepath --global
 ```
 
-To prepend the pipx bin directory to PATH instead of appending it. See "Customising your installation" section below.
+To prepend the pipx bin directory to PATH instead of appending it.
 
 ```
 sudo pipx ensurepath --prepend
 ```
+
+For more details, refer to [Customising your installation](#customising-your-installation).
 
 ### On Windows:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,7 +19,8 @@ pipx works on macOS, linux, and Windows.
 ```
 brew install pipx
 pipx ensurepath
-sudo pipx ensurepath --global # optional to allow pipx actions in global scope. See "Global installation" section below.
+sudo pipx ensurepath --global # optional to allow pipx actions in global scope. See "Customising your installation" section below.
+sudo pipx ensurepath --prepend # optional to prepend the pipx bin directory to PATH instead of appending it. See "Customising your installation" section below.
 ```
 
 ### On Linux:
@@ -30,7 +31,8 @@ sudo pipx ensurepath --global # optional to allow pipx actions in global scope. 
 sudo apt update
 sudo apt install pipx
 pipx ensurepath
-sudo pipx ensurepath --global # optional to allow pipx actions in global scope. See "Global installation" section below.
+sudo pipx ensurepath --global # optional to allow pipx actions in global scope. See "Customising your installation" section below.
+sudo pipx ensurepath --prepend # optional to prepend the pipx bin directory to PATH instead of appending it. See "Customising your installation" section below.
 ```
 
 - Fedora:
@@ -38,7 +40,8 @@ sudo pipx ensurepath --global # optional to allow pipx actions in global scope. 
 ```
 sudo dnf install pipx
 pipx ensurepath
-sudo pipx ensurepath --global # optional to allow pipx actions in global scope. See "Global installation" section below.
+sudo pipx ensurepath --global # optional to allow pipx actions in global scope. See "Customising your installation" section below.
+sudo pipx ensurepath --prepend # optional to prepend the pipx bin directory to PATH instead of appending it. See "Customising your installation" section below.
 ```
 
 - Using `pip` on other distributions:
@@ -46,7 +49,8 @@ sudo pipx ensurepath --global # optional to allow pipx actions in global scope. 
 ```
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath
-sudo pipx ensurepath --global # optional to allow pipx actions in global scope. See "Global installation" section below.
+sudo pipx ensurepath --global # optional to allow pipx actions in global scope. See "Customising your installation" section below.
+sudo pipx ensurepath --prepend # optional to prepend the pipx bin directory to PATH instead of appending it. See "Customising your installation" section below.
 ```
 
 
@@ -160,7 +164,9 @@ sudo PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin PIPX_MAN_DIR=/usr/local/sha
 > This was reverted in 1.5.0 for Windows and MacOS. We heavily recommend not using these locations on Windows and MacOS anymore, due to
 > multiple incompatibilities discovered with these locations, documented [here](https://github.com/pypa/pipx/discussions/1247#discussion-6188916).
 
-### Global installation
+### Customising your installation
+
+#### `--global` argument
 
 Pipx also comes with a `--global` argument which helps to execute actions in global scope which exposes the app to
 all system users. By default the global binary location is set to `/usr/local/bin` and can be overridden with the
@@ -170,6 +176,12 @@ is `/opt/pipx`, can be overridden with environment variable `PIPX_GLOBAL_HOME`. 
 if you intend to use this feature.
 
 Note that the `--global` argument is not supported on Windows.
+
+#### `--prepend` argument
+
+The `--prepend` argument can be passed to the `pipx ensurepath` command to prepend the `pipx` bin directory to the user's PATH
+environment variable instead of appending to it. This can be useful if you want to prioritise `pipx`-installed binaries over
+system-installed binaries of the same name.
 
 ## Upgrade pipx
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -399,7 +399,7 @@ def run_pipx_command(args: argparse.Namespace, subparsers: Dict[str, argparse.Ar
         return commands.run_pip(package, venv_dir, args.pipargs, args.verbose)
     elif args.command == "ensurepath":
         try:
-            return commands.ensure_pipx_paths(force=args.force)
+            return commands.ensure_pipx_paths(prepend=args.prepend, force=args.force)
         except Exception as e:
             logger.debug("Uncaught Exception:", exc_info=True)
             raise PipxError(str(e), wrap_message=False) from None
@@ -873,6 +873,14 @@ def _add_ensurepath(subparsers: argparse._SubParsersAction, shared_parser: argpa
             "your shell's configuration file(s) such as '~/.bashrc'."
         ),
         parents=[shared_parser],
+    )
+    p.add_argument(
+        "--prepend",
+        action="store_true",
+        help=(
+            "Prepend directories to your PATH instead of appending. "
+            "This is useful if you want to prioritize pipx apps over system apps."
+        ),
     )
     p.add_argument(
         "--force",


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [x] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

Closes #1424.

This PR adds an option to `pipx ensurepath`, i.e., `pipx ensurepath --prepend` to allow users to prepend `pipx`-installed applications to the `PATH` environment variable rather than appending to it. This is disabled and set to `False` by default; it is only enabled if the user does `pipx ensurepath --prepend` (or its `--force` counterparts such as `pipx ensurepath --force --prepend` or `pipx ensurepath --prepend --force`). The implementation is through `userpath.prepend`, which is similar to `userpath.append` (see https://github.com/ofek/userpath#api).

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```bash
# command(s) to exercise these changes
pipx ensurepath --prepend  # or pipx ensurepath --prepend --force if already in PATH
```

This modifies my `~/.zshrc` file on macOS accordingly:

```zsh
# Created by `pipx` on 2024-05-20 14:27:49
export PATH="$PATH:/Users/agriyakhetarpal/.local/bin"

# Created by `pipx` on 2024-06-13 14:24:36
export PATH="/Users/agriyakhetarpal/.local/bin:$PATH"
```

Therefore, the latter entry from these changes has prepended `pipx`'s installation location to `PATH`. The earlier entry is from an older `pipx` installation I had that had appended the location. I'm happy to add additional tests in an appropriate place in `tests/` as necessary (though I notice that `ensurepath` doesn't have tests yet), and update the documentation (not sure where a mention of this would be best appropriate to add, though).