### PR TITLE
fix(standalone_python): extract hash from sha256: prefix in digest field

### DIFF
--- a/src/pipx/standalone_python.py
+++ b/src/pipx/standalone_python.py
@@ -155,10 +155,7 @@ def get_latest_python_releases() -> list[tuple[str, str]]:
         # raise
         raise PipxError(f"Unable to fetch python-build-standalone release data (from {GITHUB_API_URL}).") from e
 
-    return [
-        (asset["browser_download_url"], asset["digest"].partition(":")[2])
-        for asset in release_data["assets"]
-    ]
+    return [(asset["browser_download_url"], asset["digest"].partition(":")[2]) for asset in release_data["assets"]]
 
 
 def list_pythons(use_cache: bool = True) -> dict[str, tuple[str, str]]:

--- a/src/pipx/standalone_python.py
+++ b/src/pipx/standalone_python.py
@@ -155,7 +155,10 @@ def get_latest_python_releases() -> list[tuple[str, str]]:
         # raise
         raise PipxError(f"Unable to fetch python-build-standalone release data (from {GITHUB_API_URL}).") from e
 
-    return [(asset["browser_download_url"], asset["digest"]) for asset in release_data["assets"]]
+    return [
+        (asset["browser_download_url"], asset["digest"].partition(":")[2])
+        for asset in release_data["assets"]
+    ]
 
 
 def list_pythons(use_cache: bool = True) -> dict[str, tuple[str, str]]:

--- a/tests/test_standalone_interpreter.py
+++ b/tests/test_standalone_interpreter.py
@@ -137,3 +137,39 @@ def test_upgrade_standalone_interpreter_nothing_to_upgrade(pipx_temp_env, capsys
     assert not run_pipx_cli(["interpreter", "upgrade"])
     captured = capsys.readouterr()
     assert "Nothing to upgrade" in captured.out
+
+
+def test_get_latest_python_releases_extracts_hash_only(monkeypatch):
+    """Test that get_latest_python_releases extracts just the hash from sha256:prefix format."""
+    import urllib.request
+    from unittest.mock import Mock
+
+    mock_response = Mock()
+    mock_response.__enter__ = Mock(return_value=mock_response)
+    mock_response.__exit__ = Mock(return_value=False)
+    mock_response.read.return_value = json.dumps({
+        "assets": [
+            {
+                "browser_download_url": "https://example.com/cpython-3.12.0-linux-x86_64-gnu.tar.zst",
+                "digest": "sha256:a1b2c3d4e5f6abc1234567890abcdef1234567890abcdef1234567890abcdef1234"
+            },
+            {
+                "browser_download_url": "https://example.com/cpython-3.11.0-linux-x86_64-gnu.tar.zst",
+                "digest": "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+            }
+        ]
+    }).encode()
+
+    def mock_urlopen(url):
+        return mock_response
+
+    monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+    releases = standalone_python.get_latest_python_releases()
+
+    assert len(releases) == 2
+    # Verify that the sha256: prefix is stripped
+    assert releases[0][1] == "a1b2c3d4e5f6abc1234567890abcdef1234567890abcdef1234567890abcdef1234"
+    assert releases[1][1] == "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+    # Verify URLs are preserved
+    assert releases[0][0] == "https://example.com/cpython-3.12.0-linux-x86_64-gnu.tar.zst"

--- a/tests/test_standalone_interpreter.py
+++ b/tests/test_standalone_interpreter.py
@@ -147,18 +147,20 @@ def test_get_latest_python_releases_extracts_hash_only(monkeypatch):
     mock_response = Mock()
     mock_response.__enter__ = Mock(return_value=mock_response)
     mock_response.__exit__ = Mock(return_value=False)
-    mock_response.read.return_value = json.dumps({
-        "assets": [
-            {
-                "browser_download_url": "https://example.com/cpython-3.12.0-linux-x86_64-gnu.tar.zst",
-                "digest": "sha256:a1b2c3d4e5f6abc1234567890abcdef1234567890abcdef1234567890abcdef1234"
-            },
-            {
-                "browser_download_url": "https://example.com/cpython-3.11.0-linux-x86_64-gnu.tar.zst",
-                "digest": "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
-            }
-        ]
-    }).encode()
+    mock_response.read.return_value = json.dumps(
+        {
+            "assets": [
+                {
+                    "browser_download_url": "https://example.com/cpython-3.12.0-linux-x86_64-gnu.tar.zst",
+                    "digest": "sha256:a1b2c3d4e5f6abc1234567890abcdef1234567890abcdef1234567890abcdef1234",
+                },
+                {
+                    "browser_download_url": "https://example.com/cpython-3.11.0-linux-x86_64-gnu.tar.zst",
+                    "digest": "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+                },
+            ]
+        }
+    ).encode()
 
     def mock_urlopen(url):
         return mock_response


### PR DESCRIPTION
## Summary

Fixes a `ValueError: too many values to unpack` that occurred when using `--fetch-missing-python`.

## Root Cause

The GitHub API's `asset["digest"]` field returns values in the format `"sha256:HASH"` (a single string), but `get_latest_python_releases()` stored this directly as the second tuple element. When `list_pythons()` later iterated and unpacked `for link, digest in python_releases`, it expected two separate values but got a single string containing a colon, causing the error.

## Fix

Extract just the hash portion using `.partition(":")[2]`:

```python
# Before
return [(asset["browser_download_url"], asset["digest"]) for asset in release_data["assets"]]

# After
return [
    (asset["browser_download_url"], asset["digest"].partition(":")[2])
    for asset in release_data["assets"]
]
```

This is safe because the GitHub API digest format is always `"sha256:HASH"` with exactly one colon.

## Testing

Added `test_get_latest_python_releases_extracts_hash_only` to verify that digests with `sha256:` prefix are correctly stripped to just the hash value.

Fixes #1774