### PR TITLE
📝 docs: clarify --global flag placement

### DIFF
--- a/docs/how-to/configure-paths.md
+++ b/docs/how-to/configure-paths.md
@@ -49,14 +49,23 @@ sudo pipx install --global <PACKAGE>
 
 #### `--global` argument
 
-pipx also comes with a `--global` argument which helps to execute actions in global scope which exposes the app to all
-system users. By default the global binary location is set to `/usr/local/bin` and can be overridden with the
-environment variable `PIPX_GLOBAL_BIN_DIR`. Default global manual page location is `/usr/local/share/man`. This can be
-overridden with environment variable `PIPX_GLOBAL_MAN_DIR`. Finally, default global virtual environment location is
-`/opt/pipx`, can be overridden with environment variable `PIPX_GLOBAL_HOME`. Make sure to run
-`sudo pipx ensurepath --global` if you intend to use this feature.
+The `--global` flag installs applications into a system-wide location accessible to all users. It must be placed
+**after** the subcommand, not before it:
 
-Note that the `--global` argument is not supported on Windows.
+```
+# correct
+sudo pipx install --global pycowsay
+sudo pipx list --global
+
+# wrong (--global is silently ignored when placed before the subcommand)
+sudo pipx --global install pycowsay
+```
+
+Default global paths are `/usr/local/bin` for binaries, `/usr/local/share/man` for man pages, and `/opt/pipx` for
+virtual environments. Override them with `PIPX_GLOBAL_BIN_DIR`, `PIPX_GLOBAL_MAN_DIR`, and `PIPX_GLOBAL_HOME`. Run
+`sudo pipx ensurepath --global` to add the global binary directory to the system `PATH`.
+
+The `--global` flag is not supported on Windows.
 
 #### `--prepend` argument
 

--- a/docs/reference/examples.md
+++ b/docs/reference/examples.md
@@ -18,7 +18,7 @@ pipx install --include-deps jupyter
 pipx install --pip-args='--pre' poetry
 pipx install --pip-args='--index-url=<private-repo-host>:<private-repo-port> --trusted-host=<private-repo-host>:<private-repo-port>' private-repo-package
 pipx install --index-url https://test.pypi.org/simple/ --pip-args='--extra-index-url https://pypi.org/simple/' some-package
-pipx --global install pycowsay
+pipx install --global pycowsay
 pipx install .
 pipx install path/to/some-project
 ```

--- a/docs/tutorial/install-applications.md
+++ b/docs/tutorial/install-applications.md
@@ -8,7 +8,8 @@ pipx install PACKAGE
 
 pipx creates a virtual environment, installs the package, and adds its entry points to a location on your `PATH`.
 `pipx install pycowsay` makes the `pycowsay` command available system-wide while sandboxing pycowsay in its own virtual
-environment. No `sudo` required.
+environment. No `sudo` required. To install for all users on the system, pass `--global` after the subcommand (see
+[Configure Paths](../how-to/configure-paths.md#-global-argument)).
 
 ```
 >> pipx install pycowsay


### PR DESCRIPTION
Running `pipx --global list` silently ignores the `--global` flag and shows user-local venvs. The flag must come after the subcommand: `pipx list --global`. Multiple users have reported confusion about this in #1537.

The how-to guide now shows correct and incorrect placement with explicit examples. The `reference/examples.md` entry `pipx --global install pycowsay` used the wrong position and is fixed to `pipx install --global pycowsay`. The install-applications tutorial adds a cross-reference to the `--global` how-to for users who want system-wide installs.

Closes #1537