### PR TITLE
Add examples for using ssh to install from Source Control

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -235,6 +235,7 @@ You can also install from a git repository. Here, `black` is used as an example.
 
 ```
 pipx install git+https://github.com/psf/black.git
+pipx install git+ssh://git@github.com/psf/black # using ssh
 pipx install git+https://github.com/psf/black.git@branch  # branch of your choice
 pipx install git+https://github.com/psf/black.git@ce14fa8b497bae2b50ec48b3bd7022573a59cdb1  # git hash
 pipx install https://github.com/psf/black/archive/18.9b0.zip  # install a release
@@ -435,6 +436,7 @@ You can also run from a git repository. Here, `black` is used as an example.
 
 ```
 pipx run --spec git+https://github.com/psf/black.git black
+pipx run --spec git+ssh://git@github.com/psf/black black # using ssh
 pipx run --spec git+https://github.com/psf/black.git@branch black  # branch of your choice
 pipx run --spec git+https://github.com/psf/black.git@ce14fa8b497bae2b50ec48b3bd7022573a59cdb1 black  # git hash
 pipx run --spec https://github.com/psf/black/archive/18.9b0.zip black # install a release


### PR DESCRIPTION
Added an example for using ssh, in case you do not work with https credentials for private repositories.

The "<URL>.git" extension on https:// links also works for ssh:// links on GitHub, but not on Azure DevOps Repos, which is why it is removed from the example.

<!-- add an 'x' in the brackets below -->

- [ ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)
(Not Applicable)

## Summary of changes
Added Bash code lines showcasing examples of installing from Source Control via ssh.

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
# command(s) to exercise these changes
pipx install git+ssh://git@github.com/psf/black
pipx uninstall black
pipx install git+ssh://git@github.com/psf/black.git
pipx uninstall black
```

![image](https://github.com/user-attachments/assets/c50c9bd3-b653-41a5-9694-0d680a07785a)
