### PR TITLE
🐛 fix(interpreter): resolve PIPX_DEFAULT_PYTHON like --python

### DIFF
--- a/src/pipx/interpreter.py
+++ b/src/pipx/interpreter.py
@@ -47,6 +47,12 @@ class InterpreterResolutionError(PipxError):
                 )
         if source == "the python-build-standalone project":
             message += "listed in https://github.com/astral-sh/python-build-standalone/releases/latest."
+        if source == "PIPX_DEFAULT_PYTHON":
+            message += (
+                "on your PATH or the file path is valid. "
+                "Try setting it to an executable name (e.g. python3.10) "
+                "or a full path (e.g. /usr/bin/python3.10)."
+            )
         super().__init__(message, wrap_message)
 
 
@@ -169,11 +175,14 @@ def _get_sys_executable() -> str:
         return str(Path(sys.executable).resolve())
 
 
-def _get_absolute_python_interpreter(env_python: str) -> str:
-    which_python = shutil.which(env_python)
-    if not which_python:
-        raise PipxError(f"Default python interpreter '{env_python}' is invalid.")
-    return which_python
+def _resolve_python(python: str) -> str:
+    if (path := Path(python)).is_file():
+        return str(path.resolve())
+    if found := shutil.which(python):
+        return found
+    if not WINDOWS and (found := find_unix_command_python(python)):
+        return found
+    raise InterpreterResolutionError(source="PIPX_DEFAULT_PYTHON", version=python)
 
 
 env_default_python = os.environ.get("PIPX_DEFAULT_PYTHON")
@@ -181,4 +190,4 @@ env_default_python = os.environ.get("PIPX_DEFAULT_PYTHON")
 if not env_default_python:
     DEFAULT_PYTHON = _get_sys_executable()
 else:
-    DEFAULT_PYTHON = _get_absolute_python_interpreter(env_default_python)
+    DEFAULT_PYTHON = _resolve_python(env_default_python)

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -149,6 +149,7 @@ def test_resolve_python_absolute_path() -> None:
     assert Path(result).resolve() == Path(sys.executable).resolve()
 
 
+@pytest.mark.skipif(WINDOWS, reason="pythonX.Y is not typically on PATH on Windows")
 def test_resolve_python_executable_name() -> None:
     major = sys.version_info.major
     minor = sys.version_info.minor

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -149,11 +149,14 @@ def test_resolve_python_absolute_path() -> None:
     assert Path(result).resolve() == Path(sys.executable).resolve()
 
 
-@pytest.mark.skipif(WINDOWS, reason="pythonX.Y is not typically on PATH on Windows")
 def test_resolve_python_executable_name() -> None:
-    major = sys.version_info.major
-    minor = sys.version_info.minor
-    name = f"python{major}.{minor}"
+    candidates = [
+        f"python{sys.version_info.major}.{sys.version_info.minor}",
+        f"python{sys.version_info.major}",
+        "python",
+    ]
+    name = next((c for c in candidates if shutil.which(c)), None)
+    assert name is not None, "no python executable on PATH"
     result = _resolve_python(name)
     assert Path(result).is_absolute()
     assert Path(result).is_file()

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -1,6 +1,7 @@
 import shutil
 import subprocess
 import sys
+from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
@@ -12,7 +13,7 @@ from pipx.constants import WINDOWS
 from pipx.interpreter import (
     InterpreterResolutionError,
     _find_default_windows_python,
-    _get_absolute_python_interpreter,
+    _resolve_python,
     find_python_interpreter,
 )
 from pipx.util import PipxError
@@ -143,14 +144,44 @@ def test_windows_python_no_venv_store_python(monkeypatch):
     assert _find_default_windows_python() == "WindowsApps"
 
 
-def test_bad_env_python(monkeypatch):
-    with pytest.raises(PipxError):
-        _get_absolute_python_interpreter("bad_python")
+def test_resolve_python_absolute_path() -> None:
+    result = _resolve_python(sys.executable)
+    assert Path(result).resolve() == Path(sys.executable).resolve()
 
 
-def test_good_env_python(monkeypatch, capsys):
-    good_exec = _get_absolute_python_interpreter(sys.executable)
-    assert good_exec == sys.executable
+def test_resolve_python_executable_name() -> None:
+    major = sys.version_info.major
+    minor = sys.version_info.minor
+    name = f"python{major}.{minor}"
+    result = _resolve_python(name)
+    assert Path(result).is_absolute()
+    assert Path(result).is_file()
+
+
+@pytest.mark.skipif(WINDOWS, reason="Unix command resolution")
+def test_resolve_python_bare_version() -> None:
+    major = sys.version_info.major
+    minor = sys.version_info.minor
+    result = _resolve_python(f"{major}.{minor}")
+    assert Path(result).is_absolute()
+    assert Path(result).is_file()
+
+
+def test_resolve_python_relative_path_resolves_to_absolute(tmp_path: Path) -> None:
+    fake_python = tmp_path / "mypython"
+    fake_python.touch(mode=0o755)
+    result = _resolve_python(str(fake_python))
+    assert Path(result).is_absolute()
+
+
+def test_resolve_python_invalid_raises() -> None:
+    with pytest.raises(InterpreterResolutionError, match="PIPX_DEFAULT_PYTHON"):
+        _resolve_python("no_such_python_99.99")
+
+
+def test_resolve_python_invalid_version_raises() -> None:
+    with pytest.raises(InterpreterResolutionError, match="PIPX_DEFAULT_PYTHON"):
+        _resolve_python("99.99")
 
 
 def test_find_python_interpreter_by_path(monkeypatch):


### PR DESCRIPTION
`PIPX_DEFAULT_PYTHON=3.10` crashes at import time with a `PipxError` because the env var resolution only calls `shutil.which()`, which can't handle bare version strings. Meanwhile `--python 3.10` works fine through `find_python_interpreter()`, which tries multiple resolution strategies. This inconsistency was reported in #1523.

The fix replaces `_get_absolute_python_interpreter` with a lightweight `_resolve_python` that tries file path lookup, `shutil.which`, and unix command resolution (`python3.X`) — the same strategies `find_python_interpreter` uses for the common cases. It deliberately excludes py launcher (subprocess at import time) and standalone downloads (network at import time) to keep the module-level cost low. On failure it raises `InterpreterResolutionError` with `source="PIPX_DEFAULT_PYTHON"` so the error message names the env var and suggests valid formats.

File paths are now resolved to absolute via `Path.resolve()`, so relative paths in `PIPX_DEFAULT_PYTHON` also work correctly.

## Resolution flow

```mermaid
flowchart TB
    subgraph Before["Before: _get_absolute_python_interpreter"]
        B1[PIPX_DEFAULT_PYTHON value] --> B2{shutil.which?}
        B2 -->|hit| B3[return path]
        B2 -->|miss| B4[raise PipxError<br/>'...is invalid.']
    end

    subgraph After["After: _resolve_python"]
        A1[PIPX_DEFAULT_PYTHON value] --> A2{Path.is_file?}
        A2 -->|yes| A3[return path.resolve<br/>absolute]
        A2 -->|no| A4{shutil.which?}
        A4 -->|hit| A5[return which result]
        A4 -->|miss| A6{not WINDOWS?}
        A6 -->|yes| A7{find_unix_command_python<br/>e.g. '3.10' to 'python3.10'}
        A7 -->|hit| A8[return path]
        A7 -->|miss| A9[raise InterpreterResolutionError<br/>source=PIPX_DEFAULT_PYTHON]
        A6 -->|no| A9
    end

    style B4 fill:#fdd
    style A9 fill:#fdd
    style A3 fill:#dfd
    style A5 fill:#dfd
    style A8 fill:#dfd
```

## Accepted inputs after the change

- Full path: `/usr/bin/python3.10`
- Relative path (resolved to absolute)
- Executable name: `python3.10`
- Bare version: `3.10` (Unix only — Windows py-launcher resolution is not attempted at import time)

Fixes #1523
