### PR TITLE
📝 docs: replace pipx-in-pipx warning with self-managed install guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -47,10 +47,6 @@ Best of all, pipx runs with regular user permissions, never calling `sudo pip in
 
 ## Install pipx
 
-> [!WARNING]
-> It is not recommended to install `pipx` via `pipx`. If you'd like to do this anyway, take a look at the
-> [`pipx-in-pipx`](https://github.com/mattsb42-meta/pipx-in-pipx) project and read about the limitations there.
-
 ### On macOS
 
 ```

--- a/docs/how-to/install-pipx.md
+++ b/docs/how-to/install-pipx.md
@@ -109,10 +109,6 @@ you did not get the warning):
 This will add both the above mentioned path and the `%USERPROFILE%\.local\bin` folder to your search path. Restart your
 terminal session and verify `pipx` does run.
 
-> [!WARNING]
-> It is not recommended to install `pipx` via `pipx`. If you'd like to do this anyway, take a look at the
-> [`pipx-in-pipx`](https://github.com/mattsb42-meta/pipx-in-pipx) project and read about the limitations there.
-
 ### On FreeBSD:
 
 - Install via package manager
@@ -136,6 +132,22 @@ Python 3.9+ interpreter:
 ```
 python pipx.pyz ensurepath
 ```
+
+### Self-managed pipx
+
+You can use pipx to manage its own installation. This keeps pipx up to date through `pipx upgrade pipx` and avoids
+relying on distro packages that may ship older versions. Bootstrap it with a temporary virtual environment:
+
+```
+python3 -m venv /tmp/bootstrap
+/tmp/bootstrap/bin/pip install pipx
+/tmp/bootstrap/bin/pipx install pipx
+rm -rf /tmp/bootstrap
+pipx ensurepath
+```
+
+After this, `pipx upgrade pipx` upgrades pipx like any other pipx-managed application. On Windows, pipx cannot delete
+its own running executable, so it moves locked files to a trash directory and cleans them up on the next run.
 
 ## Installing packages from source control
 


### PR DESCRIPTION
The warning "It is not recommended to install pipx via pipx" dates back to early versions. Since then, three PRs addressed the underlying issues: #718 added Windows file-locking workarounds (rename-to-trash for locked executables), #1231 fixed self-uninstall on Windows, and #1340 fixed `DEFAULT_PYTHON` resolution that broke self-managed reinstalls. A maintainer acknowledged in #1449 that the warning should be removed if nobody can reproduce the original problems.

Removed the outdated warning from both `install-pipx.md` and `README.md`. Added a "Self-managed pipx" section documenting the bootstrap approach (temporary venv to seed the initial install). The Windows behavior is documented: pipx moves locked files to a `PIPX_HOME/.trash` directory and cleans them up on the next run.

Closes #1449