### PR TITLE
Enforce new ruff rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ lint.extend-select = [
   "C9",
   "I",
   "ISC",
+  "PERF",
   "PGH",
   "PLC",
   "PLE",
@@ -80,6 +81,9 @@ lint.extend-select = [
   "RUF012",
   "RUF100",
   "W",
+]
+lint.ignore = [
+  "PERF203",
 ]
 lint.isort = { known-first-party = [
   "helpers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ lint.extend-select = [
   "RSE",
   "RUF012",
   "RUF100",
+  "TCH",
   "W",
 ]
 lint.ignore = [

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -452,7 +452,7 @@ def run_post_install_actions(
     expose_resources_globally("man", local_man_dir, package_metadata.man_paths, force=force)
 
     if include_dependencies:
-        for _, app_paths in package_metadata.app_paths_of_dependencies.items():
+        for app_paths in package_metadata.app_paths_of_dependencies.values():
             expose_resources_globally(
                 "app",
                 local_bin_dir,
@@ -460,7 +460,7 @@ def run_post_install_actions(
                 force=force,
                 suffix=package_metadata.suffix,
             )
-        for _, man_paths in package_metadata.man_paths_of_dependencies.items():
+        for man_paths in package_metadata.man_paths_of_dependencies.values():
             expose_resources_globally("man", local_man_dir, man_paths, force=force)
 
     package_summary, _ = get_venv_summary(venv_dir, package_name=package_name, new_install=True)

--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -1,8 +1,10 @@
 import logging
-from collections.abc import Callable
 from pathlib import Path
 from shutil import which
-from typing import List, Optional, Set
+from typing import TYPE_CHECKING, List, Optional, Set
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 from pipx.commands.common import (
     add_suffix,

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -68,7 +68,7 @@ def _upgrade_package(
         expose_resources_globally("man", paths.ctx.man_dir, package_metadata.man_paths, force=force)
 
     if package_metadata.include_dependencies:
-        for _, app_paths in package_metadata.app_paths_of_dependencies.items():
+        for app_paths in package_metadata.app_paths_of_dependencies.values():
             expose_resources_globally(
                 "app",
                 paths.ctx.bin_dir,
@@ -76,7 +76,7 @@ def _upgrade_package(
                 force=force,
                 suffix=package_metadata.suffix,
             )
-        for _, man_paths in package_metadata.man_paths_of_dependencies.items():
+        for man_paths in package_metadata.man_paths_of_dependencies.values():
             expose_resources_globally("man", paths.ctx.man_dir, man_paths, force=force)
 
     if old_version == new_version:

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -4,8 +4,10 @@ import re
 import shutil
 import time
 from pathlib import Path
-from subprocess import CompletedProcess
-from typing import Dict, Generator, List, NoReturn, Optional, Set
+from typing import TYPE_CHECKING, Dict, Generator, List, NoReturn, Optional, Set
+
+if TYPE_CHECKING:
+    from subprocess import CompletedProcess
 
 try:
     from importlib.metadata import Distribution, EntryPoint


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [ ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

* Enforce ruff/Perflint rules `PERF`
  For now, leave out this rule:
  ``
  PERF203 `try`-`except` within a loop incurs performance overhead
  ``
* Enforce ruff/flake8-type-checking rules `TCH`

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

CI tests.