### PR TITLE
♻️ refactor(config): rename MAX_PIPX_LOGS to PIPX_MAX_LOGS

### DIFF
--- a/changelog.d/1570.feature.md
+++ b/changelog.d/1570.feature.md
@@ -1,1 +1,1 @@
-Add MAX_PIPX_LOGS environment variable to configure the maximum number of log files to keep.
+Add `PIPX_MAX_LOGS` environment variable to configure the maximum number of log files to keep.

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -94,7 +94,8 @@ Reference: [pip Environment Variables](https://pip.pypa.io/en/stable/user_guide/
 ## `pipx` log files
 
 pipx records a verbose log file for every `pipx` command invocation. The logs for the last 10 `pipx` commands can be
-found in `$XDG_STATE_HOME/pipx/logs` or user's log path if the former is not writable by the user.
+found in `$XDG_STATE_HOME/pipx/logs` or user's log path if the former is not writable by the user. Set `PIPX_MAX_LOGS`
+to change how many log files are kept (default: `10`).
 
 For most users this location is `~/.local/state/pipx/logs`, where `~` is your home directory.
 
@@ -185,8 +186,7 @@ In pipx version 1.5, we introduced the warning you're seeing, as multiple incomp
 path were discovered. You may see this for the following reasons:
 
 1. From pipx version 1.3 to 1.5, we were by default using a path with a space on it on macOS. This unfortunately means
-    that all users who installed pipx in this time frame and were using the default behavior are seeing this warning
-    now.
+   that all users who installed pipx in this time frame and were using the default behavior are seeing this warning now.
 1. You set your `PIPX_HOME` to a path with spaces in it explicitly or because your `$HOME` path contains a space.
 
 ### Why are spaces in the `PIPX_HOME` path bad

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -186,7 +186,8 @@ In pipx version 1.5, we introduced the warning you're seeing, as multiple incomp
 path were discovered. You may see this for the following reasons:
 
 1. From pipx version 1.3 to 1.5, we were by default using a path with a space on it on macOS. This unfortunately means
-   that all users who installed pipx in this time frame and were using the default behavior are seeing this warning now.
+    that all users who installed pipx in this time frame and were using the default behavior are seeing this warning
+    now.
 1. You set your `PIPX_HOME` to a path with spaces in it explicitly or because your `$HOME` path contains a space.
 
 ### Why are spaces in the `PIPX_HOME` path bad

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -15,6 +15,7 @@ pipx reads the following environment variables. All are optional.
 | `PIPX_FETCH_MISSING_PYTHON` | Fetch missing Python versions when `--python` is used.       | _(unset)_                                                                  |
 | `PIPX_HOME_ALLOW_SPACE`     | Set to `true` to suppress the "space in PIPX_HOME" warning.  | _(unset)_                                                                  |
 | `PIPX_USE_EMOJI`            | Set to `0` to disable emoji output.                          | `1`                                                                        |
+| `PIPX_MAX_LOGS`             | Maximum number of log files to keep in the logs directory.   | `10`                                                                       |
 
 ### Notes
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -1071,7 +1071,7 @@ def delete_oldest_logs(file_list: list[Path], keep_number: int) -> None:
 
 
 def _setup_log_file(pipx_log_dir: Optional[Path] = None) -> Path:
-    max_logs = int(os.getenv("MAX_PIPX_LOGS", 10))
+    max_logs = int(os.getenv("PIPX_MAX_LOGS", 10))
     pipx_log_dir = pipx_log_dir or paths.ctx.logs
     # don't use utils.mkdir, to prevent emission of log message
     pipx_log_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_max_logs.py
+++ b/tests/test_max_logs.py
@@ -1,4 +1,4 @@
-"""Tests for MAX_PIPX_LOGS environment variable functionality."""
+"""Tests for PIPX_MAX_LOGS environment variable functionality."""
 
 from pipx.main import _setup_log_file, delete_oldest_logs
 
@@ -35,8 +35,8 @@ def test_delete_oldest_logs_keeps_all_when_under_limit(tmp_path):
 
 
 def test_max_logs_defaults_to_10(tmp_path, monkeypatch):
-    """Test that max_logs defaults to 10 when MAX_PIPX_LOGS is not set."""
-    monkeypatch.delenv("MAX_PIPX_LOGS", raising=False)
+    """Test that max_logs defaults to 10 when PIPX_MAX_LOGS is not set."""
+    monkeypatch.delenv("PIPX_MAX_LOGS", raising=False)
 
     # Create 15 log files
     for i in range(15):
@@ -51,8 +51,8 @@ def test_max_logs_defaults_to_10(tmp_path, monkeypatch):
 
 
 def test_max_logs_respects_env_var(tmp_path, monkeypatch):
-    """Test that max_logs respects the MAX_PIPX_LOGS environment variable."""
-    monkeypatch.setenv("MAX_PIPX_LOGS", "5")
+    """Test that max_logs respects the PIPX_MAX_LOGS environment variable."""
+    monkeypatch.setenv("PIPX_MAX_LOGS", "5")
 
     # Create 15 log files
     for i in range(15):
@@ -67,8 +67,8 @@ def test_max_logs_respects_env_var(tmp_path, monkeypatch):
 
 
 def test_max_logs_with_large_value(tmp_path, monkeypatch):
-    """Test that a large MAX_PIPX_LOGS value keeps all logs."""
-    monkeypatch.setenv("MAX_PIPX_LOGS", "100")
+    """Test that a large PIPX_MAX_LOGS value keeps all logs."""
+    monkeypatch.setenv("PIPX_MAX_LOGS", "100")
 
     # Create 5 log files
     for i in range(5):


### PR DESCRIPTION
All pipx environment variables use the `PIPX_` prefix (`PIPX_HOME`, `PIPX_BIN_DIR`, `PIPX_DEFAULT_PYTHON`, etc.). The recently added `MAX_PIPX_LOGS` breaks that convention, making it harder to discover via tab completion or documentation scans.

Renames to `PIPX_MAX_LOGS` for consistency and adds the variable to the environment variables reference page and the troubleshooting guide, where it was previously undocumented.

Since `MAX_PIPX_LOGS` shipped in an unreleased commit, no backwards compatibility shim is needed.