### PR TITLE
Add --all-shells flag to ensure_path

### DIFF
--- a/changelog.d/1585.feature.md
+++ b/changelog.d/1585.feature.md
@@ -1,0 +1,1 @@
+Add `--all-shells` flag to `pipx ensurepath`.

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -51,7 +51,7 @@ def get_pipx_user_bin_path() -> Optional[Path]:
     return pipx_bin_path
 
 
-def ensure_path(location: Path, *, force: bool, prepend: bool = False) -> Tuple[bool, bool]:
+def ensure_path(location: Path, *, force: bool, prepend: bool = False, all_shells: bool = False) -> Tuple[bool, bool]:
     """Ensure location is in user's PATH or add it to PATH.
     If prepend is True, location will be prepended to PATH, else appended.
     Returns True if location was added to PATH
@@ -63,9 +63,9 @@ def ensure_path(location: Path, *, force: bool, prepend: bool = False) -> Tuple[
 
     if force or (not in_current_path and not need_shell_restart):
         if prepend:
-            path_added = userpath.prepend(location_str, "pipx")
+            path_added = userpath.prepend(location_str, "pipx", all_shells=all_shells)
         else:
-            path_added = userpath.append(location_str, "pipx")
+            path_added = userpath.append(location_str, "pipx", all_shells=all_shells)
         if not path_added:
             print(
                 pipx_wrap(
@@ -100,7 +100,7 @@ def ensure_path(location: Path, *, force: bool, prepend: bool = False) -> Tuple[
     return (path_added, need_shell_restart)
 
 
-def ensure_pipx_paths(force: bool, prepend: bool = False) -> ExitCode:
+def ensure_pipx_paths(force: bool, prepend: bool = False, all_shells: bool = False) -> ExitCode:
     """Returns pipx exit code."""
     bin_paths = {paths.ctx.bin_dir}
 
@@ -113,7 +113,9 @@ def ensure_pipx_paths(force: bool, prepend: bool = False) -> ExitCode:
     path_action_str = "prepended to" if prepend else "appended to"
 
     for bin_path in bin_paths:
-        (path_added_current, need_shell_restart_current) = ensure_path(bin_path, prepend=prepend, force=force)
+        (path_added_current, need_shell_restart_current) = ensure_path(
+            bin_path, prepend=prepend, force=force, all_shells=all_shells
+        )
         path_added |= path_added_current
         need_shell_restart |= need_shell_restart_current
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -414,7 +414,7 @@ def run_pipx_command(args: argparse.Namespace, subparsers: Dict[str, argparse.Ar
         return commands.run_pip(package, venv_dir, args.pipargs, args.verbose)
     elif args.command == "ensurepath":
         try:
-            return commands.ensure_pipx_paths(prepend=args.prepend, force=args.force)
+            return commands.ensure_pipx_paths(prepend=args.prepend, force=args.force, all_shells=args.all_shells)
         except Exception as e:
             logger.debug("Uncaught Exception:", exc_info=True)
             raise PipxError(str(e), wrap_message=False) from None
@@ -905,6 +905,11 @@ def _add_ensurepath(subparsers: argparse._SubParsersAction, shared_parser: argpa
             "Add text to your shell's config file even if it looks like your "
             "PATH already contains paths to pipx and pipx-install apps."
         ),
+    )
+    p.add_argument(
+        "--all-shells",
+        action="store_true",
+        help=("Add directories to PATH in all shells instead of just the current one."),
     )
 
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [x] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

Add `--all-shells` flag to `pipx ensure_path`, see issue: https://github.com/pypa/pipx/issues/1585

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running:

```
$ pipx ensurepath --all-shells
```

I have one failing test (`test_run_with_requirements`):

```
ERROR    pipx.util:util.py:347 Fatal error from pip prevented installation. Full pip output in file:
```

The pip output file contains:

```
PIP STDOUT
----------
Looking in indexes: http://127.0.0.1:62640/simple/

PIP STDERR
----------
ERROR: Could not find a version that satisfies the requirement requests==2.31.0 (from versions: 2.32.3)
ERROR: No matching distribution found for requests==2.31.0
```

Unfortunately I don't know what is causing this or how I can fix it, any ideas?