### PR TITLE
🐛 fix(shared_libs): remove setuptools after creation

### DIFF
--- a/changelog.d/1539.bugfix.md
+++ b/changelog.d/1539.bugfix.md
@@ -1,0 +1,1 @@
+Remove `setuptools` from shared libs to prevent version conflicts when app venvs use a different Python.

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -109,6 +109,15 @@ class _SharedLibs:
             pip_args.append("--force-reinstall")
             self.upgrade(pip_args=pip_args, verbose=verbose, raises=True)
 
+            # Remove setuptools from shared libs to prevent it from leaking into
+            # app venvs via the .pth file. On Python < 3.12, venv bundles setuptools
+            # via ensurepip, but a 3.10 setuptools breaks when imported under 3.12+
+            # because distutils was removed from the stdlib.
+            run_subprocess(
+                [self.python_path, "-m", "pip", "--no-input", "uninstall", "-y", "setuptools"],
+                capture_stderr=False,
+            )
+
     @property
     def is_valid(self) -> bool:
         if self.python_path.is_file():

--- a/tests/test_shared_libs.py
+++ b/tests/test_shared_libs.py
@@ -1,4 +1,6 @@
+import json
 import os
+import subprocess
 import time
 from pathlib import Path
 from unittest.mock import patch
@@ -65,6 +67,19 @@ def test_venv_python_is_valid_existing_interpreter(tmp_path: Path) -> None:
     pyvenv_cfg.write_text(f"home = {original_python_dir}\nversion = 3.12.0\n")
 
     assert shared_libs._venv_python_is_valid(python_exe) is True
+
+
+def test_shared_libs_excludes_setuptools(pipx_ultra_temp_env: None) -> None:
+    shared_libs.shared_libs.create(verbose=True, pip_args=[])
+    result = subprocess.run(
+        [str(shared_libs.shared_libs.python_path), "-m", "pip", "list", "--format=json"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    installed = {pkg["name"].lower() for pkg in json.loads(result.stdout)}
+    assert "pip" in installed
+    assert "setuptools" not in installed
 
 
 def test_venv_python_is_valid_non_windows() -> None:


### PR DESCRIPTION
Running `pipx run --python 3.12 --spec setuptools python -c "import setuptools"` fails with `ModuleNotFoundError: No module named 'distutils'` when pipx itself runs on Python 3.10. 🐛 The shared libs `.pth` file exposes the 3.10 `setuptools` (which expects `distutils` from stdlib) to the 3.12 app venv (where `distutils` was removed). This affects any app that depends on `setuptools` when the pipx Python differs from the app Python.

On Python < 3.12, `python -m venv` bundles `setuptools` via `ensurepip`. Since pipx only needs `pip` in the shared libs, uninstalling `setuptools` after creation prevents it from leaking into app venvs through the `.pth` file. Apps that need `setuptools` will install their own copy in their isolated venv.

Existing shared libs are unaffected until recreated (via `pipx upgrade-shared` or natural refresh). Users hitting this issue can run `pipx upgrade-shared` to get a clean shared libs without `setuptools`.

Fixes #1539