### PR TITLE
🐛 fix(install): ignore PIP_TARGET env var

### DIFF
--- a/changelog.d/735.bugfix.md
+++ b/changelog.d/735.bugfix.md
@@ -1,0 +1,1 @@
+Ignore `PIP_TARGET` environment variable to prevent pip from installing outside the venv.

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -149,8 +149,9 @@ def _fix_subprocess_env(env: dict[str, str]) -> dict[str, str]:
     # Make sure that Python writes output in UTF-8
     env["PYTHONIOENCODING"] = "utf-8"
     env["PYTHONLEGACYWINDOWSSTDIO"] = "utf-8"
-    # Make sure we install package to venv, not userbase dir
+    # Make sure we install packages to venv, not to userbase or a custom target dir
     env["PIP_USER"] = "0"
+    env.pop("PIP_TARGET", None)
     env.setdefault("PIP_KEYRING_PROVIDER", "subprocess")
     return env
 

--- a/tests/test_subprocess_env.py
+++ b/tests/test_subprocess_env.py
@@ -1,0 +1,13 @@
+from pipx.util import _fix_subprocess_env
+
+
+def test_pip_target_removed_from_env() -> None:
+    env = {"PATH": "/usr/bin", "PIP_TARGET": "/some/custom/target"}
+    result = _fix_subprocess_env(env)
+    assert "PIP_TARGET" not in result
+
+
+def test_pip_user_disabled_in_env() -> None:
+    env = {"PATH": "/usr/bin", "PIP_USER": "1"}
+    result = _fix_subprocess_env(env)
+    assert result["PIP_USER"] == "0"


### PR DESCRIPTION
When `PIP_TARGET` is set or `target` is configured in `pip.conf`, pip installs packages to that custom directory instead of the venv's site-packages. 🐛 This causes pipx to fail with "cannot find package metadata" because the installed package ends up outside the venv where pipx expects to find it.

`PIP_USER` was already being neutralized for the same class of problem (#435). This applies the same treatment to `PIP_TARGET` by stripping it from the subprocess environment before invoking pip. Users who need a custom target for other pip usage are unaffected since the variable is only removed for pipx's internal pip calls.

Fixes #735