### PR TITLE
📝 docs: add version requirements for --global and --prepend

### DIFF
--- a/docs/how-to/install-pipx.md
+++ b/docs/how-to/install-pipx.md
@@ -23,17 +23,22 @@ pipx ensurepath
 
 #### Additional (optional) commands
 
-To allow pipx actions in global scope.
+To allow pipx actions in global scope (requires pipx 1.5.0+):
 
 ```
 sudo pipx ensurepath --global
 ```
 
-To prepend the pipx bin directory to PATH instead of appending it.
+To prepend the pipx bin directory to PATH instead of appending it (requires pipx 1.7.0+):
 
 ```
 sudo pipx ensurepath --prepend
 ```
+
+> [!NOTE]
+> Some distributions ship older pipx versions (e.g. Ubuntu 24.04 ships v1.4.3). If `--global` or `--prepend` fails with
+> "unrecognized arguments", upgrade pipx first: `pip install --user --upgrade pipx`, or install a newer version from a
+> different source.
 
 For more details, refer to [Customising your installation](configure-paths.md).
 
@@ -63,13 +68,13 @@ python3 -m pipx ensurepath
 
 #### Additional (optional) commands
 
-To allow pipx actions in global scope.
+To allow pipx actions in global scope (requires pipx 1.5.0+):
 
 ```
 sudo pipx ensurepath --global
 ```
 
-To prepend the pipx bin directory to PATH instead of appending it.
+To prepend the pipx bin directory to PATH instead of appending it (requires pipx 1.7.0+):
 
 ```
 sudo pipx ensurepath --prepend


### PR DESCRIPTION
Ubuntu 24.04 ships pipx 1.4.3, which lacks `--global` (added in 1.5.0) and `--prepend` (added in 1.7.0). Users following the install docs get "unrecognized arguments" errors (#1524). The docs showed these flags without any version caveat.

Added version requirements next to each flag and a note explaining that distro-packaged pipx may be too old, with an upgrade suggestion.

Closes #1524