### PR TITLE
package_is_path: do not check if path exists

### DIFF
--- a/changelog.d/1778.bugfix.md
+++ b/changelog.d/1778.bugfix.md
@@ -1,0 +1,1 @@
+Do not check if the package name exists as path.

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -214,7 +214,7 @@ def package_is_url(package: str, raise_error: bool = True) -> bool:
 
 
 def package_is_path(package: str):
-    if os.path.sep in package or Path(package).exists():
+    if os.path.sep in package:
         raise PipxError(
             pipx_wrap(
                 f"""


### PR DESCRIPTION
Having separators is the real indicator that the user is doing something wrong. We shouldn't unnecessarily error out in the off chance the user has a directory that has the same name as a package in the current working directory.

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://pipx.pypa.io/latest/contributing/))

- [x] ran the linter to address style issues (`pre-commit run --all-files`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [x] added news fragment in `changelog.d/` folder
- [ ] updated/extended the documentation

Not entirely sure if this needs a test or documentation update considering it's so small and there aren't many tests for specific functions outlined in the `main.py`.

Fixes: #1778