### PR TITLE
Add help subcommand alias

### DIFF
--- a/changelog.d/1535.feature.rst
+++ b/changelog.d/1535.feature.rst
@@ -1,0 +1,1 @@
+Add ``pipx help`` and ``pipx help <command>`` aliases for existing help output.

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -1036,6 +1036,12 @@ def get_command_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Ar
         description="Print instructions on enabling shell completions for pipx",
         parents=[shared_parser],
     )
+    subparsers.add_parser(
+        "help",
+        help="Show help for pipx or a command",
+        description="Show help for pipx or a command",
+        parents=[shared_parser],
+    )
     return parser, subparsers_with_subcommands
 
 
@@ -1194,13 +1200,21 @@ def check_args(parsed_pipx_args: argparse.Namespace) -> None:
             parsed_pipx_args.subparser.error("the following arguments are required: app")
 
 
+def normalize_help_command(args: list[str]) -> list[str]:
+    if args and args[0] == "help":
+        if len(args) == 1:
+            return ["--help"]
+        return args[1:] + ["--help"]
+    return args
+
+
 def cli() -> ExitCode:
     """Entry point from command line"""
     try:
         hide_cursor()
         parser, subparsers = get_command_parser()
         argcomplete.autocomplete(parser, always_complete_options=False)
-        parsed_pipx_args = parser.parse_args()
+        parsed_pipx_args = parser.parse_args(normalize_help_command(sys.argv[1:]))
         setup(parsed_pipx_args)
         check_args(parsed_pipx_args)
         if not parsed_pipx_args.command:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,6 +15,24 @@ def test_help_text(monkeypatch, capsys):
     assert "usage: pipx" in captured.out
 
 
+def test_help_command_text(monkeypatch, capsys):
+    mock_exit = mock.Mock(side_effect=ValueError("raised in test to exit early"))
+    with mock.patch.object(sys, "exit", mock_exit), pytest.raises(ValueError, match="raised in test to exit early"):
+        assert not run_pipx_cli(["help"])
+    captured = capsys.readouterr()
+    mock_exit.assert_called_with(0)
+    assert "usage: pipx" in captured.out
+
+
+def test_help_command_for_subcommand(monkeypatch, capsys):
+    mock_exit = mock.Mock(side_effect=ValueError("raised in test to exit early"))
+    with mock.patch.object(sys, "exit", mock_exit), pytest.raises(ValueError, match="raised in test to exit early"):
+        assert not run_pipx_cli(["help", "install"])
+    captured = capsys.readouterr()
+    mock_exit.assert_called_with(0)
+    assert "usage: pipx install" in captured.out
+
+
 def test_version(monkeypatch, capsys):
     mock_exit = mock.Mock(side_effect=ValueError("raised in test to exit early"))
     with mock.patch.object(sys, "exit", mock_exit), pytest.raises(ValueError, match="raised in test to exit early"):


### PR DESCRIPTION
Fixes #1535.

This lets `pipx help` show the top-level help and `pipx help <command>` show the existing command help output. It normalizes the help subcommand before argparse handles the rest, so the command implementations stay unchanged.

Checked with:
- `uv run --with pytest --with-editable . pytest tests/test_main.py -q`
- `uv run --with ruff ruff check src/pipx/main.py tests/test_main.py`
- `git diff --check`