### PR TITLE
Apply ruff/pycodestyle rule E721

### DIFF
--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -39,7 +39,7 @@ def run_pipx_cli_exit(pipx_cmd_list, assert_exit=None):
     with pytest.raises(SystemExit) as sys_exit:
         run_pipx_cli(pipx_cmd_list)
     if assert_exit is not None:
-        assert sys_exit.type == SystemExit
+        assert sys_exit.type is SystemExit
         assert sys_exit.value.code == assert_exit
 
 


### PR DESCRIPTION
- [ ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

New in ruff 0.5.0?
```
E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
```

## Test plan

CI tests.