### PR TITLE
fix: make Github Action safe to RCE via pull request title

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,12 +34,13 @@ jobs:
       - uses: actions/checkout@v4
       - name: Extract version to be released
         id: get-version
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
           else
-            TITLE="${{ github.event.pull_request.title }}"
-            echo "version=${TITLE/: [[:alnum:]]*}" >> "$GITHUB_OUTPUT"
+            echo "version=${PR_TITLE/: [[:alnum:]]*}" >> "$GITHUB_OUTPUT"
           fi
       - name: Bump version and push tag
         uses: mathieudutour/github-tag-action@v6.2


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [x] Make GitHub Action safe against Remote Code Execution via PR title.

## Summary of changes
A malicious actor can create a valid pull request that fixes a legitimate issue in the project. Once the issue is reviewed and the PR is approved before merging, the actor can change the PR title to something like:

`Some PR "; printenv|base64 -d; echo "123`

This allows them to exfiltrate environment variables and potentially compromise sensitive data.

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
# command(s) to exercise these changes
```
