### PR TITLE
fix: clearer error message when pip subprocess crashes

### DIFF
--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -396,6 +396,11 @@ class Venv:
         cmd_run = run_subprocess(
             [str(self.python_path), "-m", "pip", "list", "--format=json"] + (["--not-required"] if not_required else [])
         )
+        if cmd_run.returncode != 0:
+            raise PipxError(
+                f"pip list failed with exit code {cmd_run.returncode}. "
+                "This may indicate a misconfigured Python environment or a broken pip installation."
+            )
         pip_list = json.loads(cmd_run.stdout.strip())
         return {x["name"] for x in pip_list}
 


### PR DESCRIPTION
Improves error messaging when the pip subprocess crashes, making it clear that pip failed rather than showing a misleading exception.

When pip crashes during 'pip list' execution (e.g., due to a misconfigured Python environment), the subprocess returns an empty stdout. Previously, this caused a misleading JSONDecodeError when trying to parse the empty string. Now we explicitly check the subprocess return code and raise a clear error message indicating that pip failed.

Fixes #1698.