### PR TITLE
Remove redundant licence definition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ keywords = [
   "Virtual Environment",
   "workflow",
 ]
-license = "MIT"
 authors = [
   { name = "Chad Smith", email = "chadsmith.software@gmail.com" },
 ]


### PR DESCRIPTION
- [ ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

Drop the licence key, keep the licence classifier.

From the [Python Packaging User Guide](https://packaging.python.org/):
> ### `license`
> 
> This can take two forms. You can put your license in a file, typically `LICENSE` or `LICENSE.txt`, and link that file here:
> ```toml
> [project]
> license = {file = "LICENSE"}
> ```
> or you can write the name of the license:
> ```toml
> [project]
> license = {text = "MIT License"}
> ```
> If you are using a standard, well-known license, it is not necessary to use this field. Instead, you should use one of the [classifiers](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#classifiers) starting with `License ::`.
## Test plan

Pass CI tests.