### PR TITLE
Issue #1525 Preinstall from requirements file

### DIFF
--- a/changelog.d/1525.feature.md
+++ b/changelog.d/1525.feature.md
@@ -1,0 +1,1 @@
+add `pipx install --preinstall-from-file requirements.txt <pkg>` option

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -32,6 +32,7 @@ def install(
     reinstall: bool,
     include_dependencies: bool,
     preinstall_packages: Optional[List[str]],
+    preinstall_from_file: Optional[List[str]],
     suffix: str = "",
     python_flag_passed=False,
 ) -> ExitCode:
@@ -96,6 +97,8 @@ def install(
             venv.create_venv(venv_args, pip_args, override_shared)
             for dep in preinstall_packages or []:
                 venv.upgrade_package_no_metadata(dep, [])
+            if preinstall_from_file:
+                venv.install_packages_from_file(preinstall_from_file, pip_args)
             venv.install_package(
                 package_name=package_name,
                 package_or_url=package_spec,
@@ -213,6 +216,7 @@ def install_all(
                 reinstall=False,
                 include_dependencies=main_package.include_dependencies,
                 preinstall_packages=[],
+                preinstall_from_file=[],
                 suffix=main_package.suffix,
             )
 

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -74,6 +74,7 @@ def reinstall(
         reinstall=True,
         include_dependencies=venv.pipx_metadata.main_package.include_dependencies,
         preinstall_packages=[],
+        preinstall_from_file=[],
         suffix=venv.pipx_metadata.main_package.suffix,
         python_flag_passed=python_flag_passed,
     )

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -136,6 +136,7 @@ def _upgrade_venv(
                 reinstall=False,
                 include_dependencies=False,
                 preinstall_packages=None,
+                preinstall_from_file=None,
                 python_flag_passed=python_flag_passed,
             )
             return 0

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -507,8 +507,8 @@ def _add_install(subparsers: argparse._SubParsersAction, shared_parser: argparse
         "--preinstall-from-file",
         action="append",
         help=(
-            "Path to Requirements File Format file listing optional packages to be installed "
-            "into the Virtual Environment before installing the main package."
+            "Absolute path to requirements file listing optional packages to be preinstalled into the "
+            "Virtual Environment before installing the main package. Use this flag multiple times for multiple files."
         ),
     )
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -293,6 +293,7 @@ def run_pipx_command(args: argparse.Namespace, subparsers: Dict[str, argparse.Ar
             reinstall=False,
             include_dependencies=args.include_deps,
             preinstall_packages=args.preinstall,
+            preinstall_from_file=args.preinstall_from_file,
             suffix=args.suffix,
             python_flag_passed=python_flag_passed,
         )
@@ -502,6 +503,14 @@ def _add_install(subparsers: argparse._SubParsersAction, shared_parser: argparse
         ),
     )
     add_pip_venv_args(p)
+    p.add_argument(
+        "--preinstall-from-file",
+        action="append",
+        help=(
+            "Path to Requirements File Format file listing optional packages to be installed "
+            "into the Virtual Environment before installing the main package."
+        ),
+    )
 
 
 def _add_install_all(subparsers: argparse._SubParsersAction, shared_parser: argparse.ArgumentParser) -> None:

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -345,6 +345,16 @@ class Venv:
 
         return package_name
 
+    def install_packages_from_file(self, requirements_files: List[str], pip_args: List[str]) -> None:
+        msg = f"Preinstalling requirements from '{requirements_files}'"
+        logger.info(msg)
+        pip_cmd = ["--no-input", "install", "--no-deps"] + pip_args
+        for requirements_file in requirements_files:
+            pip_cmd += ["--requirement", requirements_file]
+        with animate(msg, self.do_animation):
+            pip_process = self._run_pip(pip_cmd)
+        subprocess_post_check(pip_process)
+
     def get_venv_metadata_for_package(self, package_name: str, package_extras: Set[str]) -> VenvMetadata:
         data_start = time.time()
         venv_metadata = inspect_venv(package_name, package_extras, self.bin_path, self.python_path, self.man_path)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -395,6 +395,18 @@ def test_preinstall_specific_version(pipx_temp_env, caplog):
     assert "black==22.8.0" in caplog.text
 
 
+def test_preinstall_from_file(pipx_temp_env, tmp_path, caplog):
+    package = "black"
+    version = "22.8.0"
+    requirements_file_name = "requirements.txt"
+    requirements_file = tmp_path / requirements_file_name
+    requirements_file.write_text(f"{package}=={version}")
+    requirements_file.touch()
+    assert not run_pipx_cli(["install", "--preinstall-from-file", str(requirements_file), "nox"])
+    assert "nox" in caplog.text
+    assert str(requirements_file) in caplog.text
+
+
 @pytest.mark.xfail
 def test_do_not_wait_for_input(pipx_temp_env, pipx_session_shared_dir, monkeypatch):
     monkeypatch.setenv("PIP_INDEX_URL", "http://127.0.0.1:8080/simple")


### PR DESCRIPTION

<!-- add an 'x' in the brackets below -->

- [x] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

## Test plan

Confirm venv includes packages specified in requirements files

Tested by running

```
$ echo "httpx==0.27.0" > /tmp/httpx-req.txt
$ echo "attrs==23.1.0" > /tmp/attrs-req.txt
$ pipx install -v --preinstall-from-file /tmp/httpx-req.txt --preinstall-from-file /tmp/attrs-req.txt dunk
pipx >(setup:1119): pipx version is 0.1.dev811+gfd6d5e5
pipx >(setup:1120): Default python interpreter is '/usr/bin/python3.9'
pipx >(package_name_from_spec:381): Determined package name: dunk
pipx >(package_name_from_spec:382): Package name determined in 0.0s
pipx >(create_venv:164): Creating virtual environment
creating virtual environment...
pipx >(run_subprocess:175): running /usr/bin/python3.9 -m venv --without-pip /home/yolabingo/.local/share/pipx/venvs/dunk
pipx >(run_subprocess:175): running <checking pip's availability>
pipx >(run_subprocess:175): running /home/yolabingo/.local/share/pipx/venvs/dunk/bin/python -c import sysconfig; print(sysconfig.get_path('purelib'))
pipx >(run_subprocess:175): running /home/yolabingo/.local/share/pipx/shared/bin/python -c import sysconfig; print(sysconfig.get_path('purelib'))
pipx >(run_subprocess:175): running /home/yolabingo/.local/share/pipx/venvs/dunk/bin/python --version
pipx >(install_packages_from_file:350): Preinstalling requirements from '['/tmp/httpx-req.txt', '/tmp/attrs-req.txt']'
Preinstalling requirements from '['/tmp/httpx-req.txt', '/tmp/attrs-req.txt']'...
pipx >(run_subprocess:175): running /home/yolabingo/.local/share/pipx/venvs/dunk/bin/python -m pip --no-input install --no-deps --requirement /tmp/httpx-req.txt --requirement /tmp/attrs-req.txt
pipx >(_parsed_package_to_package_or_url:139): cleaned package spec: dunk
pipx >(install_package:247): Installing dunk
installing dunk...
pipx >(run_subprocess:175): running /home/yolabingo/.local/share/pipx/venvs/dunk/bin/python -m pip --no-input install dunk
pipx >(run_subprocess:175): running <fetch_info_in_venv commands>
pipx >(get_venv_metadata_for_package:361): get_venv_metadata_for_package: 65ms
pipx >(_parsed_package_to_package_or_url:139): cleaned package spec: dunk
  installed package dunk 0.4.0a0, installed using Python 3.9.2
  These apps are now globally available
    - dunk

$ ${HOME}/.local/share/pipx/venvs/dunk/bin/python -m pip freeze
attrs==23.1.0
commonmark==0.9.1
dunk==0.4.0a0
httpx==0.27.0
pkg_resources==0.0.0
Pygments==2.18.0
rich==12.6.0
unidiff==0.7.5
```