### PR TITLE
ci: group dependabot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,6 +1,12 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
+  - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
Sometimes action updates are grouped, like when upload/download artifact get bumped. This also reduces the number of standalone PRs a bit, making it more like pre-commit.
