### PR TITLE
📝 docs: document installing from a pull request

### DIFF
--- a/docs/how-to/install-pipx.md
+++ b/docs/how-to/install-pipx.md
@@ -154,3 +154,18 @@ Use pip's `egg` syntax when installing extras:
 ```
 pipx install "git+https://github.com/psf/black.git#egg=black[jupyter]"
 ```
+
+### Installing from a pull request
+
+To test a package from an open pull request, find the fork owner and branch name on the PR page, then build the git URL.
+For example, PR #794 from user `contributor` on branch `fix-something`:
+
+```
+pipx install git+https://github.com/contributor/pipx.git@fix-something
+```
+
+If the PR branch has been merged, use the merge commit hash instead:
+
+```
+pipx install git+https://github.com/pypa/pipx.git@abc123def
+```


### PR DESCRIPTION
Users testing packages from open pull requests had to figure out the fork owner, branch name, and git URL syntax on their own (#812). The install docs had git examples but nothing specific to the PR workflow.

Added a "Installing from a pull request" section showing how to construct the git URL from a PR page, covering both open PRs (fork+branch) and merged PRs (commit hash).

Closes #812