### PR TITLE
📝 docs: add PEP 668 note to Linux install guide

### DIFF
--- a/docs/how-to/install-pipx.md
+++ b/docs/how-to/install-pipx.md
@@ -62,8 +62,8 @@ python3 -m pipx ensurepath
 ```
 
 > [!NOTE]
-> Distributions that adopt [PEP 668](https://peps.python.org/pep-0668/) (Ubuntu 23.04+, Debian 12+, Fedora 38+) mark
-> the system Python as externally managed. Running `pip install --user` on these systems fails with an
+> Distributions that adopt [PEP 668](https://peps.python.org/pep-0668/) (Ubuntu 23.04+, Debian 12+, Fedora 38+) mark the
+> system Python as externally managed. Running `pip install --user` on these systems fails with an
 > `externally-managed-environment` error. Use your distribution's package manager (`apt install pipx`,
 > `dnf install pipx`) instead. If no distro package exists, install pipx inside its own virtual environment:
 >

--- a/docs/how-to/install-pipx.md
+++ b/docs/how-to/install-pipx.md
@@ -61,6 +61,19 @@ python3 -m pip install --user pipx
 python3 -m pipx ensurepath
 ```
 
+> [!NOTE]
+> Distributions that adopt [PEP 668](https://peps.python.org/pep-0668/) (Ubuntu 23.04+, Debian 12+, Fedora 38+) mark
+> the system Python as externally managed. Running `pip install --user` on these systems fails with an
+> `externally-managed-environment` error. Use your distribution's package manager (`apt install pipx`,
+> `dnf install pipx`) instead. If no distro package exists, install pipx inside its own virtual environment:
+>
+> ```
+> python3 -m venv ~/.local/share/pipx-venv
+> ~/.local/share/pipx-venv/bin/pip install pipx
+> ln -s ~/.local/share/pipx-venv/bin/pipx ~/.local/bin/pipx
+> pipx ensurepath
+> ```
+
 #### Additional (optional) commands
 
 To allow pipx actions in global scope.


### PR DESCRIPTION
Distributions adopting [PEP 668](https://peps.python.org/pep-0668/) (Ubuntu 23.04+, Debian 12+, Fedora 38+) mark the system Python as externally managed. Running `pip install --user pipx` on these systems fails with an `externally-managed-environment` error. The install docs listed distro packages first but the pip fallback had no warning about this.

Added a note explaining the error and recommending the distro package manager. For distros without a pipx package, included a venv-based workaround that creates an isolated environment for pipx itself.

Closes #982