### PR TITLE
Handle recursive symlinks in PIPX_BIN_DIR

### DIFF
--- a/changelog.d/1592.bugfix.md
+++ b/changelog.d/1592.bugfix.md
@@ -1,0 +1,1 @@
+Ignore recursive symlink loops in PIPX_BIN_DIR.

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -135,7 +135,7 @@ def _symlink_package_resource(
         logger.info(f"Force is true. Removing {symlink_path!s}.")
         try:
             symlink_path.unlink()
-        except FileNotFoundError:
+        except (FileNotFoundError, RuntimeError):
             pass
         except IsADirectoryError:
             rmdir(symlink_path)
@@ -307,7 +307,7 @@ def get_exposed_paths_for_package(
             if is_same_file:
                 symlinks.add(b)
 
-        except FileNotFoundError:
+        except (FileNotFoundError, RuntimeError):
             pass
     return symlinks
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,16 @@
+from helpers import skip_if_windows
+from pipx.commands.common import get_exposed_paths_for_package
+
+
+@skip_if_windows
+def test_get_exposed_paths_ignores_recursive_symlink(tmp_path):
+    venv_resource_path = tmp_path / "venv_bin"
+    venv_resource_path.mkdir()
+    local_resource_dir = tmp_path / "bin"
+    local_resource_dir.mkdir()
+    loop = local_resource_dir / "recursiveexample"
+    loop.symlink_to(loop.name)
+
+    exposed = get_exposed_paths_for_package(venv_resource_path, local_resource_dir)
+
+    assert loop not in exposed


### PR DESCRIPTION
- [x] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes
Closes #1592
- Ignore recursive symlink loops in `PIPX_BIN_DIR` when scanning exposed app paths.
- Catch `RuntimeError` from `Path.resolve()` on symlink loops and treat them as missing entries so installs continue.
- Add a regression test for recursive symlinks.

## Test plan
py -m pytest tests/test_common.py

Skipped on Windows because creating symlink loops requires elevated privileges/Developer Mode and is not reliably available, so the test is marked undefined on Windows to avoid spurious failures.