### PR TITLE
Proposal: Add `--upgrade` argument for install command

### DIFF
--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -29,6 +29,7 @@ def install(
     verbose: bool,
     *,
     force: bool,
+    upgrade: bool,
     reinstall: bool,
     include_dependencies: bool,
     preinstall_packages: Optional[List[str]],
@@ -60,7 +61,7 @@ def install(
 
         venv = Venv(venv_dir, python=python, verbose=verbose)
         venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
-        if exists:
+        if exists and not upgrade:
             if not reinstall and force and python_flag_passed:
                 print(
                     pipx_wrap(
@@ -85,6 +86,8 @@ def install(
                     )
                 )
                 return EXIT_CODE_INSTALL_VENV_EXISTS
+        elif exists:
+            pip_args = ["--upgrade"] + pip_args
 
         try:
             # Enable installing shared library `pip` with `pipx`
@@ -207,6 +210,7 @@ def install_all(
                 verbose,
                 force=force,
                 reinstall=False,
+                upgrade=False,
                 include_dependencies=main_package.include_dependencies,
                 preinstall_packages=[],
                 suffix=main_package.suffix,

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -72,6 +72,7 @@ def reinstall(
         verbose,
         force=True,
         reinstall=True,
+        upgrade=True,
         include_dependencies=venv.pipx_metadata.main_package.include_dependencies,
         preinstall_packages=[],
         suffix=venv.pipx_metadata.main_package.suffix,

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -134,6 +134,7 @@ def _upgrade_venv(
                 verbose=verbose,
                 force=force,
                 reinstall=False,
+                upgrade=False,
                 include_dependencies=False,
                 preinstall_packages=None,
                 python_flag_passed=python_flag_passed,

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -276,6 +276,7 @@ def run_pipx_command(args: argparse.Namespace, subparsers: Dict[str, argparse.Ar
             venv_args,
             verbose,
             force=args.force,
+            upgrade=args.upgrade,
             reinstall=False,
             include_dependencies=args.include_deps,
             preinstall_packages=args.preinstall,
@@ -469,6 +470,12 @@ def _add_install(subparsers: argparse._SubParsersAction, shared_parser: argparse
         "-f",
         action="store_true",
         help="Modify existing virtual environment and files in PIPX_BIN_DIR and PIPX_MAN_DIR",
+    )
+    p.add_argument(
+        "--upgrade",
+        "-U",
+        action="store_true",
+        help="Upgrade all specified packages to the newest available version.",
     )
     p.add_argument(
         "--suffix",

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -440,3 +440,13 @@ def test_install_python_command_version_micro_mismatch(pipx_temp_env, monkeypatc
     assert not run_pipx_cli(["install", "--python", python_version, "--verbose", "pycowsay"])
     captured = capsys.readouterr()
     assert f"It may not match the specified version {python_version} at the micro/patch level" in captured.err
+
+
+def test_install_upgrade(pipx_temp_env, capsys):
+    assert not run_pipx_cli(["install", "black==22.8.0"])
+    captured = capsys.readouterr()
+    assert "22.8.0" in captured.out
+
+    assert not run_pipx_cli(["install", "--upgrade", "black"])
+    captured = capsys.readouterr()
+    assert "22.8.0" not in captured.out


### PR DESCRIPTION
- [ ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Proposal

The following is a proposal to support an upgrade option with pipx's install command. A practice I use for documenting various Python-based utilities is to have an installation section which has a single command to either install or upgrade a package:

```
pip install -U example
```

Now trying to promote the use of `pipx` over `pip`, this does not seem to be possible in a single command unless using the `--force` argument:

```
pipx install --force example
```

Using the "force" argument does not feel right, and the intention is not to have packages be re-installed if they are already in a good/upgraded state. Alternatively, I could update documentation to have two paragraphs to identify a method to install and a method to upgrade, but I would rather promote a single command that could do both.

## Summary of changes

When installing a package, both `pip install` and `pipx install` allow a new package to be installed. If a target package is already installed, no changes are made. Both pip and pipx also support a forced reinstall using `--force-reinstall` and `--force` respectively. Another popular installation more for pip is using the `--upgrade` option, which will only perform a package change if a new version is detected. Such a request is not possible in pipx.

This commit adds support for an upgrade method by adding the `--upgrade` option and forwarding it to pip when a package has been detected as already installed.

## Test plan

Tested by provided unit tests and running:

```
pipx install black==22.8.0
pipx install black
pipx install --upgrade black
```

<details><summary>Example output</summary>
<pre>
(venv) [jdknight@devel venv]$ pipx install black==22.8.0
  installed package black 22.8.0, installed using Python 3.12.4
  These apps are now globally available
    - black
    - blackd
done!
(venv) [jdknight@devel venv]$ pipx install black
'black' already seems to be installed. Not modifying existing installation in '.../.local/share/pipx/venvs/black'. Pass '--force' to
force installation.
(venv) [jdknight@devel venv]$ pipx install --upgrade black
  installed package black 24.4.2, installed using Python 3.12.4
  These apps are now globally available
    - black
    - blackd
done!
</pre>
</details>
