### PR TITLE
🐛 fix(cli): error on -v/-q before subcommand

### DIFF
--- a/changelog.d/1282.bugfix.md
+++ b/changelog.d/1282.bugfix.md
@@ -1,0 +1,1 @@
+`--verbose` and `--quiet` flags before the subcommand are no longer silently ignored.

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -1005,28 +1005,6 @@ def get_command_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Ar
     )
     parser.man_short_description = PIPX_DESCRIPTION.splitlines()[1]  # type: ignore[attr-defined]
 
-    parser.add_argument(
-        "--quiet",
-        "-q",
-        action="count",
-        default=0,
-        help=(
-            "Give less output. May be used multiple times corresponding to the"
-            " ERROR and CRITICAL logging levels. The count maxes out at 2."
-        ),
-    )
-
-    parser.add_argument(
-        "--verbose",
-        "-v",
-        action="count",
-        default=0,
-        help=(
-            "Give more output. May be used multiple times corresponding to the"
-            " INFO, DEBUG and NOTSET logging levels. The count maxes out at 3."
-        ),
-    )
-
     subparsers = parser.add_subparsers(dest="command", description="Get help for commands with pipx COMMAND --help")
 
     subparsers_with_subcommands = {}
@@ -1152,10 +1130,10 @@ def setup(args: argparse.Namespace) -> None:
         print_version()
         sys.exit(0)
 
-    if not constants.WINDOWS and args.is_global:
+    if not constants.WINDOWS and getattr(args, "is_global", False):
         paths.ctx.make_global()
 
-    verbose = args.verbose - args.quiet
+    verbose = getattr(args, "verbose", 0) - getattr(args, "quiet", 0)
 
     setup_logging(verbose)
 


### PR DESCRIPTION
Running `pipx -v install foo` silently discards the `-v` flag and produces no verbose output. 🐛 This happens because both the top-level parser and each subcommand parser define `--verbose`/`--quiet`. The top-level parser consumes the flags before the subcommand parser gets a chance to see them.

The fix removes `--verbose` and `--quiet` from the top-level parser. Every subcommand already inherits these flags via `shared_parser`, so `pipx install -v foo` continues to work exactly as before. `pipx -v install foo` now gives a clear argument error instead of silently doing nothing.

This is technically a breaking change for users who put `-v`/`-q` before the subcommand, but since those flags were silently ignored in that position, no one was relying on the behavior.

Fixes #1282