### PR TITLE
`__package__` → `__spec__.parent`

### DIFF
--- a/src/pipx/__main__.py
+++ b/src/pipx/__main__.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-if not __package__:
+if not __spec__ or not __spec__.parent:
     # Running from source. Add pipx's source code to the system
     # path to allow direct invocation, such as:
     #   python src/pipx --help


### PR DESCRIPTION
- [ ] I have added a news fragment under `changelog.d/` (if the patch affects the end users)

## Summary of changes

Removed deprecated `__package__`, scheduled for [removal in Python 3.15](https://docs.python.org/3.15/reference/datamodel.html#module.__package__).

## Test plan

Just CI.