### PR TITLE
🐛 fix(install): show version and suggest upgrade

### DIFF
--- a/changelog.d/795.bugfix.md
+++ b/changelog.d/795.bugfix.md
@@ -1,0 +1,1 @@
+Show installed version and suggest `upgrade` when `install` detects an existing installation.

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -76,12 +76,15 @@ def install(
                 print(f"Installing to existing venv {venv.name!r}")
                 pip_args = ["--force-reinstall"] + pip_args
             else:
+                installed_version = venv.pipx_metadata.main_package.package_version
+                version_info = f" ({installed_version})" if installed_version else ""
                 print(
                     pipx_wrap(
                         f"""
-                        {venv.name!r} already seems to be installed. Not modifying
-                        existing installation in '{venv_dir}'. Pass '--force'
-                        to force installation.
+                        {venv.name!r}{version_info} already seems to be installed. Not
+                        modifying existing installation in '{venv_dir}'.
+                        Pass '--force' to force installation, or use
+                        'pipx upgrade {venv.name}' to upgrade.
                         """
                     )
                 )

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -93,8 +93,8 @@ def test_install_multiple_packages_when_some_already_installed(capsys, pipx_temp
 
     run_pipx_cli(["install", "black", "pycowsay", "isort"])
     captured = capsys.readouterr()
-    assert "'black' already seems to be installed" in captured.out
-    assert "'pycowsay' already seems to be installed" in captured.out
+    assert "black" in captured.out and "already seems to be installed" in captured.out
+    assert "pycowsay" in captured.out and "already seems to be installed" in captured.out
     assert "installed package isort" in captured.out
 
 
@@ -129,7 +129,7 @@ def test_force_install(pipx_temp_env, capsys):
     run_pipx_cli(["install", "pycowsay"])
     captured = capsys.readouterr()
     assert "installed package" not in captured.out
-    assert "'pycowsay' already seems to be installed" in captured.out
+    assert "pycowsay" in captured.out and "already seems to be installed" in captured.out
 
     run_pipx_cli(["install", "pycowsay", "--force"])
     captured = capsys.readouterr()
@@ -146,7 +146,9 @@ def test_install_same_package_twice_no_force(pipx_temp_env, capsys):
     assert not run_pipx_cli(["install", "pycowsay"])
     assert not run_pipx_cli(["install", "pycowsay"])
     captured = capsys.readouterr()
-    assert "'pycowsay' already seems to be installed. Not modifying existing installation" in captured.out
+    assert "already seems to be installed" in captured.out
+    assert "pipx upgrade" in captured.out
+    assert "0.0.0.2" in captured.out
 
 
 def test_include_deps(pipx_temp_env, capsys):


### PR DESCRIPTION
Running `pipx install poetry==1.2.0a2` when `poetry 1.1.12` is already installed gives a confusing error: "'poetry' already seems to be installed". Users don't know what version is installed or how to change it. The only suggestion is `--force`, but `pipx upgrade` is usually what they want. 🐛

The message now includes the installed version (e.g. `'poetry' (1.1.12) already seems to be installed`) and suggests both `--force` for reinstallation and `pipx upgrade` for version changes.

Fixes #795