### PR TITLE
🐛 fix(uninject): remove dependency app symlinks

### DIFF
--- a/changelog.d/1364.bugfix.md
+++ b/changelog.d/1364.bugfix.md
@@ -1,0 +1,1 @@
+Remove dependency app symlinks when uninjecting a package that was injected with `--include-deps`.

--- a/src/pipx/commands/uninject.py
+++ b/src/pipx/commands/uninject.py
@@ -146,13 +146,20 @@ def get_include_resource_paths(package_name: str, venv: Venv, local_bin_dir: Pat
             local_man_dir / man_section,
         )
 
+    pkg_metadata = venv.package_metadata[package_name]
+    all_apps = set(pkg_metadata.apps)
+    all_man_pages = set(pkg_metadata.man_pages)
+    if pkg_metadata.include_dependencies:
+        all_apps.update(pkg_metadata.apps_of_dependencies)
+        all_man_pages.update(pkg_metadata.man_pages_of_dependencies)
+
     need_to_remove = set()
     for bin_dir_app_path in bin_dir_app_paths:
-        if bin_dir_app_path.name in venv.package_metadata[package_name].apps:
+        if bin_dir_app_path.name in all_apps:
             need_to_remove.add(bin_dir_app_path)
     for man_path in man_paths:
         path = Path(man_path.parent.name) / man_path.name
-        if str(path) in venv.package_metadata[package_name].man_pages:
+        if str(path) in all_man_pages:
             need_to_remove.add(path)
 
     return need_to_remove

--- a/tests/test_uninject.py
+++ b/tests/test_uninject.py
@@ -32,6 +32,16 @@ def test_uninject_with_include_apps(pipx_temp_env, capsys, caplog):
     assert "removed file" in caplog.text
 
 
+def test_uninject_removes_dependency_app_symlinks(pipx_temp_env, capsys, caplog):
+    assert not run_pipx_cli(["install", "pycowsay"])
+    assert not run_pipx_cli(["inject", "pycowsay", PKG["pylint"]["spec"], "--include-deps", "--include-apps"])
+    captured = capsys.readouterr()
+    assert "isort" in captured.out
+    assert not run_pipx_cli(["uninject", "pycowsay", "pylint", "--verbose"])
+    assert "removed file" in caplog.text
+    assert "isort" in caplog.text
+
+
 def test_uninject_leave_deps(pipx_temp_env, capsys, caplog):
     assert not run_pipx_cli(["install", "pycowsay"])
     assert not run_pipx_cli(["inject", "pycowsay", PKG["black"]["spec"]])


### PR DESCRIPTION
When a package is injected with `--include-deps --include-apps`, both its own apps and its dependencies' apps get symlinked into `~/.local/bin`. Uninjecting that package removes the direct app symlinks but leaves the dependency app symlinks behind as broken links. 🐛 For example, injecting `pylint` with `--include-deps` exposes `isort` in `~/.local/bin`, but `pipx uninject pylint` leaves a broken `isort` symlink.

The resource path collection already gathered both direct and dependency app paths via `_get_package_bin_dir_app_paths`, but the subsequent filter only checked the direct `apps` list, discarding dependency apps. The filter now also includes `apps_of_dependencies` and `man_pages_of_dependencies` when the package was injected with `include_dependencies`, matching how `uninstall` handles this.

Fixes #1364