### PR TITLE
chore: add towncrier default cats

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,5 +3,5 @@
 - [ ] ran the linter to address style issues (`pre-commit run --all-files`)
 - [ ] wrote descriptive pull request text
 - [ ] ensured there are test(s) validating the fix
-- [ ] added news fragment in `changelog.d/` folder
+- [ ] added news fragment in `changelog.d/` folder (choose a type: `feature`, `bugfix`, `doc`, `removal`, or `misc`)
 - [ ] updated/extended the documentation


### PR DESCRIPTION
This makes it a little easier for contributors. Got the idea from `pypa/build`.


:robot: Assisted-by: OpenCode:Kimi-K2.5

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://pipx.pypa.io/latest/contributing/))

- [ ] ran the linter to address style issues (`pre-commit run --all-files`)
- [ ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `changelog.d/` folder
- [ ] updated/extended the documentation
