### PR TITLE
fix(#1575): Prevent CWD from being added to sys.path during subprocess calls

### DIFF
--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -177,8 +177,13 @@ def run_subprocess(
     # windows cannot take Path objects, only strings
     cmd_str_list = [str(c) for c in cmd]
 
-    # TODO: Switch to using `-P` / PYTHONSAFEPATH instead of running in
-    # separate directory in Python 3.11
+    # Set PYTHONSAFEPATH to prevent adding CWD to sys.path in subprocess Python commands
+    # This prevents local files from shadowing standard library modules (security issue #1575)
+    # Supported in Python 3.11+; for earlier versions, the environment variable is ignored
+    # but those versions are less commonly used and the risk is lower
+    if len(cmd_str_list) > 0 and "python" in Path(cmd_str_list[0]).name.lower():
+        env.setdefault("PYTHONSAFEPATH", "1")
+
     completed_process = subprocess.run(
         cmd_str_list,
         env=env,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -23,3 +23,10 @@ def test_subprocess_keyring_provider(monkeypatch: pytest.MonkeyPatch, env_value:
     result = run_subprocess([sys.executable, "-c", "import os; print(os.environ['PIP_KEYRING_PROVIDER'])"])
 
     assert result.stdout.strip() == expected
+
+
+def test_subprocess_pythonsafepath_set_for_python_commands() -> None:
+    """Test that PYTHONSAFEPATH is set for Python subprocess calls to prevent CWD shadowing (issue #1575)."""
+    result = run_subprocess([sys.executable, "-c", "import os, sys; sys.stdout.write(os.environ.get('PYTHONSAFEPATH', ''))"])
+
+    assert result.stdout == "1"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -27,6 +27,8 @@ def test_subprocess_keyring_provider(monkeypatch: pytest.MonkeyPatch, env_value:
 
 def test_subprocess_pythonsafepath_set_for_python_commands() -> None:
     """Test that PYTHONSAFEPATH is set for Python subprocess calls to prevent CWD shadowing (issue #1575)."""
-    result = run_subprocess([sys.executable, "-c", "import os, sys; sys.stdout.write(os.environ.get('PYTHONSAFEPATH', ''))"])
+    result = run_subprocess(
+        [sys.executable, "-c", "import os, sys; sys.stdout.write(os.environ.get('PYTHONSAFEPATH', ''))"]
+    )
 
     assert result.stdout == "1"


### PR DESCRIPTION
# Fix #1575: Prevent CWD from being added to sys.path during subprocess calls

## Summary
Fixes #1575 - Prevents the current working directory (CWD) from being included in Python's import path during subprocess calls, which caused both security vulnerabilities and installation failures.

## Problem
When pipx runs Python subprocess commands during package installation, the CWD was being added to Python's `sys.path` by default. This caused:

1. **Security vulnerability**: Malicious local files could shadow standard library modules and execute arbitrary code
2. **Installation failures**: Local files with names matching stdlib modules (e.g., `re.py`, `json.py`) would break imports

### Reproduction
```bash
cd $(mktemp -d)
echo "raise" > re.py
pipx install magic-wormhole  # Fails with error from re.py
```

## Solution
Set `PYTHONSAFEPATH=1` environment variable for all Python subprocess commands in `src/pipx/util.py`. This tells Python 3.11+ to not add the CWD to `sys.path`, preventing local files from shadowing standard library modules.

## Changes
- Modified `run_subprocess()` in `src/pipx/util.py` to set `PYTHONSAFEPATH=1` for Python commands
- Removed TODO comment about implementing this fix
- Added clear documentation explaining the security fix
- Added test in `tests/test_util.py` to verify PYTHONSAFEPATH is set

## Testing
✅ Tested with malicious `re.py` file in CWD - installations now succeed  
✅ Tested with `pycowsay`, `black` - no regressions  
✅ Verified environment variable is safely ignored on Python < 3.11  
✅ Added unit test to verify PYTHONSAFEPATH is set for Python subprocess calls  
✅ All linting checks pass (`ruff check`)

## Notes
- Works for Python 3.11+ (when the venv uses Python 3.11+)
- Python 3.9/3.10 venvs remain vulnerable but these versions are less common
- Uses `env.setdefault()` to avoid overriding if already set

## Checklist
- [x] Ran the linter to address style issues (`ruff check`)
- [x] Wrote descriptive pull request text
- [x] Ensured there are test(s) validating the fix
- [ ] Added news fragment in `changelog.d/` folder
- [x] Updated/extended the documentation (not needed - internal fix)

---

**🤖 AI-Assisted Development**  
This fix was developed with assistance from **Claude (claude-sonnet-4.5)** during the [PyTexas 2026](https://www.pytexas.org/2026/) conference workshop: [*"Becoming a Better Python Developer with AI"*](https://www.pytexas.org/2026/schedule/tutorials/#becoming-a-better-python-developer-with-ai)
