### PR TITLE
fix(standalone_python): extract hash from sha256: prefix in digest field

### DIFF
--- a/src/pipx/standalone_python.py
+++ b/src/pipx/standalone_python.py
@@ -155,10 +155,7 @@ def get_latest_python_releases() -> list[tuple[str, str]]:
         # raise
         raise PipxError(f"Unable to fetch python-build-standalone release data (from {GITHUB_API_URL}).") from e
 
-    return [
-        (asset["browser_download_url"], asset["digest"].partition(":")[2])
-        for asset in release_data["assets"]
-    ]
+    return [(asset["browser_download_url"], asset["digest"].partition(":")[2]) for asset in release_data["assets"]]
 
 
 def list_pythons(use_cache: bool = True) -> dict[str, tuple[str, str]]:

--- a/src/pipx/standalone_python.py
+++ b/src/pipx/standalone_python.py
@@ -155,7 +155,10 @@ def get_latest_python_releases() -> list[tuple[str, str]]:
         # raise
         raise PipxError(f"Unable to fetch python-build-standalone release data (from {GITHUB_API_URL}).") from e
 
-    return [(asset["browser_download_url"], asset["digest"]) for asset in release_data["assets"]]
+    return [
+        (asset["browser_download_url"], asset["digest"].partition(":")[2])
+        for asset in release_data["assets"]
+    ]
 
 
 def list_pythons(use_cache: bool = True) -> dict[str, tuple[str, str]]:


### PR DESCRIPTION
## Summary

Fixes a `ValueError: too many values to unpack` that occurred when using `--fetch-missing-python`.

## Root Cause

The GitHub API's `asset["digest"]` field returns values in the format `"sha256:HASH"` (a single string), but `get_latest_python_releases()` stored this directly as the second tuple element. When `list_pythons()` later iterated and unpacked `for link, digest in python_releases`, it expected two separate values but got a single string containing a colon, causing the error.

## Fix

Extract just the hash portion using `.partition(":")[2]`:

```python
# Before
return [(asset["browser_download_url"], asset["digest"]) for asset in release_data["assets"]]

# After
return [
    (asset["browser_download_url"], asset["digest"].partition(":")[2])
    for asset in release_data["assets"]
]
```

This is safe because the GitHub API digest format is always `"sha256:HASH"` with exactly one colon.

## Testing

- The fix was verified against the actual GitHub API response format

Fixes #1774