### PR TITLE
feat: rename USE_EMOJI to PIPX_USE_EMOJI

### DIFF
--- a/changelog.d/1395.feature.md
+++ b/changelog.d/1395.feature.md
@@ -1,0 +1,1 @@
+Rename environmental variable `USE_EMOJI` to `PIPX_USE_EMOJI`.

--- a/src/pipx/commands/environment.py
+++ b/src/pipx/commands/environment.py
@@ -16,7 +16,7 @@ ENVIRONMENT_VARIABLES = [
     "PIPX_SHARED_LIBS",
     "PIPX_DEFAULT_PYTHON",
     "PIPX_FETCH_MISSING_PYTHON",
-    "USE_EMOJI",
+    "PIPX_USE_EMOJI",
     "PIPX_HOME_ALLOW_SPACE",
 ]
 
@@ -34,7 +34,7 @@ def environment(value: str) -> ExitCode:
         "PIPX_VENV_CACHEDIR": paths.ctx.venv_cache,
         "PIPX_STANDALONE_PYTHON_CACHEDIR": paths.ctx.standalone_python_cachedir,
         "PIPX_DEFAULT_PYTHON": DEFAULT_PYTHON,
-        "USE_EMOJI": str(EMOJI_SUPPORT).lower(),
+        "PIPX_USE_EMOJI": str(EMOJI_SUPPORT).lower(),
         "PIPX_HOME_ALLOW_SPACE": str(paths.ctx.allow_spaces_in_home_path).lower(),
     }
     if value is None:

--- a/src/pipx/emojis.py
+++ b/src/pipx/emojis.py
@@ -20,7 +20,10 @@ def use_emojis() -> bool:
         platform_emoji_support = True
     except UnicodeEncodeError:
         platform_emoji_support = False
-    return strtobool(str(os.getenv("USE_EMOJI", platform_emoji_support)))
+    use_emoji = os.getenv("PIPX_USE_EMOJI")
+    if use_emoji is None:
+        use_emoji = str(os.getenv("USE_EMOJI", platform_emoji_support))
+    return strtobool(use_emoji)
 
 
 EMOJI_SUPPORT = use_emojis()

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -92,7 +92,7 @@ PIPX_DESCRIPTION += pipx_wrap(
       PIPX_MAN_DIR           Overrides location of manual pages installations. Manual pages are symlinked or copied here.
       PIPX_GLOBAL_MAN_DIR    Used instead of PIPX_MAN_DIR when the `--global` option is given.
       PIPX_DEFAULT_PYTHON    Overrides default python used for commands.
-      USE_EMOJI              Overrides emoji behavior. Default value varies based on platform.
+      PIPX_USE_EMOJI         Overrides emoji behavior. Default value varies based on platform.
       PIPX_HOME_ALLOW_SPACE  Overrides default warning on spaces in the home path
     """,
     subsequent_indent=" " * 24,  # match the indent of argparse options

--- a/tests/test_emojis.py
+++ b/tests/test_emojis.py
@@ -8,7 +8,7 @@ from pipx.emojis import use_emojis
 
 
 @pytest.mark.parametrize(
-    "USE_EMOJI, encoding, expected",
+    "PIPX_USE_EMOJI, encoding, expected",
     [
         # utf-8
         (None, "utf-8", True),
@@ -39,8 +39,8 @@ from pipx.emojis import use_emojis
         ("false", "cp1252", False),
     ],
 )
-def test_use_emojis(monkeypatch, USE_EMOJI, encoding, expected):
+def test_use_emojis(monkeypatch, PIPX_USE_EMOJI, encoding, expected):
     with mock.patch.object(sys, "stderr", TextIOWrapper(BytesIO(), encoding=encoding)):
-        if USE_EMOJI is not None:
-            monkeypatch.setenv("USE_EMOJI", USE_EMOJI)
+        if PIPX_USE_EMOJI is not None:
+            monkeypatch.setenv("PIPX_USE_EMOJI", PIPX_USE_EMOJI)
         assert use_emojis() is expected

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -33,7 +33,7 @@ def test_cli_with_args(monkeypatch, capsys):
     assert not run_pipx_cli(["environment", "--value", "PIPX_TRASH_DIR"])
     assert not run_pipx_cli(["environment", "--value", "PIPX_VENV_CACHEDIR"])
     assert not run_pipx_cli(["environment", "--value", "PIPX_DEFAULT_PYTHON"])
-    assert not run_pipx_cli(["environment", "--value", "USE_EMOJI"])
+    assert not run_pipx_cli(["environment", "--value", "PIPX_USE_EMOJI"])
     assert not run_pipx_cli(["environment", "--value", "PIPX_HOME_ALLOW_SPACE"])
 
     assert run_pipx_cli(["environment", "--value", "SSS"])


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [X] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes
Rename environmental variable USE_EMOJI to PIPX_USE_EMOJI. Keeps support for USE_EMOJI. Fixes [#1395](https://github.com/pypa/pipx/issues/1395).

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
nox -- -k test_emojis
nox -- -k test_environment
```
