### PR TITLE
[pre-commit] pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
+  rev: v6.0.0
   hooks:
   - id: end-of-file-fixer
   - id: check-added-large-files
   - id: trailing-whitespace
   - id: check-yaml
 - repo: https://github.com/tox-dev/pyproject-fmt
-  rev: v2.6.0
+  rev: v2.7.0
   hooks:
     - id: pyproject-fmt
 - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -17,7 +17,7 @@ repos:
     args: [ "--fix", "--unsafe-fixes", "--show-fixes", "--exit-non-zero-on-fix"]
   - id: ruff-format
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.14.1
+  rev: v1.19.1
   hooks:
   - id: mypy
     args: ['--warn-unused-ignores', '--strict-equality','--no-implicit-optional', '--check-untyped-defs']
@@ -30,7 +30,7 @@ repos:
     - "tomli; python_version < '3.11'"
 # Configuration for codespell is in pyproject.toml
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.3.0
+  rev: v2.4.1
   hooks:
   - id: codespell
     additional_dependencies:

--- a/src/pipx/interpreter.py
+++ b/src/pipx/interpreter.py
@@ -154,7 +154,7 @@ def _find_default_windows_python() -> str:
 
     proc = subprocess.run([python, "-V"], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, check=False)
     if proc.returncode != 0:
-        # Cover the 9009 return code pre-emptively.
+        # Cover the 9009 return code preemptively.
         raise PipxError("No suitable Python found")
     if not proc.stdout.strip():
         # A real Python should print version, Windows Store stub won't.

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -816,7 +816,7 @@ def _add_run(subparsers: argparse._SubParsersAction, shared_parser: argparse.Arg
             f"""
             Download the latest version of a package to a temporary virtual environment,
             then run an app from it. The environment will be cached
-            and re-used for up to {constants.TEMP_VENV_EXPIRATION_THRESHOLD_DAYS} days. This
+            and reused for up to {constants.TEMP_VENV_EXPIRATION_THRESHOLD_DAYS} days. This
             means subsequent calls to 'run' for the same package will be faster
             since they can reuse the cached Virtual Environment.
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [ ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

Apply `pre-commit autoupdate` but revert some changes:
* The Ruff update is handled in #1704.
* Update `pyproject-fmt` to 2.7.0 only, as 2.8.0 and later insist on adding Python 3.14 to Trove classifiers (defer after #1684 is merged).

## Test plan

Passes CI.