### PR TITLE
Use `SHA256SUMS` file for standalone python checksum validation

### DIFF
--- a/src/pipx/standalone_python.py
+++ b/src/pipx/standalone_python.py
@@ -112,19 +112,17 @@ def _unpack(full_version, download_link, archive: Path, download_dir: Path):
             checksum = hashlib.sha256(python_zip.read()).hexdigest()
 
         # Validate checksum
-        checksum_link = "/".join(download_link.split('/')[:-1] + ["SHA256SUMS"])
+        checksum_link = "/".join(download_link.split("/")[:-1] + ["SHA256SUMS"])
         expected_checksums = urlopen(checksum_link).read().decode().rstrip("\n")
-        release_file = unquote(download_link.split('/')[-1])
-        
-        match = re.findall(rf"(\S+)\s+{re.escape(release_file)}" , expected_checksums, re.MULTILINE)
-        
+        release_file = unquote(download_link.split("/")[-1])
+
+        match = re.findall(rf"(\S+)\s+{re.escape(release_file)}", expected_checksums, re.MULTILINE)
+
         if match is None or len(match) != 1:
-            raise PipxError(
-                f"Unable to retrieve checksum from python-build-standalone for python {full_version}"
-            )
-        
+            raise PipxError(f"Unable to retrieve checksum from python-build-standalone for python {full_version}")
+
         expected_checksum = match[0]
-        
+
         if checksum != expected_checksum:
             raise PipxError(
                 f"Checksum mismatch for python {full_version} build. Expected {expected_checksum}, got {checksum}."


### PR DESCRIPTION
**Bugfix for  #1652**

* Support new release content from python-build-standalone project

- [x] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

No entry in `changelog.d/` since this patch is a bugfix.

## Summary of changes

## Test plan

Tested by running

```
$ pipx install --python 3.11 --fetch-missing-python
```
