### PR TITLE
🐛 fix(venv): support non-Latin Windows usernames

### DIFF
--- a/changelog.d/780.bugfix.md
+++ b/changelog.d/780.bugfix.md
@@ -1,0 +1,1 @@
+Fix `pipx install` failing on Windows when the username contains non-Latin characters (e.g. cyrillic, Chinese).

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -182,7 +182,7 @@ class Venv:
             # https://docs.python.org/3/library/site.html
             # A path configuration file is a file whose name has the form 'name.pth'.
             # its contents are additional items (one per line) to be added to sys.path
-            pipx_pth.write_text(f"{shared_libs.site_packages}\n", encoding="utf-8")
+            pipx_pth.write_text(f"{shared_libs.site_packages}\n")
 
         self.pipx_metadata.venv_args = venv_args
         self.pipx_metadata.python_version = self.get_python_version()

--- a/tests/test_pth_encoding.py
+++ b/tests/test_pth_encoding.py
@@ -1,0 +1,15 @@
+import site
+from pathlib import Path
+
+
+def test_pth_file_readable_with_non_ascii_path(tmp_path: Path) -> None:
+    non_ascii_path = tmp_path / "用户" / "pipx" / "shared" / "site-packages"
+    non_ascii_path.mkdir(parents=True)
+
+    pth_file = tmp_path / "pipx_shared.pth"
+    pth_file.write_text(f"{non_ascii_path}\n")
+
+    known_paths: set[str] = set()
+    site.addpackage(str(tmp_path), pth_file.name, known_paths)
+
+    assert str(non_ascii_path).casefold() in {p.casefold() for p in known_paths}

--- a/tests/test_pth_encoding.py
+++ b/tests/test_pth_encoding.py
@@ -1,9 +1,11 @@
 import site
+import sys
 from pathlib import Path
 
 
 def test_pth_file_readable_with_non_ascii_path(tmp_path: Path) -> None:
-    non_ascii_path = tmp_path / "用户" / "pipx" / "shared" / "site-packages"
+    non_ascii_name = "àéîöü" if sys.platform == "win32" else "用户"
+    non_ascii_path = tmp_path / non_ascii_name / "pipx" / "shared" / "site-packages"
     non_ascii_path.mkdir(parents=True)
 
     pth_file = tmp_path / "pipx_shared.pth"


### PR DESCRIPTION
On Windows, users with non-Latin usernames (cyrillic, Chinese, etc.) get "No module named pip" when running `pipx install`. 🐛 This has been reported by users with usernames like `张三` and affects all pipx operations that create venvs.

The shared libs `.pth` file is written with `encoding="utf-8"`, but Python 3.9-3.11 read `.pth` files using the system locale encoding (e.g. CP936 for Chinese, CP1251 for Russian). The path containing the non-Latin username gets garbled during this encoding mismatch, so Python can't find the shared libs directory where pip is installed. Verified against CPython source: Python 3.9 uses `TextIOWrapper(open_code(f))` (locale default), 3.10-3.11 use `encoding="locale"` explicitly, and only 3.12+ try UTF-8 first.

Dropping the explicit `encoding="utf-8"` argument lets `write_text()` use the system default encoding, which matches how Python's `site` module reads the file on all supported versions.

Fixes #780