### PR TITLE
Avoid treating bare package names as cwd paths

### DIFF
--- a/changelog.d/1778.bugfix.md
+++ b/changelog.d/1778.bugfix.md
@@ -1,0 +1,1 @@
+Avoid mistaking same-named working-directory entries for package paths.

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -214,7 +214,12 @@ def package_is_url(package: str, raise_error: bool = True) -> bool:
 
 
 def package_is_path(package: str):
-    if os.path.sep in package or Path(package).exists():
+    if (
+        package in {".", ".."}
+        or os.path.sep in package
+        or (os.path.altsep is not None and os.path.altsep in package)
+        or bool(os.path.splitdrive(package)[0])
+    ):
         raise PipxError(
             pipx_wrap(
                 f"""

--- a/tests/test_reinstall.py
+++ b/tests/test_reinstall.py
@@ -1,4 +1,5 @@
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -56,6 +57,25 @@ def test_reinstall_specifier(pipx_temp_env, capsys):
     assert "installed package pylint 3.0.4" in captured.out
 
 
+@pytest.mark.parametrize("package", [".", ".."])
+def test_reinstall_with_explicit_relative_path(pipx_temp_env, capsys, package):
+    assert run_pipx_cli(["reinstall", package])
+    captured = capsys.readouterr()
+
+    assert "Expected the name of an installed package" in captured.err.replace("\n", " ")
+
+
+def test_reinstall_with_explicit_nested_relative_path(pipx_temp_env, capsys, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    path = Path("some") / "path"
+    path.parent.mkdir()
+
+    assert run_pipx_cli(["reinstall", str(path)])
+    captured = capsys.readouterr()
+
+    assert "Expected the name of an installed package" in captured.err.replace("\n", " ")
+
+
 def test_reinstall_with_path(pipx_temp_env, capsys, tmp_path):
     path = tmp_path / "some" / "path"
 
@@ -68,6 +88,18 @@ def test_reinstall_with_path(pipx_temp_env, capsys, tmp_path):
     captured = capsys.readouterr()
 
     assert "Expected the name of an installed package" in captured.err.replace("\n", " ")
+
+
+def test_reinstall_package_name_when_same_named_cwd_path_exists(pipx_temp_env, capsys, tmp_path, monkeypatch):
+    assert not run_pipx_cli(["install", "pycowsay"])
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pycowsay").mkdir()
+
+    assert not run_pipx_cli(["reinstall", "--python", sys.executable, "pycowsay"])
+
+    captured = capsys.readouterr()
+    assert "installed package pycowsay" in captured.out
 
 
 def test_reinstall_pinned_package(pipx_temp_env, capsys):


### PR DESCRIPTION
### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://pipx.pypa.io/latest/contributing/))

- [x] ran the linter to address style issues (`pre-commit run --all-files`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `changelog.d/` folder
- [ ] updated/extended the documentation

Closes #1778.

`package_is_path()` currently rejects any package name that also exists as a path in the current working directory. That makes commands like `pipx reinstall pycowsay` fail if the user happens to be in a directory that contains a `pycowsay/` entry, even though the CLI argument is just an installed package name.

This narrows the path check to explicit path syntax only: `.` / `..`, path separators, and drive-prefixed paths. Bare package names no longer depend on whether a same-named entry exists in the current working directory.

Validation:
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest tests/test_reinstall.py -q`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest tests/test_reinstall.py -k 'same_named_cwd_path_exists or explicit_relative_path or reinstall_with_path' -q`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/pre-commit run --files src/pipx/main.py tests/test_reinstall.py changelog.d/1778.bugfix.md`
- manual CLI repro before/after with `pipx install pycowsay`, a same-named cwd directory, and `pipx reinstall pycowsay`
