### PR TITLE
First attempt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,97 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What is pipx
+
+pipx installs Python CLI applications into isolated virtual environments and exposes their entry points on PATH. Each
+app gets its own venv under `PIPX_HOME/venvs/`, preventing dependency conflicts. `pipx run` additionally supports
+ephemeral venvs (including PEP 723 inline script metadata).
+
+## Commands
+
+**Primary dev tool is `tox` (uses `uv` internally).**
+
+```bash
+# Run tests for a specific Python version
+tox run -e 3.13
+
+# Run linting (ruff, mypy, pre-commit hooks)
+tox run -e lint
+
+# Build docs
+tox run -e docs
+
+# Create an editable dev environment
+tox run -e dev
+
+# Or install directly
+python -m pip install -e .
+```
+
+**Running tests directly:**
+
+```bash
+pytest tests/                          # all tests
+pytest tests/test_install.py -v        # single file
+pytest tests/test_install.py::test_foo # single test
+pytest --all-packages                  # exhaustive (slow, normally skipped)
+```
+
+**Changelog:** Every PR needs a fragment in `changelog.d/{issue_number}.{type}.md` (types: `feature`, `bugfix`, `doc`,
+`removal`, `misc`). Built by `towncrier`.
+
+## Architecture
+
+```
+src/pipx/
+├── main.py              # CLI parser (argparse + argcomplete), entry point pipx.main:cli
+├── venv.py              # Venv (single venv wrapper) + VenvContainer (manages PIPX_HOME/venvs/)
+├── paths.py             # Resolves PIPX_HOME, PIPX_BIN_DIR, etc. via paths.ctx singleton
+├── pipx_metadata_file.py # JSON metadata per venv: PackageInfo, PipxMetadata (v0.4)
+├── venv_inspect.py      # Reads venv metadata, extracts entry points from distributions
+├── shared_libs.py       # Shared pip venv to deduplicate common dependencies
+├── interpreter.py       # Python interpreter resolution (PIPX_DEFAULT_PYTHON, system)
+├── standalone_python.py # Downloads python-build-standalone builds; cached in PIPX_INTERPRETER_FOLDER
+├── package_specifier.py # PEP 508 parsing and validation
+├── util.py              # PipxError, run_subprocess wrappers, path helpers
+├── constants.py         # Platform flags (WINDOWS/MACOS/LINUX), ExitCode values
+└── commands/            # One module per CLI subcommand
+    ├── install.py       # pipx install
+    ├── run.py           # pipx run (ephemeral venv, PEP 723 support)
+    ├── upgrade.py       # pipx upgrade / upgrade-all
+    ├── inject.py        # pipx inject (add dep to existing venv)
+    ├── uninject.py      # pipx uninject
+    ├── uninstall.py     # pipx uninstall / uninstall-all
+    ├── reinstall.py     # pipx reinstall (different Python)
+    ├── list_packages.py # pipx list
+    ├── pin.py           # pipx pin / unpin
+    ├── interpreter.py   # pipx interpreter (manage standalone Pythons)
+    ├── ensure_path.py   # pipx ensurepath
+    ├── environment.py   # pipx environment
+    ├── run_pip.py       # pipx runpip
+    └── common.py        # Shared install/upgrade utilities
+```
+
+**Key design patterns:**
+
+- All package management goes through the `Venv` class in `venv.py`.
+- Each venv stores a `pipx_metadata.json` (see `pipx_metadata_file.py`) enabling reproducible upgrades and reinstalls.
+- `paths.ctx` is a singleton resolving all configurable paths; tests override it via the `pipx_temp_env` fixture.
+- New CLI subcommands: add a module under `commands/`, wire it in `main.py`.
+
+## Tests
+
+Tests live in `tests/`. Key infrastructure:
+
+- **`conftest.py`**: `pipx_temp_env` fixture isolates each test with temporary `PIPX_HOME`/`PIPX_BIN_DIR`;
+    `pipx_local_pypiserver` serves packages from a local cache to avoid network calls.
+- **`helpers.py`**: `run_pipx_cli()` invokes the CLI in-process; `mock_legacy_venv()` tests backward-compat metadata
+    migrations.
+- **`package_info.py`**: Database of test package specs, apps, and dependencies.
+- Tests marked `@pytest.mark.all_packages` are excluded from normal runs (use `--all-packages` flag).
+
+## Linting
+
+Line length is 121. Ruff handles formatting and a broad set of lint rules (see `pyproject.toml [tool.ruff]`). mypy runs
+in strict mode. Run `tox run -e lint` or `pre-commit run --all-files` before pushing. \]

--- a/changelog.d/1523.bugfix.md
+++ b/changelog.d/1523.bugfix.md
@@ -1,0 +1,1 @@
+Increase flexibility of `PIPX_DEFAULT_PYTHON`

--- a/src/pipx/interpreter.py
+++ b/src/pipx/interpreter.py
@@ -170,10 +170,10 @@ def _get_sys_executable() -> str:
 
 
 def _get_absolute_python_interpreter(env_python: str) -> str:
-    which_python = shutil.which(env_python)
-    if not which_python:
-        raise PipxError(f"Default python interpreter '{env_python}' is invalid.")
-    return which_python
+    try:
+        return find_python_interpreter(env_python)
+    except InterpreterResolutionError as err:
+        raise PipxError(f"Default python interpreter '{env_python}' is invalid.") from err
 
 
 env_default_python = os.environ.get("PIPX_DEFAULT_PYTHON")
@@ -181,4 +181,8 @@ env_default_python = os.environ.get("PIPX_DEFAULT_PYTHON")
 if not env_default_python:
     DEFAULT_PYTHON = _get_sys_executable()
 else:
-    DEFAULT_PYTHON = _get_absolute_python_interpreter(env_default_python)
+    try:
+        DEFAULT_PYTHON = find_python_interpreter(env_default_python)
+    except InterpreterResolutionError:
+        # Store the raw spec; find_python_interpreter will surface a proper error at command time
+        DEFAULT_PYTHON = env_default_python

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -11,8 +11,9 @@ from packaging.specifiers import SpecifierSet
 from pipx import paths
 from pipx.animate import animate
 from pipx.constants import WINDOWS
-from pipx.interpreter import DEFAULT_PYTHON
+from pipx.interpreter import DEFAULT_PYTHON, InterpreterResolutionError, find_python_interpreter
 from pipx.util import (
+    PipxError,
     get_site_packages,
     get_venv_paths,
     run_subprocess,
@@ -97,10 +98,12 @@ class _SharedLibs:
 
     def create(self, pip_args: list[str], verbose: bool = False) -> None:
         if not self.is_valid:
+            try:
+                python = find_python_interpreter(DEFAULT_PYTHON)
+            except InterpreterResolutionError as e:
+                raise PipxError(str(e)) from e
             with animate("creating shared libraries", not verbose):
-                create_process = run_subprocess(
-                    [DEFAULT_PYTHON, "-m", "venv", "--clear", self.root], run_dir=str(self.root)
-                )
+                create_process = run_subprocess([python, "-m", "venv", "--clear", self.root], run_dir=str(self.root))
             subprocess_post_check(create_process)
 
             # ignore installed packages to ensure no unexpected patches from the OS vendor

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -1,3 +1,4 @@
+import importlib
 import shutil
 import subprocess
 import sys
@@ -151,6 +152,29 @@ def test_bad_env_python(monkeypatch):
 def test_good_env_python(monkeypatch, capsys):
     good_exec = _get_absolute_python_interpreter(sys.executable)
     assert good_exec == sys.executable
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="version-style lookup uses unix command naming")
+def test_env_python_by_version(monkeypatch):
+    major = sys.version_info.major
+    minor = sys.version_info.minor
+    result = _get_absolute_python_interpreter(f"{major}.{minor}")
+    assert result is not None
+    assert str(major) in result
+
+
+def test_default_python_env_var_version_not_found(monkeypatch):
+    """PIPX_DEFAULT_PYTHON with a version not on PATH stores raw spec rather than crashing at import."""
+    monkeypatch.setenv("PIPX_DEFAULT_PYTHON", "1.1")
+    reloaded = importlib.reload(pipx.interpreter)
+    assert reloaded.DEFAULT_PYTHON == "1.1"
+
+
+def test_default_python_env_var_full_path(monkeypatch):
+    """PIPX_DEFAULT_PYTHON with a full path resolves correctly."""
+    monkeypatch.setenv("PIPX_DEFAULT_PYTHON", sys.executable)
+    reloaded = importlib.reload(pipx.interpreter)
+    assert reloaded.DEFAULT_PYTHON == sys.executable
 
 
 def test_find_python_interpreter_by_path(monkeypatch):


### PR DESCRIPTION
#  Summary
                                                                                                            
  - `PIPX_DEFAULT_PYTHON` previously only accepted a full path or a PATH-resolvable name; version strings like
   3.12 were rejected at import time with a cryptic error                                                   
  - _get_absolute_python_interpreter now delegates to find_python_interpreter (which handles version-style
  lookup via pythonX.Y naming convention) instead of shutil.which                                           
  - When resolution fails at module import time, the raw spec is stored and resolution is deferred to
  command execution, so pipx doesn't crash on startup when a standalone Python hasn't been downloaded yet   
  - shared_libs.create now re-resolves DEFAULT_PYTHON at call time, catching any deferred resolution errors
  with a clean PipxError                                                                                    
                  
  Test plan                                                                                                 
                  
  - test_env_python_by_version — verifies X.Y version strings resolve correctly on Unix                     
  - test_default_python_env_var_version_not_found — verifies an unavailable version defers gracefully
  instead of crashing at import                                                                             
  - test_default_python_env_var_full_path — verifies a full path still resolves correctly
  - Run pytest tests/test_interpreter.py -v locally to confirm all three new tests pass 