### PR TITLE
fix: expose editable install man pages

### DIFF
--- a/src/pipx/venv_inspect.py
+++ b/src/pipx/venv_inspect.py
@@ -3,7 +3,9 @@ import logging
 import textwrap
 from collections.abc import Collection
 from pathlib import Path
+from shutil import copy2
 from typing import NamedTuple, Optional
+from urllib.parse import unquote, urlparse
 
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
@@ -130,6 +132,45 @@ def get_resources(dist: metadata.Distribution, bin_path: Path, man_path: Path) -
     app_names = app_names_ep | app_names_df | app_names_if
     man_names = man_names_df | man_names_if
     return sorted(app_names), sorted(man_names)
+
+
+def _get_editable_project_path(dist: metadata.Distribution) -> Optional[Path]:
+    direct_url_text = dist.read_text("direct_url.json")
+    if not direct_url_text:
+        return None
+
+    try:
+        direct_url = json.loads(direct_url_text)
+    except json.JSONDecodeError:
+        return None
+
+    if not direct_url.get("dir_info", {}).get("editable"):
+        return None
+
+    parsed_url = urlparse(direct_url.get("url", ""))
+    if parsed_url.scheme != "file":
+        return None
+
+    return Path(unquote(parsed_url.path))
+
+
+def _copy_editable_man_pages(dist: metadata.Distribution, venv_man_path: Path) -> list[str]:
+    project_path = _get_editable_project_path(dist)
+    if project_path is None or not project_path.exists():
+        return []
+
+    man_pages = set()
+    for section in MAN_SECTIONS:
+        for source_path in project_path.rglob(f"{section}/*"):
+            if not source_path.is_file() or source_path.parent.name != section:
+                continue
+
+            target_path = venv_man_path / section / source_path.name
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            copy2(source_path, target_path)
+            man_pages.add(str(Path(section) / source_path.name))
+
+    return sorted(man_pages)
 
 
 def _dfs_package_resources(
@@ -292,6 +333,8 @@ def inspect_venv(
     )
 
     apps, man_pages = get_resources(root_dist, venv_bin_path, venv_man_path)
+    if not man_pages:
+        man_pages = _copy_editable_man_pages(root_dist, venv_man_path)
     app_paths = [venv_bin_path / app for app in apps]
     man_paths = [venv_man_path / man_page for man_page in man_pages]
     if WINDOWS:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -14,6 +14,32 @@ from pipx import paths, shared_libs
 TEST_DATA_PATH = "./testdata/test_package_specifier"
 
 
+def create_local_project_with_man_page(project_dir: Path) -> None:
+    (project_dir / "src" / "demo_man").mkdir(parents=True)
+    (project_dir / "man" / "man1").mkdir(parents=True)
+    (project_dir / "src" / "demo_man" / "__init__.py").write_text("__version__ = '0.1'\n")
+    (project_dir / "src" / "demo_man" / "cli.py").write_text("def main():\n    print('demo-man')\n")
+    (project_dir / "man" / "man1" / "demo-man.1").write_text(
+        ".TH demo-man 1\n.SH NAME\ndemo-man \\- demo editable install test\n"
+    )
+    (project_dir / "pyproject.toml").write_text(
+        "[build-system]\n"
+        "requires = ['setuptools>=69', 'wheel']\n"
+        "build-backend = 'setuptools.build_meta'\n\n"
+        "[project]\n"
+        "name = 'demo-man'\n"
+        "version = '0.1'\n\n"
+        "[project.scripts]\n"
+        "demo-man = 'demo_man.cli:main'\n\n"
+        "[tool.setuptools]\n"
+        "package-dir = {'' = 'src'}\n\n"
+        "[tool.setuptools.packages.find]\n"
+        "where = ['src']\n\n"
+        "[tool.setuptools.data-files]\n"
+        '"share/man/man1" = ["man/man1/demo-man.1"]\n'
+    )
+
+
 def test_help_text(monkeypatch, capsys):
     mock_exit = mock.Mock(side_effect=ValueError("raised in test to exit early"))
     with mock.patch.object(sys, "exit", mock_exit), pytest.raises(ValueError, match="raised in test to exit early"):
@@ -338,6 +364,18 @@ def test_man_page_install(pipx_temp_env, capsys):
     captured = capsys.readouterr()
     assert f"- {Path('man6/pycowsay.6')}" in captured.out
     assert (paths.ctx.man_dir / "man6" / "pycowsay.6").exists()
+
+
+@skip_if_windows
+def test_man_page_install_editable_local_package(pipx_temp_env, tmp_path, capsys):
+    project_dir = tmp_path / "editable-man-package"
+    create_local_project_with_man_page(project_dir)
+
+    assert not run_pipx_cli(["install", "--editable", str(project_dir)])
+    captured = capsys.readouterr()
+
+    assert f"- {Path('man1/demo-man.1')}" in captured.out
+    assert (paths.ctx.man_dir / "man1" / "demo-man.1").exists()
 
 
 def test_install_pip_failure(pipx_temp_env, capsys):


### PR DESCRIPTION
## Summary\n- copy editable-install man pages from the local project into the venv man directory when pip does not install them\n- add a regression test covering editable local installs with man pages\n\n## Testing\n- python -m pytest tests/test_install.py -k man_page_install tests/test_uninstall.py -k man_page -q\n- python -m tox run -e lint