### PR TITLE
🐛 fix(install): preserve URL constraints in pip-args

### DIFF
--- a/changelog.d/1582.bugfix.md
+++ b/changelog.d/1582.bugfix.md
@@ -1,0 +1,1 @@
+Fix `--pip-args='-c <url>'` breaking when constraint target is a URL instead of a local path.

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -169,17 +169,13 @@ def parse_specifier_for_install(package_spec: str, pip_args: list[str]) -> tuple
 
         if option in ("-c", "--constraint"):
             argument_index = index + 1
-            if argument_index < len(pip_args):
-                constraints_file = pip_args[argument_index]
-                pip_args[argument_index] = str(Path(constraints_file).expanduser().resolve())
+            if argument_index < len(pip_args) and not urllib.parse.urlsplit(pip_args[argument_index]).scheme:
+                pip_args[argument_index] = str(Path(pip_args[argument_index]).expanduser().resolve())
 
-        else:  # option == "--constraint=some_path"
-            option_list = option.split("=")
-
-            if len(option_list) == 2:
-                key, value = option_list
-                value_path = Path(value).expanduser().resolve()
-                pip_args[index] = f"{key}={value_path}"
+        elif (option_list := option.split("=", maxsplit=1)) and len(option_list) == 2:
+            key, value = option_list
+            if not urllib.parse.urlsplit(value).scheme:
+                pip_args[index] = f"{key}={Path(value).expanduser().resolve()}"
 
         break
 

--- a/tests/test_package_specifier.py
+++ b/tests/test_package_specifier.py
@@ -275,3 +275,36 @@ def test_parse_specifier_for_install(
     parse_specifier_for_install(package_spec_in, pip_args_in)
     if warning_str is not None:
         assert warning_str in caplog.text
+
+
+@pytest.mark.parametrize(
+    "pip_args_in,pip_args_expected",
+    [
+        (
+            ["-c", "https://example.com/constraints.txt"],
+            ["-c", "https://example.com/constraints.txt"],
+        ),
+        (
+            ["--constraint", "https://example.com/constraints.txt"],
+            ["--constraint", "https://example.com/constraints.txt"],
+        ),
+        (
+            ["--constraint=https://example.com/constraints.txt"],
+            ["--constraint=https://example.com/constraints.txt"],
+        ),
+        (
+            ["-c", "constraints.txt"],
+            ["-c", str(Path("constraints.txt").resolve())],
+        ),
+        (
+            ["--constraint=constraints.txt"],
+            [f"--constraint={Path('constraints.txt').resolve()}"],
+        ),
+    ],
+)
+def test_parse_specifier_for_install_constraint_args(
+    pip_args_in: list[str],
+    pip_args_expected: list[str],
+) -> None:
+    _, pip_args_out = parse_specifier_for_install("pipx", pip_args_in)
+    assert pip_args_out == pip_args_expected


### PR DESCRIPTION
Since 1.7.0, `parse_specifier_for_install()` calls `Path.resolve()` on `-c`/`--constraint` arguments unconditionally, turning URLs like `https://example.com/constraints.txt` into bogus local paths such as `/home/user/https:/example.com/...`. This broke `pipx install foo --pip-args='-c https://...'`.

The fix checks for a URL scheme via `urlsplit()` before resolving, so URLs pass through untouched while local paths still get resolved. Both the separate-arg form (`-c <url>`) and the combined form (`--constraint=<url>`) are handled.

Fixes #1582