### PR TITLE
test: fix tests for package url

### DIFF
--- a/tests/test_package_specifier.py
+++ b/tests/test_package_specifier.py
@@ -39,12 +39,12 @@ def test_valid_pypi_name(package_spec_in, package_name_out):
         (
             "nox@https://github.com/ambv/black/archive/18.9b0.zip",
             "black",
-            "black@ https://github.com/ambv/black/archive/18.9b0.zip",
+            "black @ https://github.com/ambv/black/archive/18.9b0.zip",
         ),
         (
             "nox[extra]@https://github.com/ambv/black/archive/18.9b0.zip",
             "black",
-            "black[extra]@ https://github.com/ambv/black/archive/18.9b0.zip",
+            "black[extra] @ https://github.com/ambv/black/archive/18.9b0.zip",
         ),
     ],
 )
@@ -75,7 +75,7 @@ _ROOT = Path(__file__).parents[1]
         ),
         (
             "nox@git+https://github.com/cs01/nox.git@5ea70723e9e6",
-            "nox@ git+https://github.com/cs01/nox.git@5ea70723e9e6",
+            "nox @ git+https://github.com/cs01/nox.git@5ea70723e9e6",
             True,
         ),
         (
@@ -85,22 +85,22 @@ _ROOT = Path(__file__).parents[1]
         ),
         (
             "black@https://github.com/ambv/black/archive/18.9b0.zip",
-            "black@ https://github.com/ambv/black/archive/18.9b0.zip",
+            "black @ https://github.com/ambv/black/archive/18.9b0.zip",
             True,
         ),
         (
             "black @ https://github.com/ambv/black/archive/18.9b0.zip",
-            "black@ https://github.com/ambv/black/archive/18.9b0.zip",
+            "black @ https://github.com/ambv/black/archive/18.9b0.zip",
             True,
         ),
         (
             "black[extra] @ https://github.com/ambv/black/archive/18.9b0.zip",
-            "black[extra]@ https://github.com/ambv/black/archive/18.9b0.zip",
+            "black[extra] @ https://github.com/ambv/black/archive/18.9b0.zip",
             True,
         ),
         (
             'my-project[cli] @ git+ssh://git@bitbucket.org/my-company/myproject.git ; python_version<"3.8"',
-            "my-project[cli]@ git+ssh://git@bitbucket.org/my-company/myproject.git",
+            "my-project[cli] @ git+ssh://git@bitbucket.org/my-company/myproject.git",
             True,
         ),
         ("path/doesnt/exist", "non-existent-path", False),
@@ -143,7 +143,7 @@ def test_parse_specifier_for_metadata(package_spec_in, package_or_url_correct, v
         ),
         (
             "nox@git+https://github.com/cs01/nox.git@5ea70723e9e6",
-            "nox@ git+https://github.com/cs01/nox.git@5ea70723e9e6",
+            "nox @ git+https://github.com/cs01/nox.git@5ea70723e9e6",
             True,
         ),
         (
@@ -153,22 +153,22 @@ def test_parse_specifier_for_metadata(package_spec_in, package_or_url_correct, v
         ),
         (
             "black@https://github.com/ambv/black/archive/18.9b0.zip",
-            "black@ https://github.com/ambv/black/archive/18.9b0.zip",
+            "black @ https://github.com/ambv/black/archive/18.9b0.zip",
             True,
         ),
         (
             "black @ https://github.com/ambv/black/archive/18.9b0.zip",
-            "black@ https://github.com/ambv/black/archive/18.9b0.zip",
+            "black @ https://github.com/ambv/black/archive/18.9b0.zip",
             True,
         ),
         (
             "black[extra] @ https://github.com/ambv/black/archive/18.9b0.zip",
-            "black[extra]@ https://github.com/ambv/black/archive/18.9b0.zip",
+            "black[extra] @ https://github.com/ambv/black/archive/18.9b0.zip",
             True,
         ),
         (
             'my-project[cli] @ git+ssh://git@bitbucket.org/my-company/myproject.git ; python_version<"3.8"',
-            "my-project[cli]@ git+ssh://git@bitbucket.org/my-company/myproject.git",
+            "my-project[cli] @ git+ssh://git@bitbucket.org/my-company/myproject.git",
             True,
         ),
         ("path/doesnt/exist", "non-existent-path", False),

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -349,7 +349,7 @@ def test_run_with_failing_requirements(capfd, pipx_temp_env, tmp_path):
     captured = capfd.readouterr()
 
     assert return_code != 0
-    assert "Error installing will_fail@ git+https://0.0.0.0/will_fail.git." in captured.err
+    assert "Error installing will_fail @ git+https://0.0.0.0/will_fail.git." in captured.err
 
     # Attempt second invocation of `pipx run`.
     # If above failure was detected and the temporary venv marked for deletion,
@@ -360,7 +360,7 @@ def test_run_with_failing_requirements(capfd, pipx_temp_env, tmp_path):
 
     assert return_code != 0
     assert "ModuleNotFoundError: No module named 'will_fail'" not in captured.err
-    assert "Error installing will_fail@ git+https://0.0.0.0/will_fail.git." in captured.err
+    assert "Error installing will_fail @ git+https://0.0.0.0/will_fail.git." in captured.err
 
 
 def test_pip_args_forwarded_to_shared_libs(pipx_ultra_temp_env, capsys, caplog):


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->

- [ ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

Seems the dependency update in https://github.com/pypa/pipx/pull/1700 breaks the tests on main branch https://github.com/pypa/pipx/actions/runs/21233580202, and this pull request try to fix the issue.

## Test plan

<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->

Tested by running

```
# command(s) to exercise these changes
nox -s tests-3.12
```
