### PR TITLE
ci: bump setup-uv to maintained tag scheme

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: 🚀 Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
       - name: 🐍 Setup Python ${{ matrix.py }}
         uses: actions/setup-python@v6
         with:
@@ -59,7 +59,7 @@ jobs:
       - name: 📥 Checkout code
         uses: actions/checkout@v6
       - name: 🚀 Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
       - name: 📦 Install tox
         run: uv tool install --python-preference only-managed --python 3.13 "tox>=4.45" --with tox-uv
       - name: 📖 Build man page


### PR DESCRIPTION
The old vX tags have been dropped to (force) (usually) better security practices. Dependabot will not update, however, leaving this v7 tag forever. Manually updating now.

See https://github.com/astral-sh/setup-uv/issues/830

Committed via https://github.com/asottile/all-repos