### PR TITLE
🐛 fix(uninject): preserve shared dependencies

### DIFF
--- a/changelog.d/1672.bugfix.md
+++ b/changelog.d/1672.bugfix.md
@@ -1,0 +1,1 @@
+Prevent `uninject` from removing dependencies still needed by other packages in the venv.

--- a/src/pipx/commands/uninject.py
+++ b/src/pipx/commands/uninject.py
@@ -2,6 +2,7 @@ import logging
 import os
 from importlib import metadata
 from pathlib import Path
+from typing import Optional
 
 from packaging.utils import canonicalize_name
 
@@ -175,7 +176,7 @@ def _collect_transitive_deps(
     package_name: str,
     distributions: tuple[metadata.Distribution, ...],
     env: dict[str, str],
-    visited: set[str] | None = None,
+    visited: Optional[set[str]] = None,
 ) -> set[str]:
     if visited is None:
         visited = set()

--- a/src/pipx/commands/uninject.py
+++ b/src/pipx/commands/uninject.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from importlib import metadata
 from pathlib import Path
 
 from packaging.utils import canonicalize_name
@@ -18,33 +19,51 @@ from pipx.constants import (
 from pipx.emojis import stars
 from pipx.util import PipxError, pipx_wrap
 from pipx.venv import Venv
+from pipx.venv_inspect import fetch_info_in_venv, get_dist, get_package_dependencies
 
 logger = logging.getLogger(__name__)
 
 
-def get_include_resource_paths(package_name: str, venv: Venv, local_bin_dir: Path, local_man_dir: Path) -> set[Path]:
-    bin_dir_app_paths = _get_package_bin_dir_app_paths(
-        venv, venv.package_metadata[package_name], venv.bin_path, local_bin_dir
-    )
-    man_paths = set()
-    for man_section in MAN_SECTIONS:
-        man_paths |= _get_package_man_paths(
-            venv,
-            venv.package_metadata[package_name],
-            venv.man_path / man_section,
-            local_man_dir / man_section,
+def uninject(
+    venv_dir: Path,
+    dependencies: list[str],
+    *,
+    local_bin_dir: Path,
+    local_man_dir: Path,
+    leave_deps: bool,
+    verbose: bool,
+) -> ExitCode:
+    """Returns pipx exit code"""
+
+    if not venv_dir.exists() or next(venv_dir.iterdir(), None) is None:
+        raise PipxError(f"Virtual environment {venv_dir.name} does not exist.")
+
+    venv = Venv(venv_dir, verbose=verbose)
+
+    if not venv.package_metadata:
+        raise PipxError(
+            f"""
+            Can't uninject from Virtual Environment {venv_dir.name!r}.
+            {venv_dir.name!r} has missing internal pipx metadata.
+            It was likely installed using a pipx version before 0.15.0.0.
+            Please uninstall and install {venv_dir.name!r} manually to fix.
+            """
         )
 
-    need_to_remove = set()
-    for bin_dir_app_path in bin_dir_app_paths:
-        if bin_dir_app_path.name in venv.package_metadata[package_name].apps:
-            need_to_remove.add(bin_dir_app_path)
-    for man_path in man_paths:
-        path = Path(man_path.parent.name) / man_path.name
-        if str(path) in venv.package_metadata[package_name].man_pages:
-            need_to_remove.add(path)
+    all_success = True
+    for dep in dependencies:
+        all_success &= uninject_dep(
+            venv,
+            dep,
+            local_bin_dir=local_bin_dir,
+            local_man_dir=local_man_dir,
+            leave_deps=leave_deps,
+        )
 
-    return need_to_remove
+    if all_success:
+        return EXIT_CODE_OK
+    else:
+        return EXIT_CODE_UNINJECT_ERROR
 
 
 def uninject_dep(
@@ -88,9 +107,9 @@ def uninject_dep(
         logger.info(f"New not required packages: {new_not_required_packages}")
 
         deps_of_uninstalled = new_not_required_packages - orig_not_required_packages
-        if len(deps_of_uninstalled) == 0:
-            pass
-        else:
+        if deps_of_uninstalled:
+            remaining_deps = _get_remaining_dependencies(venv, package_name)
+            deps_of_uninstalled -= remaining_deps
             logger.info(f"Dependencies of uninstalled package: {deps_of_uninstalled}")
 
         for dep_package_name in deps_of_uninstalled:
@@ -113,43 +132,58 @@ def uninject_dep(
     return True
 
 
-def uninject(
-    venv_dir: Path,
-    dependencies: list[str],
-    *,
-    local_bin_dir: Path,
-    local_man_dir: Path,
-    leave_deps: bool,
-    verbose: bool,
-) -> ExitCode:
-    """Returns pipx exit code"""
-
-    if not venv_dir.exists() or next(venv_dir.iterdir(), None) is None:
-        raise PipxError(f"Virtual environment {venv_dir.name} does not exist.")
-
-    venv = Venv(venv_dir, verbose=verbose)
-
-    if not venv.package_metadata:
-        raise PipxError(
-            f"""
-            Can't uninject from Virtual Environment {venv_dir.name!r}.
-            {venv_dir.name!r} has missing internal pipx metadata.
-            It was likely installed using a pipx version before 0.15.0.0.
-            Please uninstall and install {venv_dir.name!r} manually to fix.
-            """
-        )
-
-    all_success = True
-    for dep in dependencies:
-        all_success &= uninject_dep(
+def get_include_resource_paths(package_name: str, venv: Venv, local_bin_dir: Path, local_man_dir: Path) -> set[Path]:
+    bin_dir_app_paths = _get_package_bin_dir_app_paths(
+        venv, venv.package_metadata[package_name], venv.bin_path, local_bin_dir
+    )
+    man_paths = set()
+    for man_section in MAN_SECTIONS:
+        man_paths |= _get_package_man_paths(
             venv,
-            dep,
-            local_bin_dir=local_bin_dir,
-            local_man_dir=local_man_dir,
-            leave_deps=leave_deps,
+            venv.package_metadata[package_name],
+            venv.man_path / man_section,
+            local_man_dir / man_section,
         )
 
-    if all_success:
-        return EXIT_CODE_OK
-    else:
-        return EXIT_CODE_UNINJECT_ERROR
+    need_to_remove = set()
+    for bin_dir_app_path in bin_dir_app_paths:
+        if bin_dir_app_path.name in venv.package_metadata[package_name].apps:
+            need_to_remove.add(bin_dir_app_path)
+    for man_path in man_paths:
+        path = Path(man_path.parent.name) / man_path.name
+        if str(path) in venv.package_metadata[package_name].man_pages:
+            need_to_remove.add(path)
+
+    return need_to_remove
+
+
+def _get_remaining_dependencies(venv: Venv, excluded_package: str) -> set[str]:
+    venv_sys_path, venv_env, _ = fetch_info_in_venv(venv.python_path)
+    distributions = tuple(metadata.distributions(path=venv_sys_path))
+
+    remaining_deps: set[str] = set()
+    remaining_packages = [venv.pipx_metadata.main_package.package] + [
+        name for name in venv.pipx_metadata.injected_packages if name != excluded_package
+    ]
+    for pkg_name in remaining_packages:
+        remaining_deps |= _collect_transitive_deps(pkg_name, distributions, venv_env)
+
+    return remaining_deps
+
+
+def _collect_transitive_deps(
+    package_name: str,
+    distributions: tuple[metadata.Distribution, ...],
+    env: dict[str, str],
+    visited: set[str] | None = None,
+) -> set[str]:
+    if visited is None:
+        visited = set()
+    canonical = canonicalize_name(package_name)
+    if canonical in visited:
+        return visited
+    visited.add(canonical)
+    if dist := get_dist(package_name, distributions):
+        for dep_req in get_package_dependencies(dist, set(), env):
+            _collect_transitive_deps(dep_req.name, distributions, env, visited)
+    return visited

--- a/src/pipx/commands/uninject.py
+++ b/src/pipx/commands/uninject.py
@@ -163,8 +163,10 @@ def _get_remaining_dependencies(venv: Venv, excluded_package: str) -> set[str]:
     distributions = tuple(metadata.distributions(path=venv_sys_path))
 
     remaining_deps: set[str] = set()
-    remaining_packages = [venv.pipx_metadata.main_package.package] + [
-        name for name in venv.pipx_metadata.injected_packages if name != excluded_package
+    remaining_packages: list[str] = [
+        name
+        for name in [venv.pipx_metadata.main_package.package] + list(venv.pipx_metadata.injected_packages)
+        if name is not None and name != excluded_package
     ]
     for pkg_name in remaining_packages:
         remaining_deps |= _collect_transitive_deps(pkg_name, distributions, venv_env)

--- a/tests/test_uninject.py
+++ b/tests/test_uninject.py
@@ -39,3 +39,15 @@ def test_uninject_leave_deps(pipx_temp_env, capsys, caplog):
     captured = capsys.readouterr()
     assert "Uninjected package black from venv pycowsay" in captured.out
     assert "Dependencies of uninstalled package:" not in caplog.text
+
+
+def test_uninject_preserves_shared_deps(pipx_temp_env, capsys):
+    assert not run_pipx_cli(["install", "pycowsay"])
+    assert not run_pipx_cli(["inject", "pycowsay", PKG["black"]["spec"]])
+    assert not run_pipx_cli(["inject", "pycowsay", PKG["pylint"]["spec"]])
+    assert not run_pipx_cli(["uninject", "pycowsay", "black"])
+    capsys.readouterr()
+    assert not run_pipx_cli(["list", "--include-injected"])
+    captured = capsys.readouterr()
+    assert "pylint" in captured.out
+    assert "black" not in captured.out


### PR DESCRIPTION
Running `pipx uninject` without `--leave-deps` can break other packages in the venv by removing dependencies they still need. 🐛 If two injected packages share a transitive dependency (e.g. both `black` and `pylint` depend on `platformdirs`), uninjecting one removes the shared dependency and breaks the other.

The existing orphan detection compares `pip list --not-required` before and after removing the target package. This correctly identifies newly orphaned packages, but has no awareness of pipx's package ownership model. Before removing any orphaned dependency, the fix now computes the full transitive dependency graph of all remaining packages (main + other injected) and protects those from removal. This reuses the existing `get_package_dependencies` machinery from `venv_inspect.py`.

The safety check only runs when there are orphaned deps to remove, so the common case (no shared deps) adds no overhead.

Fixes #1672