### PR TITLE
📝 docs: explain sudo pipx failure with --user installs

### DIFF
--- a/docs/how-to/install-pipx.md
+++ b/docs/how-to/install-pipx.md
@@ -77,6 +77,12 @@ sudo pipx ensurepath --prepend
 
 For more details, refer to [Customising your installation](configure-paths.md).
 
+> [!NOTE]
+> If you installed pipx with `pip install --user`, the `pipx` binary lives in your user directory (e.g.
+> `~/.local/bin/pipx`). Running `sudo pipx` will fail because root's `PATH` does not include your user bin directory.
+> Use the full path instead: `sudo ~/.local/bin/pipx ensurepath --global`. Alternatively, install pipx system-wide with
+> `sudo pip install pipx` (without `--user`) or use your distribution's package manager.
+
 ### On Windows:
 
 - Install via [Scoop](https://scoop.sh/):

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -80,6 +80,18 @@ found in `$XDG_STATE_HOME/pipx/logs` or user's log path if the former is not wri
 
 For most users this location is `~/.local/state/pipx/logs`, where `~` is your home directory.
 
+## `sudo pipx` not found
+
+If you installed pipx with `pip install --user`, the binary lives in your user directory (e.g. `~/.local/bin/pipx`).
+Root's `PATH` does not include that directory, so `sudo pipx` fails with "command not found". Use the full path instead:
+
+```
+sudo ~/.local/bin/pipx ensurepath --global
+```
+
+To avoid this, install pipx through your distribution's package manager (`apt install pipx`, `dnf install pipx`) or
+install it system-wide with `sudo pip install pipx` (without `--user`).
+
 ## Debian, Ubuntu issues
 
 If you have issues using pipx on Debian, Ubuntu, or other Debian-based linux distributions, make sure you have the


### PR DESCRIPTION
When pipx is installed via `pip install --user`, the binary lives in `~/.local/bin/`. Running `sudo pipx` fails because root's `PATH` does not include that user directory. Several users hit this and the existing docs don't explain the cause or workaround.

Added a note to the Linux install section in `install-pipx.md` and a new troubleshoot entry with the full-path workaround (`sudo ~/.local/bin/pipx ensurepath --global`). The troubleshoot section also recommends using the distro package manager or `sudo pip install pipx` to avoid the issue entirely.

Closes #1560