### PR TITLE
📝 docs: mention gui_scripts support

### DIFF
--- a/docs/explanation/how-pipx-works.md
+++ b/docs/explanation/how-pipx-works.md
@@ -9,9 +9,8 @@ the shared pip via a [.pth file](https://docs.python.org/3/library/site.html) an
 
 Once the package is installed, pipx exposes its console scripts and GUI scripts by symlinking them into `~/.local/bin`
 (for example, `~/.local/bin/black` -> `~/.local/share/pipx/venvs/black/bin/black`). It also symlinks any manual pages
-into
-`~/.local/share/man/man[1-9]`. As long as `~/.local/bin/` is on your `PATH`, the new commands are available globally,
-and on systems with `man` support the pages are accessible too.
+into `~/.local/share/man/man[1-9]`. As long as `~/.local/bin/` is on your `PATH`, the new commands are available
+globally, and on systems with `man` support the pages are accessible too.
 
 Adding the `--global` flag to any `pipx` command executes the action in global scope, exposing the app to all system
 users. See the [configuration reference](../how-to/configure-paths.md#-global-argument) for details. Note that this is

--- a/docs/explanation/how-pipx-works.md
+++ b/docs/explanation/how-pipx-works.md
@@ -7,8 +7,9 @@ virtual environment at `~/.local/share/pipx/shared/` that contains the packaging
 to its latest version. It then creates an isolated virtual environment at `~/.local/share/pipx/venvs/PACKAGE` that uses
 the shared pip via a [.pth file](https://docs.python.org/3/library/site.html) and installs the desired package into it.
 
-Once the package is installed, pipx exposes its binaries by symlinking them into `~/.local/bin` (for example,
-`~/.local/bin/black` -> `~/.local/share/pipx/venvs/black/bin/black`). It also symlinks any manual pages into
+Once the package is installed, pipx exposes its console scripts and GUI scripts by symlinking them into `~/.local/bin`
+(for example, `~/.local/bin/black` -> `~/.local/share/pipx/venvs/black/bin/black`). It also symlinks any manual pages
+into
 `~/.local/share/man/man[1-9]`. As long as `~/.local/bin/` is on your `PATH`, the new commands are available globally,
 and on systems with `man` support the pages are accessible too.
 

--- a/docs/explanation/making-packages-compatible.md
+++ b/docs/explanation/making-packages-compatible.md
@@ -6,8 +6,9 @@ If you are a developer and want to be able to run
 pipx install MY_PACKAGE
 ```
 
-make sure you include `scripts` and, optionally for Windows GUI applications `gui-scripts`, sections under your main
-table[^1] in `pyproject.toml` or their legacy equivalents for `setup.cfg` and `setup.py`.
+make sure you include `scripts` in your main table[^1] in `pyproject.toml` or its legacy equivalents for `setup.cfg` and
+`setup.py`. pipx also exposes `gui-scripts` entry points, which are useful for GUI applications on Windows (they launch
+without opening a console window).
 
 === "pyproject.toml"
 


### PR DESCRIPTION
pipx has exposed `gui_scripts` entry points since v1.3.0, but the documentation only mentioned `console_scripts`. Users filed #711 thinking GUI applications were unsupported. A maintainer confirmed in the issue comments that `pipx install novelwriter` correctly exposes GUI entry points.

Updated the making-packages-compatible explanation to call out `gui_scripts` alongside `console_scripts`, and the how-pipx-works page to mention both script types when describing the symlink step.

Closes #711