### PR TITLE
fix: clarify install message to avoid confusion with --global flag

### DIFF
--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -352,13 +352,13 @@ def _get_list_output(
     )
 
     if new_install and (exposed_binary_names or unavailable_binary_names):
-        output.append("  These apps are now globally available")
+        output.append("  These apps are now available")
     output.extend(f"    - {name}" for name in exposed_binary_names)
     output.extend(
         f"    - {red(name)} (symlink missing or pointing to unexpected location)" for name in unavailable_binary_names
     )
     if new_install and (exposed_man_pages or unavailable_man_pages):
-        output.append("  These manual pages are now globally available")
+        output.append("  These manual pages are now available")
     output.extend(f"    - {name}" for name in exposed_man_pages)
     output.extend(
         f"    - {red(name)} (symlink missing or pointing to unexpected location)" for name in unavailable_man_pages

--- a/tests/test_install_all_packages.py
+++ b/tests/test_install_all_packages.py
@@ -275,7 +275,7 @@ def verify_installed_resources(
         return True
 
     reported_resources_re = re.search(
-        r"These " + resource_name_long + r" are now globally available\n((?:    - [^\n]+\n)*)",
+        r"These " + resource_name_long + r" are now available\n((?:    - [^\n]+\n)*)",
         captured_outerr.out,
         re.DOTALL,
     )


### PR DESCRIPTION
## Summary

Changes "These apps are now globally available" to "These apps are now available" to avoid confusion with the `--global` flag.

Fixes #1460

## Changes

- Updated install success message in `src/pipx/commands/common.py`
- Same change applied to manual pages message  
- Updated corresponding test regex in `tests/test_install_all_packages.py`

## Context

The word "globally" in the install message can mislead users into thinking a system-wide (`--global`) install was performed when they only did a regular `pipx install`. Removing "globally" clarifies the message without losing meaning.