### PR TITLE
🐛 fix(uninstall): prevent data loss from relative directory names

### DIFF
--- a/changelog.d/1718.bugfix.md
+++ b/changelog.d/1718.bugfix.md
@@ -1,0 +1,1 @@
+Prevent data loss by rejecting relative paths in `uninstall`, `reinstall`, and other package-name arguments

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -214,7 +214,7 @@ def package_is_url(package: str, raise_error: bool = True) -> bool:
 
 
 def package_is_path(package: str):
-    if os.path.sep in package:
+    if os.path.sep in package or Path(package).exists():
         raise PipxError(
             pipx_wrap(
                 f"""

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -155,6 +155,22 @@ def test_uninstall_proper_dep_behavior(pipx_temp_env, metadata_version):
         assert isort_app_path.exists()
 
 
+def test_uninstall_rejects_existing_directory_name(pipx_temp_env, tmp_path, monkeypatch):
+    local_dir = tmp_path / "myproject"
+    local_dir.mkdir()
+    (local_dir / "pyproject.toml").write_text(
+        '[project]\nname = "myproject"\nversion = "0.1.0"\n[project.scripts]\nmycmd = "myproject:main"\n'
+    )
+    (local_dir / "myproject.py").write_text("def main(): pass")
+
+    assert not run_pipx_cli(["install", "--editable", str(local_dir)])
+
+    monkeypatch.chdir(tmp_path)
+    result = run_pipx_cli(["uninstall", "myproject"])
+    assert result != 0, "uninstall should reject directory name when cwd contains that directory"
+    assert local_dir.exists(), "source directory should not be deleted"
+
+
 @pytest.mark.parametrize("metadata_version", PIPX_METADATA_LEGACY_VERSIONS)
 def test_uninstall_proper_dep_behavior_missing_interpreter(pipx_temp_env, metadata_version):
     # isort is a dependency of pylint.  Make sure that uninstalling pylint


### PR DESCRIPTION
Running `pipx uninstall myproject` from a directory containing `myproject/` passed validation (package_is_path only checked for path separators like `/` and `\`) and deleted the source tree. A user reported in #1718 losing editable source code after running `pipx uninstall pipx.tmp` from the parent directory of `pipx.tmp/`.

Extended `package_is_path()` to also check `Path(package).exists()`, which catches relative directory names that lack path separators. Added a test that reproduces the exact scenario: install an editable package, cd to its parent directory, then run uninstall with the directory name. The fix rejects the command with "looks like a path" and the source directory survives.

Closes #1718