### PR TITLE
Upgrade ruff and rename ruleset: `TCH` → `TC`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
   hooks:
     - id: pyproject-fmt
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.6.9
+  rev: v0.11.8
   hooks:
   - id: ruff
     args: [ "--fix", "--unsafe-fixes", "--show-fixes", "--exit-non-zero-on-fix"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ lint.extend-select = [
   "RSE",
   "RUF012",
   "RUF100",
-  "TCH",
+  "TC",
   "W",
 ]
 lint.ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ lint.extend-select = [
 ]
 lint.ignore = [
   "PERF203",
+  "PLW1508",
 ]
 lint.isort = { known-first-party = [
   "helpers",

--- a/scripts/generate_man.py
+++ b/scripts/generate_man.py
@@ -13,7 +13,7 @@ from pipx.main import get_command_parser
 def main():
     sys.argv[0] = "pipx"
     parser, _ = get_command_parser()
-    parser.man_short_description = cast(str, parser.description).splitlines()[1]  # type: ignore[attr-defined]
+    parser.man_short_description = cast("str", parser.description).splitlines()[1]  # type: ignore[attr-defined]
 
     manpage = Manpage(parser)
     body = str(manpage)

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -379,7 +379,7 @@ def package_name_from_spec(package_spec: str, python: str, *, pip_args: List[str
         #       will use the pypi name
         package_name = pypi_name
         logger.info(f"Determined package name: {package_name}")
-        logger.info(f"Package name determined in {time.time()-start_time:.1f}s")
+        logger.info(f"Package name determined in {time.time() - start_time:.1f}s")
         return package_name
 
     # check syntax and clean up spec and pip_args
@@ -390,7 +390,7 @@ def package_name_from_spec(package_spec: str, python: str, *, pip_args: List[str
         venv.create_venv(venv_args=[], pip_args=[])
         package_name = venv.install_package_no_deps(package_or_url=package_spec, pip_args=pip_args)
 
-    logger.info(f"Package name determined in {time.time()-start_time:.1f}s")
+    logger.info(f"Package name determined in {time.time() - start_time:.1f}s")
     return package_name
 
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -163,7 +163,7 @@ class InstalledVenvsCompleter:
         self.packages = [str(p.name) for p in sorted(venv_container.iter_venv_dirs())]
 
     def use(self, prefix: str, **kwargs: Any) -> List[str]:
-        return [f"{prefix}{x[len(prefix):]}" for x in self.packages if x.startswith(canonicalize_name(prefix))]
+        return [f"{prefix}{x[len(prefix) :]}" for x in self.packages if x.startswith(canonicalize_name(prefix))]
 
 
 def get_pip_args(parsed_args: Dict[str, str]) -> List[str]:

--- a/src/pipx/pipx_metadata_file.py
+++ b/src/pipx/pipx_metadata_file.py
@@ -114,7 +114,7 @@ class PipxMetadata:
             raise PipxError(
                 f"""
                 {self.venv_dir.name}: Unknown metadata version
-                {metadata_dict['pipx_metadata_version']}. Perhaps it was
+                {metadata_dict["pipx_metadata_version"]}. Perhaps it was
                 installed with a later version of pipx.
                 """
             )

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -348,7 +348,7 @@ class Venv:
     def get_venv_metadata_for_package(self, package_name: str, package_extras: Set[str]) -> VenvMetadata:
         data_start = time.time()
         venv_metadata = inspect_venv(package_name, package_extras, self.bin_path, self.python_path, self.man_path)
-        logger.info(f"get_venv_metadata_for_package: {1e3*(time.time()-data_start):.0f}ms")
+        logger.info(f"get_venv_metadata_for_package: {1e3 * (time.time() - data_start):.0f}ms")
         return venv_metadata
 
     def update_package_metadata(

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -66,7 +66,7 @@ def test_delay_suppresses_output(capsys, monkeypatch):
 @pytest.mark.parametrize(
     "env_columns,expected_frame_message",
     [
-        (45, f"{TEST_STRING_40_CHAR:.{45-6}}..."),
+        (45, f"{TEST_STRING_40_CHAR:.{45 - 6}}..."),
         (46, f"{TEST_STRING_40_CHAR}"),
         (47, f"{TEST_STRING_40_CHAR}"),
     ],
@@ -87,7 +87,7 @@ def test_line_lengths_emoji(capsys, monkeypatch, env_columns, expected_frame_mes
 @pytest.mark.parametrize(
     "env_columns,expected_frame_message",
     [
-        (43, f"{TEST_STRING_40_CHAR:.{43-4}}"),
+        (43, f"{TEST_STRING_40_CHAR:.{43 - 4}}"),
         (44, f"{TEST_STRING_40_CHAR}"),
         (45, f"{TEST_STRING_40_CHAR}"),
     ],

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -409,15 +409,15 @@ def test_passed_python_and_force_flag_warning(pipx_temp_env, capsys):
 
     assert not run_pipx_cli(["install", "black", "--force"])
     captured = capsys.readouterr()
-    assert (
-        "--python is ignored when --force is passed." not in captured.out
-    ), "Should only print warning if both flags present"
+    assert "--python is ignored when --force is passed." not in captured.out, (
+        "Should only print warning if both flags present"
+    )
 
     assert not run_pipx_cli(["install", "pycowsay", "--force"])
     captured = capsys.readouterr()
-    assert (
-        "--python is ignored when --force is passed." not in captured.out
-    ), "Should not print warning if package does not exist yet"
+    assert "--python is ignored when --force is passed." not in captured.out, (
+        "Should not print warning if package does not exist yet"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- [ ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

Ruff 0.8.0 changes the error codes for the rules in the [`flake8-type-checking`](https://docs.astral.sh/ruff/rules/#flake8-type-checking-tc) category from `TCH` to `TC`. This matches changes that were made in the original `flake8-type-checking` plugin from which these rules were originally adapted.

https://astral.sh/blog/ruff-v0.8.0#new-error-codes-for-flake8-type-checking-rules

Not sure whether to apply or ignore rule [TC006](https://docs.astral.sh/ruff/rules/runtime-cast-value/). See discussions here:
* https://github.com/astral-sh/ruff/issues/14676
* https://github.com/astral-sh/ruff/discussions/17127

## Test plan

Just CI.

The issues with Python 3.8 seem unrelated.