### PR TITLE
Fix uninject removing shared dependencies from other injected packages

### DIFF
--- a/changelog.d/1672.bugfix.md
+++ b/changelog.d/1672.bugfix.md
@@ -1,0 +1,1 @@
+Prevent uninject from removing dependencies still required by other packages.

--- a/tests/test_uninject.py
+++ b/tests/test_uninject.py
@@ -40,6 +40,7 @@ def test_uninject_leave_deps(pipx_temp_env, capsys, caplog):
     assert "Uninjected package black from venv pycowsay" in captured.out
     assert "Dependencies of uninstalled package:" not in caplog.text
 
+
 def test_uninject_keeps_shared_dependencies(pipx_temp_env, capsys):
     assert not run_pipx_cli(["install", "pycowsay"])
     assert not run_pipx_cli(["inject", "pycowsay", PKG["black"]["spec"]])

--- a/tests/test_uninject.py
+++ b/tests/test_uninject.py
@@ -39,3 +39,12 @@ def test_uninject_leave_deps(pipx_temp_env, capsys, caplog):
     captured = capsys.readouterr()
     assert "Uninjected package black from venv pycowsay" in captured.out
     assert "Dependencies of uninstalled package:" not in caplog.text
+
+def test_uninject_keeps_shared_dependencies(pipx_temp_env, capsys):
+    assert not run_pipx_cli(["install", "pycowsay"])
+    assert not run_pipx_cli(["inject", "pycowsay", PKG["black"]["spec"]])
+    assert not run_pipx_cli(["inject", "pycowsay", PKG["pylint"]["spec"]])
+    assert not run_pipx_cli(["uninject", "pycowsay", "black"])
+    assert not run_pipx_cli(["list", "--include-injected"])
+    captured = capsys.readouterr()
+    assert "pylint" in captured.out


### PR DESCRIPTION
## Summary

When multiple injected packages share a dependency in the same pipx venv,
`pipx uninject` could uninstall that shared dependency, even if it is still
required by other injected packages. This could break the remaining packages.

This PR makes `uninject` more conservative when cleaning up dependencies.

## Changes

- In `uninject_dep`, after uninstalling the injected package, we still compute
  the set of packages that became "not required" using
  `venv.list_installed_packages(not_required=True)`, but before uninstalling
  them we:
  - Build a set of dependencies still required by:
    - the main package of the venv, and
    - all other injected packages (excluding the one being uninjected).
  - Only uninstall dependencies that are **not** in this "protected" set.

- The user-facing behaviour is unchanged when there are no shared dependencies,
  but shared dependencies used by other packages in the venv are now preserved.

- Added a regression test `test_uninject_keeps_shared_dependencies` to ensure
  that uninjection of one injected package does not remove another injected
  package from the same venv.

- Added a changelog fragment describing the bugfix.

## Testing

Local (Windows 11):

- `python -m nox -s tests-3.10 -- -k "uninject"`

Result:

- All `uninject`-related tests pass:
  - 4 passed, 1 skipped (the global test skipped on Windows).
- The `cover` nox session fails locally because only a subset of tests is run
  (global coverage 56% < fail-under=70). I expect full coverage to be validated
  by the CI when running the complete test suite.
