### PR TITLE
Iussue #1460

### DIFF
--- a/changelog.d/1460.docs.md
+++ b/changelog.d/1460.docs.md
@@ -1,0 +1,1 @@
+provide an alternative output after an installation that is less confusing.

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -349,7 +349,7 @@ def _get_list_output(
     )
 
     if new_install and (exposed_binary_names or unavailable_binary_names):
-        output.append("  These apps are now globally available")
+        output.append("  These apps are now available")
     output.extend(f"    - {name}" for name in exposed_binary_names)
     output.extend(
         f"    - {red(name)} (symlink missing or pointing to unexpected location)" for name in unavailable_binary_names


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [x] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes
Changed `commands/common.py`line 352 from `output.append("  These apps are now globally available")` to `output.append("  These apps are now available")` as suggested on [Iussue 1460](https://github.com/pypa/pipx/issues/1460).

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
conda create --name pipx-test python pip
conda activate pipx-test
python -m pip install -e .
python -m pip install --user nox
nox -s tests-3.12
```

