### PR TITLE
🐛 fix(install): enable keyring auth for private indexes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,7 @@ repos:
           - "nox"
           - "packaging>=20"
           - "platformdirs>=2.1"
+          - "pytest"
           - "tomli; python_version < '3.11'"
   # Configuration for codespell is in pyproject.toml
   - repo: https://github.com/codespell-project/codespell

--- a/changelog.d/1603.bugfix.md
+++ b/changelog.d/1603.bugfix.md
@@ -1,0 +1,1 @@
+Enable keyring authentication for private package indexes by setting `PIP_KEYRING_PROVIDER=subprocess`

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -151,6 +151,7 @@ def _fix_subprocess_env(env: dict[str, str]) -> dict[str, str]:
     env["PYTHONLEGACYWINDOWSSTDIO"] = "utf-8"
     # Make sure we install package to venv, not userbase dir
     env["PIP_USER"] = "0"
+    env.setdefault("PIP_KEYRING_PROVIDER", "subprocess")
     return env
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 
-import pytest  # type: ignore[import-not-found]
+import pytest
 
 from helpers import WIN
 from pipx import commands, interpreter, paths, shared_libs, standalone_python, venv

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Optional
 from unittest import mock
 
-import pytest  # type: ignore[import-not-found]
+import pytest
 from packaging.utils import canonicalize_name
 
 from package_info import PKG

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -1,7 +1,7 @@
 import time
 from timeit import default_timer
 
-import pytest  # type: ignore[import-not-found]
+import pytest
 
 import pipx.animate
 from pipx.animate import (

--- a/tests/test_emojis.py
+++ b/tests/test_emojis.py
@@ -2,7 +2,7 @@ import sys
 from io import BytesIO, TextIOWrapper
 from unittest import mock
 
-import pytest  # type: ignore[import-not-found]
+import pytest
 
 from pipx.emojis import use_emojis
 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,7 +1,7 @@
 import fnmatch
 from pathlib import Path
 
-import pytest  # type: ignore[import-not-found]
+import pytest
 
 from helpers import run_pipx_cli, skip_if_windows
 from pipx import paths

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -2,7 +2,7 @@ import logging
 import re
 import textwrap
 
-import pytest  # type: ignore[import-not-found]
+import pytest
 
 from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli, skip_if_windows
 from package_info import PKG

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -5,7 +5,7 @@ import sys
 from pathlib import Path
 from unittest import mock
 
-import pytest  # type: ignore[import-not-found]
+import pytest
 
 from helpers import app_name, run_pipx_cli, skip_if_windows, unwrap_log_text
 from package_info import PKG
@@ -264,9 +264,8 @@ def test_pip_args_forwarded_to_package_name_determination(pipx_temp_env, capsys)
     assert "Cannot determine package name from spec" in captured.err
 
 
+@pytest.mark.skipif(not sys.platform.startswith("win"), reason="Windows only")
 def test_pip_args_with_windows_path(pipx_temp_env, capsys):
-    if not sys.platform.startswith("win"):
-        pytest.skip("Test pip arguments with Windows path on Windows only.")
 
     assert run_pipx_cli(
         [

--- a/tests/test_install_all_packages.py
+++ b/tests/test_install_all_packages.py
@@ -24,7 +24,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional
 
-import pytest  # type: ignore[import-not-found]
+import pytest
 
 from helpers import run_pipx_cli
 from package_info import PKG

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 from unittest.mock import Mock
 
-import pytest  # type: ignore[import-not-found]
+import pytest
 
 import pipx.interpreter
 import pipx.paths

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -5,7 +5,7 @@ import shutil
 import sys
 import time
 
-import pytest  # type: ignore[import-not-found]
+import pytest
 
 from helpers import (
     PIPX_METADATA_LEGACY_VERSIONS,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,7 @@
 import sys
 from unittest import mock
 
-import pytest  # type: ignore[import-not-found]
+import pytest
 
 from helpers import run_pipx_cli
 from pipx import main

--- a/tests/test_package_specifier.py
+++ b/tests/test_package_specifier.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-import pytest  # type: ignore[import-not-found]
+import pytest
 
 from pipx.package_specifier import (
     fix_package_name,

--- a/tests/test_pipx_metadata_file.py
+++ b/tests/test_pipx_metadata_file.py
@@ -2,7 +2,7 @@ import sys
 from dataclasses import replace
 from pathlib import Path
 
-import pytest  # type: ignore[import-not-found]
+import pytest
 
 from helpers import assert_package_metadata, create_package_info_ref, run_pipx_cli
 from package_info import PKG

--- a/tests/test_reinstall.py
+++ b/tests/test_reinstall.py
@@ -1,6 +1,6 @@
 import sys
 
-import pytest  # type: ignore[import-not-found]
+import pytest
 
 from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli, skip_if_windows
 

--- a/tests/test_reinstall_all.py
+++ b/tests/test_reinstall_all.py
@@ -1,6 +1,6 @@
 import sys
 
-import pytest  # type: ignore[import-not-found]
+import pytest
 
 from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli
 from pipx import shared_libs

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -6,7 +6,7 @@ import textwrap
 from pathlib import Path
 from unittest import mock
 
-import pytest  # type: ignore[import-not-found]
+import pytest
 
 import pipx.main
 import pipx.util

--- a/tests/test_shared_libs.py
+++ b/tests/test_shared_libs.py
@@ -3,7 +3,7 @@ import time
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest  # type: ignore[import-not-found]
+import pytest
 
 from pipx import shared_libs
 from pipx.constants import WINDOWS

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -1,6 +1,6 @@
 import sys
 
-import pytest  # type: ignore[import-not-found]
+import pytest
 
 from helpers import (
     PIPX_METADATA_LEGACY_VERSIONS,

--- a/tests/test_uninstall_all.py
+++ b/tests/test_uninstall_all.py
@@ -1,4 +1,4 @@
-import pytest  # type: ignore[import-not-found]
+import pytest
 
 from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli
 

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,4 +1,4 @@
-import pytest  # type: ignore[import-not-found]
+import pytest
 
 from helpers import (
     PIPX_METADATA_LEGACY_VERSIONS,

--- a/tests/test_upgrade_all.py
+++ b/tests/test_upgrade_all.py
@@ -1,4 +1,4 @@
-import pytest  # type: ignore[import-not-found]
+import pytest
 
 from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli
 

--- a/tests/test_upgrade_shared.py
+++ b/tests/test_upgrade_shared.py
@@ -1,6 +1,6 @@
 import subprocess
 
-import pytest  # type: ignore[import-not-found]
+import pytest
 
 from helpers import run_pipx_cli
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 import pytest

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,23 @@
+import sys
+
+import pytest
+
+from pipx.util import run_subprocess
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected"),
+    [
+        pytest.param(None, "subprocess", id="defaults_to_subprocess"),
+        pytest.param("import", "import", id="preserves_explicit"),
+    ],
+)
+def test_subprocess_keyring_provider(monkeypatch: pytest.MonkeyPatch, env_value: str | None, expected: str) -> None:
+    if env_value is not None:
+        monkeypatch.setenv("PIP_KEYRING_PROVIDER", env_value)
+    else:
+        monkeypatch.delenv("PIP_KEYRING_PROVIDER", raising=False)
+
+    result = run_subprocess([sys.executable, "-c", "import os; print(os.environ['PIP_KEYRING_PROVIDER'])"])
+
+    assert result.stdout.strip() == expected


### PR DESCRIPTION
When pip's global `index-url` points to a private repository and the user authenticates via keyring (Azure Artifacts, Artifactory, etc.), `pipx install` fails. pipx passes `--no-input` to pip, which implicitly disables keyring, and the venv doesn't have keyring installed as a library for pip to import. This makes pipx unusable for anyone relying on keyring-authenticated private indexes (#1603).

Setting `PIP_KEYRING_PROVIDER=subprocess` in the subprocess environment tells pip to invoke the system-installed `keyring` CLI rather than trying to import it as a library. The subprocess provider queries the system keyring without prompting, so it works with `--no-input`. If keyring isn't installed system-wide, pip's `shutil.which("keyring")` returns `None` and it falls back to `KeyRingNullProvider` (no-op, no errors). `setdefault` is used so any explicit `PIP_KEYRING_PROVIDER` the user already set takes precedence.

Closes #1603