### PR TITLE
✨ feat(backends): add opt-in uv backend

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,7 @@ repos:
           - "packaging>=20"
           - "platformdirs>=2.1"
           - "pytest"
+          - "pytest-mock"
           - "tomli; python_version < '3.11'"
   # Configuration for codespell is in pyproject.toml
   - repo: https://github.com/codespell-project/codespell

--- a/changelog.d/1808.feature.md
+++ b/changelog.d/1808.feature.md
@@ -1,0 +1,17 @@
+Add an opt-in `uv` backend. Install `pipx[uv]` (or put `uv` on `PATH`) and pipx will create venvs with `uv venv`, manage
+packages with `uv pip`, and run ephemeral apps via `uv tool run`.
+
+**Default change:** when `uv` is reachable, pipx uses it for **new** venvs by default. Existing venvs keep their
+recorded backend; flipping a venv requires `pipx reinstall NAME --backend X`. Set `PIPX_DEFAULT_BACKEND=pip` to force
+pip even when uv is available, or pass `--backend pip` per command. `pipx install pip` always picks the pip backend (uv
+venvs have no pip).
+
+Selection precedence: `--backend` > recorded venv metadata > `PIPX_DEFAULT_BACKEND` > auto-detect. The env var sits
+*below* metadata so setting `PIPX_DEFAULT_BACKEND=uv` does not silently retarget existing pip-backed venvs; the recorded
+backend wins until you flip it explicitly. `pipx environment` exposes the resolved backend and its source as
+`PIPX_RESOLVED_BACKEND` and `PIPX_BACKEND_SOURCE`.
+
+**Metadata version bump:** the venv metadata file format moves from `0.5` to `0.6` to record the chosen backend. Running
+this pipx version against an existing venv rewrites its metadata to `0.6` on the next install/upgrade. If you downgrade
+pipx after that, the older version raises `Unknown metadata version 0.6` and you'll need to reinstall the affected venvs
+from the older pipx (`pipx reinstall NAME`).

--- a/docs/explanation/comparisons.md
+++ b/docs/explanation/comparisons.md
@@ -10,6 +10,101 @@
 
 Example interaction: Install pipx with pip: `pip install --user pipx`
 
+## pipx vs uv tool
+
+Both [`uv tool`](https://docs.astral.sh/uv/concepts/tools/) and pipx install a Python tool into its own virtual
+environment and expose the tool's console scripts on `PATH`. Both have a one-shot run mode (`uvx` and `pipx run`). `uvx`
+is `uv tool run`. They differ in where state lives, which extra commands they ship, and how they handle managed Python.
+
+pipx keeps the same CLI across pip and uv backends; `pipx install pipx[uv]` opts you into uv-speed venv creation without
+changing any commands. `uv tool` ships a smaller per-tool surface, then reuses the rest of `uv` for free: managed
+Python, content-addressed cache, lockfiles, PEP 723 script handling.
+
+### Where state lives
+
+|                        | pipx                                           | uv tool                                    |
+| ---------------------- | ---------------------------------------------- | ------------------------------------------ |
+| Per-tool venvs         | `$PIPX_HOME/venvs/<name>` (`PIPX_HOME`)        | `$UV_TOOL_DIR/<name>` (`UV_TOOL_DIR`)      |
+| Exposed binaries       | `$PIPX_BIN_DIR` (default `~/.local/bin`)       | `$UV_TOOL_BIN_DIR` (default same)          |
+| Man pages              | `$PIPX_MAN_DIR` (default `~/.local/share/man`) | _not exposed_                              |
+| Shared pip/setup/wheel | `$PIPX_HOME/shared` (pip-backend only)         | _none; uv venvs ship without pip_          |
+| Ephemeral run cache    | `$PIPX_HOME/.cache` (TTL 14 days)              | `$UV_CACHE_DIR` (no TTL; `uv cache prune`) |
+| Standalone Python      | `$PIPX_HOME/py` (`PIPX_FETCH_PYTHON`)          | `$UV_PYTHON_INSTALL_DIR`                   |
+| System-wide install    | `--global`, `PIPX_GLOBAL_*`                    | _not supported_                            |
+
+`PIPX_BIN_DIR` and `UV_TOOL_BIN_DIR` both default to `~/.local/bin` on Unix, so installing the same tool with both
+managers writes the same filename. Each manager refuses to overwrite a binary the other one wrote without `--force`. Use
+`pipx install --suffix=...` to keep two copies side-by-side; uv has no equivalent.
+
+### Subcommand mapping
+
+| Task                           | pipx                                              | uv tool                                                             |
+| ------------------------------ | ------------------------------------------------- | ------------------------------------------------------------------- |
+| Install from PyPI              | `pipx install ruff`                               | `uv tool install ruff` (or `uvx ruff` for one-off)                  |
+| Install from a git URL         | `pipx install 'git+https://…'`                    | `uv tool install 'git+https://…'`                                   |
+| Install editable from path     | `pipx install -e ./mypkg`                         | `uv tool install -e ./mypkg`                                        |
+| One-off run (no install)       | `pipx run black .`                                | `uvx black .`                                                       |
+| One-off run with extra dep     | _no clean equivalent_                             | `uvx --with mkdocs-material mkdocs`                                 |
+| Pinned-version one-off         | `pipx run --spec 'ruff==0.6.0' ruff check`        | `uvx ruff@0.6.0 check`                                              |
+| Add a dep to existing tool     | `pipx inject mkdocs mkdocs-material`              | `uv tool install mkdocs --with mkdocs-material` (rebuilds)          |
+| Remove an injected dep         | `pipx uninject mkdocs mkdocs-material`            | _rebuild without `--with`_                                          |
+| Upgrade one                    | `pipx upgrade ruff`                               | `uv tool upgrade ruff`                                              |
+| Upgrade all                    | `pipx upgrade-all`                                | `uv tool upgrade --all`                                             |
+| List installed                 | `pipx list`                                       | `uv tool list` (`--show-with`, `--outdated`, …)                     |
+| Reinstall (e.g. after Py bump) | `pipx reinstall ruff` / `reinstall-all`           | `uv tool upgrade --reinstall ruff` / `--all -p 3.13`                |
+| Run pip inside a venv          | `pipx runpip <tool> -- pip ...`                   | _not supported (no pip in uv venvs)_                                |
+| PATH setup                     | `pipx ensurepath`                                 | `uv tool update-shell`                                              |
+| Show resolved env              | `pipx environment`                                | `uv tool dir`, `uv tool dir --bin`, `uv cache dir`, `uv python dir` |
+| PEP 723 inline script          | `pipx run script.py` (with uv backend → `uv run`) | `uv run --script script.py`                                         |
+
+### Only in pipx
+
+- `pipx inject` / `uninject` add or remove a package in place. `uv tool install --with` reaches the same end state by
+    rebuilding the venv.
+- `pipx runpip <venv> -- ...` runs pip inside a tool's venv. uv venvs have no pip.
+- `--include-deps` exposes entry points from every dependency. uv requires you to enumerate dep packages with
+    `--with-executables-from`.
+- `--suffix` keeps two copies of the same tool side-by-side.
+- `--global` and the `PIPX_GLOBAL_*` variables drive a system-wide install.
+- Manual pages get symlinked under `$PIPX_MAN_DIR`.
+- `pipx install-all <spec.json>` rebuilds every venv from a `pipx list --json` snapshot for cross-machine migration.
+- `[project.entry-points."pipx.run"]` declares pipx-specific runtime extras in the package metadata.
+- `pipx environment` prints every variable and its resolved value in one place.
+
+### Only in uv tool
+
+- `uv tool list --outdated` queries newer versions without upgrading.
+- `uv tool list` toggles columns via `--show-with`, `--show-paths`, `--show-version-specifiers`, `--show-extras`,
+    `--show-python`.
+- `uvx --with-editable PATH` adds editable extras for a one-off run.
+- `uv tool upgrade --all -p 3.13` re-pins every tool to a different Python in one shot.
+- `uv python install/list/find/pin/upgrade/uninstall` integrates managed Python; uv auto-fetches when the requested
+    Python isn't installed.
+- `--exclude-newer`, `--torch-backend`, and `--isolated` add reproducibility knobs that pipx forwards but doesn't add on
+    its own.
+- The content-addressed cache spans `uv pip`, `uv tool`, `uv run`, and `uv venv`. Wheels downloaded once get reused
+    everywhere.
+
+### Gotchas
+
+- `uvx` reuses cached envs across invocations until you prune the cache (`uv cache clean`), pin a new version
+    (`uvx black@latest`), or pass `--refresh`. `pipx run` also caches, but the temp venv expires after 14 days idle.
+- `uvx` prefers a persistent install when one exists. After `uv tool install ruff`, plain `uvx ruff` reuses that env
+    instead of building an ephemeral one. Pass `--isolated` to bypass.
+- `uv tool` ignores project-local `.python-version` files. `uv run` honors them; tool envs do not. pipx never reads
+    them; pass `--python` or set `PIPX_DEFAULT_PYTHON`.
+- `uv python upgrade` only bumps patch versions. To move a tool from 3.12 to 3.13 run `uv tool upgrade --all -p 3.13`.
+    pipx's equivalent is `reinstall-all --python python3.13`.
+- `uv run --script` needs a real on-disk path. When `pipx run script.py` content arrives via URL or named pipe, the uv
+    backend falls back to building a venv.
+
+### Picking one
+
+Pipx wins when you need its tool-specific extras: `inject`/`uninject`, `--global`, `--suffix`, manual pages, or
+`pipx install-all` for migration. Install `pipx[uv]` to keep that surface and pick up uv-speed venv creation. Reach for
+`uv tool` when you already drive uv for managed Python or `uv run --script` and want one binary for everything. Running
+both is fine; the only collision point is the shared bin dir, and both sides refuse to overwrite without `--force`.
+
 ## pipx vs poetry and pipenv
 
 - pipx is used solely for application consumption: you install CLI apps with it

--- a/docs/how-to/use-uv-backend.md
+++ b/docs/how-to/use-uv-backend.md
@@ -1,0 +1,70 @@
+# Use the uv Backend
+
+pipx can use [uv](https://github.com/astral-sh/uv) to create virtual environments, install packages, and run ephemeral
+apps in place of pip and venv. The backend turns on when uv is reachable; flip it per command (`--backend`) or globally
+(`PIPX_DEFAULT_BACKEND`).
+
+> This page covers pipx using uv to create venvs and install packages. The pipx CLI surface stays the same. For a
+> side-by-side comparison with `uv tool` (Astral's standalone command), see
+> [pipx vs uv tool](../explanation/comparisons.md#pipx-vs-uv-tool).
+
+## Why use it
+
+- uv creates venvs faster than `python -m venv`. The venv ships without pip.
+- uv resolves and installs faster than pip on large dependency trees.
+- `pipx run` execs `uv tool run`, picking up uv's cross-invocation cache.
+
+## Enable it
+
+Two ways to expose uv to pipx:
+
+1. Install pipx with the `uv` extra. pipx prefers the bundled binary when present:
+
+    ```shell
+    pipx install pipx[uv]
+    ```
+
+1. Install uv however you like (`brew install uv`, `cargo install uv`, etc.) and put it on `PATH`. pipx picks it up
+    automatically.
+
+When uv is available, pipx defaults to it for new venvs. Existing venvs keep their original backend; the choice lives in
+each venv's metadata.
+
+## Choose a backend explicitly
+
+```shell
+pipx install black --backend pip          # force pip + venv
+pipx install ruff --backend uv            # force uv (errors if uv is not available)
+PIPX_DEFAULT_BACKEND=uv pipx install ruff # global override via environment
+pipx environment --value PIPX_RESOLVED_BACKEND  # see what pipx will use right now
+```
+
+`install`, `install-all`, `inject`, `upgrade`, `upgrade-all`, `reinstall`, `reinstall-all`, and `run` all accept
+`--backend`. Run `pipx reinstall NAME --backend uv` to switch an already-installed venv.
+
+## What changes under the uv backend
+
+- pipx creates new venvs with `uv venv`. The venv contains no `pip` and no `pipx_shared.pth` file.
+- `pipx runpip` runs `uv pip <args> --python <venv>/bin/python`. uv rejects flags it doesn't understand instead of pipx
+    silently dropping them.
+- `pipx run` execs `uv tool run`; the cache lives in uv's cache directory. Pass `--no-cache` to skip it.
+- `pipx run script.py` execs `uv run --script script.py` for PEP 723 inline scripts.
+
+## Limitations
+
+- `pipx install pip --backend uv` errors out. A uv venv has no pip, so the result would be inconsistent. Use
+    `--backend pip` instead.
+- `pipx run --backend uv` does not honor `[pipx.run]` entry points; `uv tool run` only sees standard console scripts.
+    Use `--backend pip` if your package declares them.
+- Some `--pip-args` values have no `uv tool run` equivalent (for example `--editable`, `--no-build-isolation`). pipx
+    errors instead of silently dropping them. Use `--backend pip` for those flows.
+- `pipx run --backend uv` against URL or named-pipe scripts falls back to a pipx-managed venv: `uv run --script` reads
+    PEP 723 metadata off disk, and there is no on-disk path for content fetched at runtime. pipx logs a warning when
+    this fallback fires.
+
+## Cache layout
+
+`pipx run` under the uv backend caches in `UV_CACHE_DIR` instead of `PIPX_VENV_CACHEDIR`. Switching the default backend
+on a host that already used `pipx run` leaves the old pipx cache behind: `pipx environment` prints both paths so you can
+inspect them and remove the unused one manually. The 14-day expiry sweep that pipx applies to its own venv cache does
+not extend to uv's cache, which uv manages on its own schedule (`uv cache clean`).

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -11,6 +11,7 @@ pipx reads the following environment variables. All are optional.
 | `PIPX_GLOBAL_BIN_DIR`       | Binary directory for global installs.                                     | `/usr/local/bin`                                                           |
 | `PIPX_GLOBAL_MAN_DIR`       | Man page directory for global installs.                                   | `/usr/local/share/man`                                                     |
 | `PIPX_DEFAULT_PYTHON`       | Python interpreter to use when `--python` is not passed.                  | `python3` (or `py` on Windows)                                             |
+| `PIPX_DEFAULT_BACKEND`      | Backend for new venvs: `pip` or `uv`.                                     | `uv` when uv is available, else `pip`                                      |
 | `PIPX_SHARED_LIBS`          | Override the shared libraries directory.                                  | `PIPX_HOME/shared`                                                         |
 | `PIPX_FETCH_PYTHON`         | When to fetch a standalone Python build: `always`, `missing`, or `never`. | `never`                                                                    |
 | `PIPX_FETCH_MISSING_PYTHON` | Deprecated, alias for `PIPX_FETCH_PYTHON=missing`.                        | _(unset)_                                                                  |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
       - Inject Packages: "how-to/inject-packages.md"
       - Pin Packages: "how-to/pin-packages.md"
       - Run Scripts: "how-to/run-scripts.md"
+      - Use the uv Backend: "how-to/use-uv-backend.md"
       - Use with pre-commit: "how-to/use-with-pre-commit.md"
       - Configure Paths: "how-to/configure-paths.md"
       - Move Installation: "how-to/move-installation.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ dependencies = [
   "tomli; python_version<'3.11'",
   "userpath>=1.6,!=1.9",
 ]
+optional-dependencies.uv = [
+  "uv>=0.4",
+]
 urls."Issue Tracker" = "https://github.com/pypa/pipx/issues"
 urls."Release Notes" = "https://pipx.pypa.io/latest/changelog/"
 urls."Source Code" = "https://github.com/pypa/pipx"

--- a/src/pipx/backends/__init__.py
+++ b/src/pipx/backends/__init__.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import os
+from functools import cache
+
+from pipx.backends._base import KNOWN_BACKENDS, PIP, UV, Backend
+from pipx.backends.pip import PipBackend
+from pipx.backends.uv import UvBackend, find_uv_binary
+from pipx.util import PipxError
+
+
+def resolve_backend_name(
+    *,
+    cli_value: str | None = None,
+    env_value: str | None = None,
+    metadata_value: str | None = None,
+    auto: bool = True,
+) -> tuple[str, str]:
+    """Return ``(name, source)`` per precedence cli > metadata > env > auto.
+
+    ``metadata`` sits above ``env`` so ``PIPX_DEFAULT_BACKEND=uv`` cannot
+    silently retarget pip-backed venvs already on disk.
+    """
+    for candidate, source in ((cli_value, "cli"), (metadata_value, "metadata"), (env_value, "env")):
+        if (validated := _validate(candidate)) is not None:
+            return validated, source
+    if auto and (binary_source := find_uv_binary()[1]) != "missing":
+        return UV, f"auto-{binary_source}"
+    return PIP, "auto-pip"
+
+
+@cache
+def get_backend(name: str) -> Backend:
+    # Cached so ``UvBackend.__init__``'s version probe and log line fire once
+    # per process even when validation + construction both ask for the backend.
+    if name == PIP:
+        return PipBackend()
+    if name == UV:
+        return UvBackend()
+    raise PipxError(f"Unknown backend {name!r}. Valid backends: {', '.join(KNOWN_BACKENDS)}.")
+
+
+def assert_not_pip_under_uv(package_name: str, backend_name: str) -> None:
+    # Named narrowly: a future backend with its own deny-list should grow its
+    # own guard rather than overload this one.
+    if package_name == "pip" and backend_name != PIP:
+        raise PipxError(
+            "The 'pip' package cannot be installed or exposed via the uv backend, since uv venvs "
+            "don't ship pip and the resulting environment would be inconsistent.\n"
+            "Use `--backend pip` (or set PIPX_DEFAULT_BACKEND=pip) to install 'pip' as a tool."
+        )
+
+
+def env_default_backend() -> str | None:
+    raw = os.environ.get("PIPX_DEFAULT_BACKEND")
+    return raw.strip() if raw else None
+
+
+def _validate(candidate: str | None) -> str | None:
+    if not candidate:
+        return None
+    if candidate not in KNOWN_BACKENDS:
+        raise PipxError(f"Unknown backend {candidate!r}. Valid backends: {', '.join(KNOWN_BACKENDS)}.")
+    return candidate
+
+
+__all__ = [
+    "KNOWN_BACKENDS",
+    "PIP",
+    "UV",
+    "Backend",
+    "assert_not_pip_under_uv",
+    "env_default_backend",
+    "find_uv_binary",
+    "get_backend",
+    "resolve_backend_name",
+]

--- a/src/pipx/backends/_base.py
+++ b/src/pipx/backends/_base.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from subprocess import CompletedProcess
+
+
+PIP: Final[str] = "pip"
+UV: Final[str] = "uv"
+KNOWN_BACKENDS: Final[tuple[str, ...]] = (PIP, UV)
+
+
+class Backend(ABC):
+    name: str
+
+    @abstractmethod
+    def create_venv(
+        self,
+        root: Path,
+        *,
+        python: str,
+        venv_args: list[str],
+        pip_args: list[str],
+        include_pip: bool,
+        verbose: bool,
+    ) -> None: ...
+
+    @abstractmethod
+    def install(
+        self,
+        *,
+        venv_root: Path,
+        venv_python: Path,
+        requirements: list[str],
+        pip_args: list[str],
+        no_deps: bool = False,
+        upgrade: bool = False,
+        log_pip_errors: bool = True,
+        verbose: bool = False,
+    ) -> CompletedProcess[str]: ...
+
+    @abstractmethod
+    def uninstall(
+        self,
+        *,
+        venv_root: Path,
+        venv_python: Path,
+        package: str,
+        verbose: bool,
+    ) -> CompletedProcess[str]: ...
+
+    @abstractmethod
+    def list_installed(
+        self,
+        *,
+        venv_root: Path,
+        venv_python: Path,
+        not_required: bool = False,
+    ) -> set[str]: ...
+
+    @abstractmethod
+    def run_raw_pip(
+        self,
+        *,
+        venv_root: Path,
+        venv_python: Path,
+        args: list[str],
+        capture_stdout: bool = True,
+        capture_stderr: bool = True,
+        verbose: bool = False,
+    ) -> CompletedProcess[str]: ...
+
+    @abstractmethod
+    def needs_shared_libs(self) -> bool: ...
+
+    @abstractmethod
+    def upgrade_packaging_libraries(
+        self,
+        venv_python: Path,
+        pip_args: list[str],
+        *,
+        verbose: bool,
+    ) -> None: ...
+
+
+__all__ = [
+    "KNOWN_BACKENDS",
+    "PIP",
+    "UV",
+    "Backend",
+]

--- a/src/pipx/backends/pip.py
+++ b/src/pipx/backends/pip.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Final
+
+from pipx.animate import animate
+from pipx.backends._base import PIP, Backend
+from pipx.constants import PIPX_SHARED_PTH
+from pipx.shared_libs import shared_libs
+from pipx.util import (
+    PipxError,
+    get_site_packages,
+    get_venv_paths,
+    run_subprocess,
+    subprocess_post_check,
+    subprocess_post_check_handle_pip_error,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from subprocess import CompletedProcess
+
+_LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
+
+
+class PipBackend(Backend):
+    name = PIP
+
+    def needs_shared_libs(self) -> bool:
+        return True
+
+    def upgrade_packaging_libraries(
+        self,
+        venv_python: Path,
+        pip_args: list[str],
+        *,
+        verbose: bool,
+    ) -> None:
+        # Reached only for ``pipx install pip``-style venvs that ship pip
+        # in-tree; shared-libs venvs upgrade through ``shared_libs.upgrade``.
+        process = run_subprocess(
+            [str(venv_python), "-m", "pip", "--no-input", "install", "--upgrade", *pip_args, "pip"],
+            run_dir=str(venv_python.parent.parent),
+        )
+        subprocess_post_check(process)
+
+    def create_venv(
+        self,
+        root: Path,
+        *,
+        python: str,
+        venv_args: list[str],
+        pip_args: list[str],
+        include_pip: bool,
+        verbose: bool,
+    ) -> None:
+        cmd = [python, "-m", "venv"]
+        if not include_pip:
+            cmd.append("--without-pip")
+        cmd += [*venv_args, str(root)]
+        with animate("creating virtual environment", not verbose):
+            venv_process = run_subprocess(cmd, run_dir=str(root))
+        subprocess_post_check(venv_process)
+
+        shared_libs.create(verbose=verbose, pip_args=pip_args)
+        if not include_pip:
+            _, python_path, _ = get_venv_paths(root)
+            pipx_pth = get_site_packages(python_path) / PIPX_SHARED_PTH
+            pipx_pth.write_text(f"{shared_libs.site_packages}\n")
+
+    def install(
+        self,
+        *,
+        venv_root: Path,
+        venv_python: Path,
+        requirements: list[str],
+        pip_args: list[str],
+        no_deps: bool = False,
+        upgrade: bool = False,
+        log_pip_errors: bool = True,
+        verbose: bool = False,
+    ) -> CompletedProcess[str]:
+        cmd: list[str] = [str(venv_python), "-m", "pip", "--no-input", "install"]
+        if upgrade:
+            cmd.append("--upgrade")
+        if no_deps:
+            cmd.append("--no-dependencies")
+        cmd += [*pip_args, *requirements]
+        process = run_subprocess(
+            cmd,
+            log_stdout=not log_pip_errors,
+            log_stderr=not log_pip_errors,
+            run_dir=str(venv_root),
+        )
+        if log_pip_errors:
+            subprocess_post_check_handle_pip_error(process)
+        else:
+            subprocess_post_check(process, raise_error=False)
+        return process
+
+    def uninstall(
+        self,
+        *,
+        venv_root: Path,
+        venv_python: Path,
+        package: str,
+        verbose: bool,
+    ) -> CompletedProcess[str]:
+        cmd = [str(venv_python), "-m", "pip", "uninstall", "-y", package]
+        if not verbose:
+            cmd.append("-q")
+        process = run_subprocess(cmd, run_dir=str(venv_root))
+        subprocess_post_check(process)
+        return process
+
+    def list_installed(
+        self,
+        *,
+        venv_root: Path,
+        venv_python: Path,
+        not_required: bool = False,
+    ) -> set[str]:
+        del venv_root
+        cmd = [str(venv_python), "-m", "pip", "list", "--format=json"]
+        if not_required:
+            cmd.append("--not-required")
+        process = run_subprocess(cmd)
+        if process.returncode != 0:
+            raise PipxError(
+                f"Failed to execute {process.args}.\n"
+                f"Process exited with return code {process.returncode}.\n"
+                f"stderr: {process.stderr}"
+            )
+        return {entry["name"] for entry in json.loads(process.stdout.strip())}
+
+    def run_raw_pip(
+        self,
+        *,
+        venv_root: Path,
+        venv_python: Path,
+        args: list[str],
+        capture_stdout: bool = True,
+        capture_stderr: bool = True,
+        verbose: bool = False,
+    ) -> CompletedProcess[str]:
+        cmd = [str(venv_python), "-m", "pip", *args]
+        if not verbose:
+            cmd.append("-q")
+        return run_subprocess(
+            cmd,
+            capture_stdout=capture_stdout,
+            capture_stderr=capture_stderr,
+            run_dir=str(venv_root),
+        )
+
+
+__all__ = [
+    "PipBackend",
+]

--- a/src/pipx/backends/uv.py
+++ b/src/pipx/backends/uv.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import json
+import logging
+import re
+import shutil
+import subprocess
+from functools import cache
+from pathlib import Path
+from typing import TYPE_CHECKING, Final
+
+from packaging.version import InvalidVersion, Version
+
+from pipx.animate import animate
+from pipx.backends._base import UV, Backend
+from pipx.util import (
+    PipxError,
+    run_subprocess,
+    subprocess_post_check,
+    subprocess_post_check_handle_pip_error,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from subprocess import CompletedProcess
+
+_LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
+
+
+# Imported into a temporary, then assigned through Final and deleted so mypy
+# sees one Final binding (it rejects redefinition across try/except branches).
+try:
+    from uv import find_uv_bin as _uv_bin_from_extra  # type: ignore[import-not-found]
+except ImportError:
+    _uv_bin_from_extra = None
+_FIND_UV_BIN_FROM_EXTRA: Final[Callable[[], str] | None] = _uv_bin_from_extra
+del _uv_bin_from_extra
+_MIN_UV_VERSION: Final[Version] = Version("0.4.0")
+_VERSION_RE: Final[re.Pattern[str]] = re.compile(
+    r"""
+    uv \s+        # the literal "uv " prefix from `uv --version`
+    (\S+)         # capture the version token; PEP 440 parser validates it
+    """,
+    re.VERBOSE,
+)
+# Stripping VIRTUAL_ENV stops uv from auto-targeting an active venv when no
+# ``--python`` flag is passed.
+_UV_ENV_OVERRIDES: Final[dict[str, str | None]] = {"VIRTUAL_ENV": None, "UV_NO_PROGRESS": "1"}
+
+
+class UvBackend(Backend):
+    name = UV
+
+    def __init__(self) -> None:
+        self._binary = resolve_uv_binary()
+        _, self._source = find_uv_binary()
+        version = _check_uv_version(self._binary)
+        _LOGGER.info(f"using {self._source} uv {version} from {self._binary}")
+
+    def needs_shared_libs(self) -> bool:
+        return False
+
+    def upgrade_packaging_libraries(self, venv_python: Path, pip_args: list[str], *, verbose: bool) -> None:
+        del venv_python, pip_args, verbose  # uv venvs ship no pip to upgrade.
+
+    def create_venv(
+        self,
+        root: Path,
+        *,
+        python: str,
+        venv_args: list[str],
+        pip_args: list[str],
+        include_pip: bool,
+        verbose: bool,
+    ) -> None:
+        del pip_args  # uv venv has no pip to seed.
+        if include_pip:
+            raise PipxError(
+                "The uv backend cannot create a virtual environment with pip preinstalled.\n"
+                "Reinstall the package with `--backend pip` (or unset PIPX_DEFAULT_BACKEND)."
+            )
+        cmd: list[str | Path] = [self._binary, "venv", "--python", python, *venv_args]
+        cmd.append("--verbose" if verbose else "--quiet")
+        cmd.append(str(root))
+        with animate("creating virtual environment", not verbose):
+            process = run_subprocess(cmd, run_dir=str(root), env_overrides=_UV_ENV_OVERRIDES)
+        subprocess_post_check(process)
+
+    def install(
+        self,
+        *,
+        venv_root: Path,
+        venv_python: Path,
+        requirements: list[str],
+        pip_args: list[str],
+        no_deps: bool = False,
+        upgrade: bool = False,
+        log_pip_errors: bool = True,
+        verbose: bool = False,
+    ) -> CompletedProcess[str]:
+        cmd = self._uv_pip_command("install", venv_python, verbose=verbose)
+        if upgrade:
+            cmd.append("--upgrade")
+        if no_deps:
+            cmd.append("--no-deps")
+        cmd += [*_strip_pip_quiet_flags(pip_args), *requirements]
+        process = run_subprocess(
+            cmd,
+            run_dir=str(venv_root),
+            log_stdout=not log_pip_errors,
+            log_stderr=not log_pip_errors,
+            env_overrides=_UV_ENV_OVERRIDES,
+        )
+        if log_pip_errors:
+            subprocess_post_check_handle_pip_error(process, tool_name="uv")
+        else:
+            subprocess_post_check(process, raise_error=False)
+        return process
+
+    def uninstall(
+        self,
+        *,
+        venv_root: Path,
+        venv_python: Path,
+        package: str,
+        verbose: bool,
+    ) -> CompletedProcess[str]:
+        cmd = self._uv_pip_command("uninstall", venv_python, verbose=verbose)
+        cmd.append(package)
+        process = run_subprocess(cmd, run_dir=str(venv_root), env_overrides=_UV_ENV_OVERRIDES)
+        subprocess_post_check(process)
+        return process
+
+    def list_installed(
+        self,
+        *,
+        venv_root: Path,
+        venv_python: Path,
+        not_required: bool = False,
+    ) -> set[str]:
+        cmd = self._uv_pip_command("list", venv_python, verbose=False)
+        cmd += ["--format", "json"]
+        if not_required:
+            cmd.append("--not-required")
+        process = run_subprocess(cmd, run_dir=str(venv_root), env_overrides=_UV_ENV_OVERRIDES)
+        if process.returncode != 0:
+            raise PipxError(
+                f"Failed to execute {process.args}.\n"
+                f"Process exited with return code {process.returncode}.\n"
+                f"stderr: {process.stderr}"
+            )
+        return {entry["name"] for entry in json.loads(process.stdout.strip())}
+
+    def run_raw_pip(
+        self,
+        *,
+        venv_root: Path,
+        venv_python: Path,
+        args: list[str],
+        capture_stdout: bool = True,
+        capture_stderr: bool = True,
+        verbose: bool = False,
+    ) -> CompletedProcess[str]:
+        # Mirror pip-backend ``pipx runpip TOOL`` (no args -> pip's help).
+        cmd: list[str | Path] = [self._binary, "pip", args[0] if args else "--help"]
+        cmd += ["--python", str(venv_python)]
+        if verbose:
+            cmd.append("--verbose")
+        elif args:
+            cmd.append("--quiet")
+        cmd += _strip_pip_quiet_flags(args[1:])
+        return run_subprocess(
+            cmd,
+            run_dir=str(venv_root),
+            capture_stdout=capture_stdout,
+            capture_stderr=capture_stderr,
+            env_overrides=_UV_ENV_OVERRIDES,
+        )
+
+    def _uv_pip_command(self, subcommand: str, venv_python: Path, *, verbose: bool) -> list[str | Path]:
+        cmd: list[str | Path] = [self._binary, "pip", subcommand, "--python", str(venv_python)]
+        cmd.append("--verbose" if verbose else "--quiet")
+        return cmd
+
+
+def resolve_uv_binary() -> Path:
+    # The version check fires here so non-Backend callers (e.g. ``pipx run``'s
+    # uv-tool-run shortcut) still get the "needs uv >= X" message rather than
+    # an opaque uv-side error.
+    binary, _ = find_uv_binary()
+    if binary is None:
+        raise PipxError(
+            "The uv backend was requested but the 'uv' executable could not be found.\n"
+            "Install pipx with the uv extra (`pipx install pipx[uv]`) or place 'uv' on your PATH.\n"
+            "Alternatively, run with `--backend pip` (or set PIPX_DEFAULT_BACKEND=pip)."
+        )
+    _check_uv_version(binary)
+    return binary
+
+
+@cache
+def find_uv_binary() -> tuple[Path | None, str]:
+    # Cached so ``upgrade-all`` and similar hot loops don't re-walk PATH per venv.
+    if _FIND_UV_BIN_FROM_EXTRA is not None:
+        try:
+            bundled = Path(_FIND_UV_BIN_FROM_EXTRA())
+        except FileNotFoundError:
+            pass
+        else:
+            # ``is_file`` rejects a stale path from a half-installed extra;
+            # ``_binary_runs`` catches the exec-fails case (missing dylib,
+            # ENOEXEC) so we fall through to PATH instead of erroring later.
+            if bundled.is_file() and _binary_runs(bundled):
+                return bundled, "bundled"
+    if path := shutil.which("uv"):
+        return Path(path), "path"
+    return None, "missing"
+
+
+def _binary_runs(binary: Path) -> bool:
+    # Liveness probe; full floor-version check stays in ``_check_uv_version``.
+    try:
+        process = subprocess.run([str(binary), "--version"], check=False, text=True, capture_output=True, timeout=10)
+    except OSError as exc:
+        _LOGGER.debug(f"uv launch probe failed for {binary}: {exc}")
+        return False
+    if process.returncode != 0 or not _VERSION_RE.search(process.stdout):
+        _LOGGER.debug(
+            f"uv launch probe rejected {binary}: "
+            f"rc={process.returncode}, stdout={process.stdout!r}, stderr={process.stderr!r}"
+        )
+        return False
+    return True
+
+
+@cache
+def _check_uv_version(binary: Path) -> Version:
+    # Cached so ``upgrade-all`` over many venvs doesn't fork uv repeatedly.
+    process = subprocess.run([str(binary), "--version"], check=False, text=True, capture_output=True)
+    if (match := _VERSION_RE.search(process.stdout)) is None:
+        raise PipxError(
+            f"Could not parse uv version from {binary} "
+            f"(rc={process.returncode}, stdout={process.stdout!r}, stderr={process.stderr!r})."
+        )
+    try:
+        version = Version(match.group(1))
+    except InvalidVersion as exc:
+        raise PipxError(f"Unrecognized uv version {match.group(1)!r}.") from exc
+    if version < _MIN_UV_VERSION:
+        raise PipxError(
+            f"pipx needs uv>={_MIN_UV_VERSION}, but {binary} reports {version}.\n"
+            "Upgrade uv (`uv self update` or reinstall pipx[uv]), or run with `--backend pip` to bypass."
+        )
+    return version
+
+
+def _strip_pip_quiet_flags(pip_args: list[str]) -> list[str]:
+    return [arg for arg in pip_args if arg not in ("-q", "-qq", "--quiet")]
+
+
+__all__ = [
+    "UvBackend",
+    "find_uv_binary",
+    "resolve_uv_binary",
+]

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -9,6 +9,7 @@ import time
 from pathlib import Path
 from shutil import which
 from tempfile import TemporaryDirectory
+from typing import Final
 
 import userpath  # type: ignore[import-not-found]
 from packaging.utils import canonicalize_name
@@ -22,7 +23,7 @@ from pipx.pipx_metadata_file import PackageInfo
 from pipx.util import PipxError, mkdir, pipx_wrap, rmdir, safe_unlink
 from pipx.venv import Venv
 
-logger = logging.getLogger(__name__)
+_LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
 
 class VenvProblems:
@@ -110,7 +111,7 @@ def _copy_package_resource(dest_dir: Path, path: Path, suffix: str = "") -> None
     if dest.exists():
         if filecmp.cmp(dest, src, shallow=False):
             return
-        logger.warning(f"{hazard}  Overwriting file {dest!s} with {src!s}")
+        _LOGGER.warning(f"{hazard}  Overwriting file {dest!s} with {src!s}")
         safe_unlink(dest)
     if src.exists():
         shutil.copy(src, dest)
@@ -131,7 +132,7 @@ def _symlink_package_resource(
         mkdir(symlink_path.parent)
 
     if force:
-        logger.info(f"Force is true. Removing {symlink_path!s}.")
+        _LOGGER.info(f"Force is true. Removing {symlink_path!s}.")
         try:
             symlink_path.unlink()
         except (FileNotFoundError, RuntimeError):
@@ -143,9 +144,9 @@ def _symlink_package_resource(
     is_symlink = symlink_path.is_symlink()
     if exists:
         if symlink_path.samefile(path):
-            logger.info(f"Same path {symlink_path!s} and {path!s}")
+            _LOGGER.info(f"Same path {symlink_path!s} and {path!s}")
         else:
-            logger.warning(
+            _LOGGER.warning(
                 pipx_wrap(
                     f"""
                     {hazard}  File exists at {symlink_path!s} and points
@@ -157,7 +158,7 @@ def _symlink_package_resource(
             )
         return
     if is_symlink and not exists:
-        logger.info(f"Removing existing symlink {symlink_path!s} since it pointed non-existent location")
+        _LOGGER.info(f"Removing existing symlink {symlink_path!s} since it pointed non-existent location")
         symlink_path.unlink()
 
     if executable:
@@ -167,7 +168,7 @@ def _symlink_package_resource(
     symlink_path.symlink_to(path)
 
     if executable and existing_executable_on_path:
-        logger.warning(
+        _LOGGER.warning(
             pipx_wrap(
                 f"""
                 {hazard}  Note: {name_suffixed} was already on your
@@ -364,7 +365,15 @@ def _get_list_output(
     return "\n".join(output)
 
 
-def package_name_from_spec(package_spec: str, python: str, *, pip_args: list[str], verbose: bool) -> str:
+def package_name_from_spec(
+    package_spec: str,
+    python: str,
+    *,
+    pip_args: list[str],
+    verbose: bool,
+    backend: str | None = None,
+    env_backend: str | None = None,
+) -> str:
     start_time = time.time()
 
     # shortcut if valid PyPI name
@@ -373,19 +382,19 @@ def package_name_from_spec(package_spec: str, python: str, *, pip_args: list[str
         # NOTE: if pypi name and installed package name differ, this means pipx
         #       will use the pypi name
         package_name = pypi_name
-        logger.info(f"Determined package name: {package_name}")
-        logger.info(f"Package name determined in {time.time() - start_time:.1f}s")
+        _LOGGER.info(f"Determined package name: {package_name}")
+        _LOGGER.info(f"Package name determined in {time.time() - start_time:.1f}s")
         return package_name
 
     # check syntax and clean up spec and pip_args
     (package_spec, pip_args) = parse_specifier_for_install(package_spec, pip_args)
 
     with tempfile.TemporaryDirectory() as temp_venv_dir:
-        venv = Venv(Path(temp_venv_dir), python=python, verbose=verbose)
+        venv = Venv(Path(temp_venv_dir), python=python, verbose=verbose, backend=backend, env_backend=env_backend)
         venv.create_venv(venv_args=[], pip_args=[])
         package_name = venv.install_package_no_deps(package_or_url=package_spec, pip_args=pip_args)
 
-    logger.info(f"Package name determined in {time.time() - start_time:.1f}s")
+    _LOGGER.info(f"Package name determined in {time.time() - start_time:.1f}s")
     return package_name
 
 
@@ -471,7 +480,7 @@ def run_post_install_actions(
 
 def warn_if_not_on_path(local_bin_dir: Path) -> None:
     if not userpath.in_current_path(str(local_bin_dir)):
-        logger.warning(
+        _LOGGER.warning(
             pipx_wrap(
                 f"""
                 {hazard}  Note: '{local_bin_dir}' is not on your PATH
@@ -490,3 +499,17 @@ def add_suffix(name: str, suffix: str) -> str:
 
     app = Path(name)
     return f"{app.stem}{suffix}{app.suffix}"
+
+
+__all__ = [
+    "VenvProblems",
+    "add_suffix",
+    "can_symlink",
+    "expose_resources_globally",
+    "get_exposed_man_paths_for_package",
+    "get_exposed_paths_for_package",
+    "get_venv_summary",
+    "package_name_from_spec",
+    "run_post_install_actions",
+    "venv_health_check",
+]

--- a/src/pipx/commands/environment.py
+++ b/src/pipx/commands/environment.py
@@ -1,6 +1,7 @@
 import os
 
 from pipx import paths
+from pipx.backends import env_default_backend, find_uv_binary, resolve_backend_name
 from pipx.constants import EXIT_CODE_OK, ExitCode
 from pipx.emojis import EMOJI_SUPPORT
 from pipx.interpreter import DEFAULT_PYTHON
@@ -15,6 +16,7 @@ ENVIRONMENT_VARIABLES = [
     "PIPX_GLOBAL_MAN_DIR",
     "PIPX_SHARED_LIBS",
     "PIPX_DEFAULT_PYTHON",
+    "PIPX_DEFAULT_BACKEND",
     "PIPX_FETCH_MISSING_PYTHON",
     "PIPX_FETCH_PYTHON",
     "PIPX_USE_EMOJI",
@@ -26,12 +28,18 @@ DERIVED_ENVIRONMENT_VARIABLES = [
     "PIPX_TRASH_DIR",
     "PIPX_VENV_CACHEDIR",
     "PIPX_STANDALONE_PYTHON_CACHEDIR",
+    "PIPX_RESOLVED_BACKEND",
+    "PIPX_BACKEND_SOURCE",
+    "PIPX_UV_BINARY",
+    "UV_CACHE_DIR",
 ]
 ENVIRONMENT_VALUE_CHOICES = ENVIRONMENT_VARIABLES + DERIVED_ENVIRONMENT_VARIABLES
 
 
 def environment(value: str) -> ExitCode:
     """Print a list of environment variables and paths used by pipx"""
+    resolved_backend, backend_source = resolve_backend_name(env_value=env_default_backend())
+    uv_binary, _uv_source = find_uv_binary()
     derived_values = {
         "PIPX_HOME": paths.ctx.home,
         "PIPX_BIN_DIR": paths.ctx.bin_dir,
@@ -43,6 +51,10 @@ def environment(value: str) -> ExitCode:
         "PIPX_VENV_CACHEDIR": paths.ctx.venv_cache,
         "PIPX_STANDALONE_PYTHON_CACHEDIR": paths.ctx.standalone_python_cachedir,
         "PIPX_DEFAULT_PYTHON": DEFAULT_PYTHON,
+        "PIPX_RESOLVED_BACKEND": resolved_backend,
+        "PIPX_BACKEND_SOURCE": backend_source,
+        "PIPX_UV_BINARY": str(uv_binary) if uv_binary else "",
+        "UV_CACHE_DIR": os.environ.get("UV_CACHE_DIR", ""),
         "PIPX_USE_EMOJI": str(EMOJI_SUPPORT).lower(),
         "PIPX_HOME_ALLOW_SPACE": str(paths.ctx.allow_spaces_in_home_path).lower(),
     }

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -4,8 +4,12 @@ import re
 import sys
 from collections.abc import Generator, Iterable
 from pathlib import Path
+from typing import Final
+
+from packaging.utils import canonicalize_name
 
 from pipx import paths
+from pipx.backends import assert_not_pip_under_uv
 from pipx.colors import bold
 from pipx.commands.common import package_name_from_spec, run_post_install_actions
 from pipx.constants import EXIT_CODE_INJECT_ERROR, EXIT_CODE_OK, ExitCode
@@ -13,9 +17,9 @@ from pipx.emojis import hazard, stars
 from pipx.util import PipxError, pipx_wrap
 from pipx.venv import Venv
 
-logger = logging.getLogger(__name__)
+_LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
-COMMENT_RE = re.compile(r"(^|\s+)#.*$")
+_COMMENT_RE: Final[re.Pattern[str]] = re.compile(r"(^|\s+)#.*$")
 
 
 def inject_dep(
@@ -29,8 +33,10 @@ def inject_dep(
     include_dependencies: bool,
     force: bool,
     suffix: bool = False,
+    backend: str | None = None,
+    env_backend: str | None = None,
 ) -> bool:
-    logger.debug("Injecting package %s", package_spec)
+    _LOGGER.debug("Injecting package %s", package_spec)
 
     if not venv_dir.exists() or next(venv_dir.iterdir(), None) is None:
         raise PipxError(
@@ -41,7 +47,7 @@ def inject_dep(
             """
         )
 
-    venv = Venv(venv_dir, verbose=verbose)
+    venv = Venv(venv_dir, verbose=verbose, backend=backend, env_backend=env_backend)
     venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
 
     if not venv.package_metadata:
@@ -62,10 +68,16 @@ def inject_dep(
             os.fspath(venv.python_path),
             pip_args=pip_args,
             verbose=verbose,
+            backend=venv.backend_name,
+            env_backend=env_backend,
         )
 
+    # Mirrors the install-side guard: dropping pip into a uv venv works for
+    # ``pipx run`` but breaks anyone reaching for the venv's missing pip.
+    assert_not_pip_under_uv(canonicalize_name(package_name), venv.backend_name)
+
     if not force and venv.has_package(package_name):
-        logger.info("Package %s has already been injected", package_name)
+        _LOGGER.info("Package %s has already been injected", package_name)
         print(
             pipx_wrap(
                 f"""
@@ -119,6 +131,8 @@ def inject(
     include_dependencies: bool,
     force: bool,
     suffix: bool = False,
+    backend: str | None = None,
+    env_backend: str | None = None,
 ) -> ExitCode:
     """Returns pipx exit code."""
     # Combined collection of package specifications
@@ -131,23 +145,25 @@ def inject(
 
     if not packages:
         raise PipxError("No packages have been specified.")
-    logger.info("Injecting packages: %r", packages)
+    _LOGGER.info("Injecting packages: %r", packages)
 
     # Inject packages
     if not include_apps and include_dependencies:
         include_apps = True
     all_success = True
-    for dep in packages:
+    for dependency in packages:
         all_success &= inject_dep(
             venv_dir,
             package_name=None,
-            package_spec=dep,
+            package_spec=dependency,
             pip_args=pip_args,
             verbose=verbose,
             include_apps=include_apps,
             include_dependencies=include_dependencies,
             force=force,
             suffix=suffix,
+            backend=backend,
+            env_backend=env_backend,
         )
 
     # Any failure to install will raise PipxError, otherwise success
@@ -164,5 +180,12 @@ def parse_requirements(filename: str | os.PathLike) -> Generator[str, None, None
     with open(filename) as f:
         for line in f:
             # Strip comments and filter empty lines
-            if pkgspec := COMMENT_RE.sub("", line).strip():
+            if pkgspec := _COMMENT_RE.sub("", line).strip():
                 yield pkgspec
+
+
+__all__ = [
+    "inject",
+    "inject_dep",
+    "parse_requirements",
+]

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -3,7 +3,10 @@ import sys
 from collections.abc import Iterator
 from pathlib import Path
 
+from packaging.utils import canonicalize_name
+
 from pipx import commands, paths
+from pipx.backends import PIP
 from pipx.commands.common import package_name_from_spec, run_post_install_actions
 from pipx.constants import (
     EXIT_CODE_INSTALL_VENV_EXISTS,
@@ -12,7 +15,7 @@ from pipx.constants import (
 )
 from pipx.emojis import sleep
 from pipx.interpreter import DEFAULT_PYTHON
-from pipx.pipx_metadata_file import PackageInfo, PipxMetadata, _json_decoder_object_hook
+from pipx.pipx_metadata_file import PackageInfo, PipxMetadata, load_spec_file
 from pipx.util import PipxError, pipx_wrap
 from pipx.venv import Venv, VenvContainer
 
@@ -33,7 +36,9 @@ def install(
     include_dependencies: bool,
     preinstall_packages: list[str] | None,
     suffix: str = "",
-    python_flag_passed=False,
+    python_flag_passed: bool = False,
+    backend: str | None = None,
+    env_backend: str | None = None,
 ) -> ExitCode:
     """Returns pipx exit code."""
     # package_spec is anything pip-installable, including package_name, vcs spec,
@@ -44,7 +49,14 @@ def install(
     package_names = package_names or []
     if len(package_names) != len(package_specs):
         package_names = [
-            package_name_from_spec(package_spec, python, pip_args=pip_args, verbose=verbose)
+            package_name_from_spec(
+                package_spec,
+                python,
+                pip_args=pip_args,
+                verbose=verbose,
+                backend=backend,
+                env_backend=env_backend,
+            )
             for package_spec in package_specs
         ]
 
@@ -58,7 +70,21 @@ def install(
         except StopIteration:
             exists = False
 
-        venv = Venv(venv_dir, python=python, verbose=verbose)
+        # ``pipx install pip`` always uses pip (uv venvs ship no pip). Override
+        # only the implicit env path; ``--backend uv`` still falls through to
+        # ``assert_not_pip_under_uv`` so an explicit conflict fails loudly.
+        install_backend, install_env_backend = backend, env_backend
+        if canonicalize_name(package_name) == "pip":
+            install_backend = backend or PIP
+            install_env_backend = None
+
+        venv = Venv(
+            venv_dir,
+            python=python,
+            verbose=verbose,
+            backend=install_backend,
+            env_backend=install_env_backend,
+        )
         venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
         if exists:
             if not reinstall and force and python_flag_passed:
@@ -94,11 +120,10 @@ def install(
                 continue
 
         try:
-            # Enable installing shared library `pip` with `pipx`
-            override_shared = package_name == "pip"
+            override_shared = canonicalize_name(package_name) == "pip"
             venv.create_venv(venv_args, pip_args, override_shared)
-            for dep in preinstall_packages or []:
-                venv.upgrade_package_no_metadata(dep, [])
+            for dependency in preinstall_packages or []:
+                venv.upgrade_package_no_metadata(dependency, [])
             venv.install_package(
                 package_name=package_name,
                 package_or_url=package_spec,
@@ -130,26 +155,22 @@ def install(
 
 
 def extract_venv_metadata(spec_metadata_file: Path) -> Iterator[PipxMetadata]:
-    """Extract venv metadata from spec metadata file."""
-    with open(spec_metadata_file) as spec_metadata_fh:
-        try:
-            spec_metadata_dict = json.load(spec_metadata_fh, object_hook=_json_decoder_object_hook)
-        except json.decoder.JSONDecodeError as exc:
-            raise PipxError("The spec metadata file is an invalid JSON file.") from exc
+    try:
+        spec = load_spec_file(spec_metadata_file)
+    except json.decoder.JSONDecodeError as exc:
+        raise PipxError("The spec metadata file is an invalid JSON file.") from exc
 
-        if not ("venvs" in spec_metadata_dict and len(spec_metadata_dict["venvs"])):
-            raise PipxError("No packages found in the spec metadata file.")
+    venvs_metadata_dict = spec.get("venvs")
+    if not venvs_metadata_dict:
+        raise PipxError("No packages found in the spec metadata file.")
+    if not isinstance(venvs_metadata_dict, dict):
+        raise PipxError("The spec metadata file is invalid.")
 
-        venvs_metadata_dict = spec_metadata_dict["venvs"]
-
-        if not isinstance(venvs_metadata_dict, dict):
-            raise PipxError("The spec metadata file is invalid.")
-
-        for package_path_name in venvs_metadata_dict:
-            venv_dir = paths.ctx.venvs.joinpath(package_path_name)
-            venv_metadata = PipxMetadata(venv_dir, read=False)
-            venv_metadata.from_dict(venvs_metadata_dict[package_path_name]["metadata"])
-            yield venv_metadata
+    for package_path_name, entry in venvs_metadata_dict.items():
+        venv_dir = paths.ctx.venvs.joinpath(package_path_name)
+        venv_metadata = PipxMetadata(venv_dir, read=False)
+        venv_metadata.from_dict(entry["metadata"])
+        yield venv_metadata
 
 
 def generate_package_spec(package_info: PackageInfo) -> str:
@@ -191,6 +212,8 @@ def install_all(
     verbose: bool,
     *,
     force: bool,
+    backend: str | None = None,
+    env_backend: str | None = None,
 ) -> ExitCode:
     """Return pipx exit code."""
     venv_container = VenvContainer(paths.ctx.venvs)
@@ -217,6 +240,8 @@ def install_all(
                 include_dependencies=main_package.include_dependencies,
                 preinstall_packages=[],
                 suffix=main_package.suffix,
+                backend=backend or venv_metadata.backend,
+                env_backend=env_backend,
             )
 
             # Install the injected packages
@@ -243,3 +268,12 @@ def install_all(
         raise PipxError(f"The following package(s) failed to install: {', '.join(failed)}")
     # Any failure to install will raise PipxError, otherwise success
     return EXIT_CODE_OK
+
+
+__all__ = [
+    "extract_venv_metadata",
+    "generate_package_spec",
+    "get_python_interpreter",
+    "install",
+    "install_all",
+]

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -27,6 +27,8 @@ def reinstall(
     verbose: bool,
     force_reinstall_shared_libs: bool = False,
     python_flag_passed: bool = False,
+    backend: str | None = None,
+    env_backend: str | None = None,
 ) -> ExitCode:
     """Returns pipx exit code."""
     if not venv_dir.exists():
@@ -44,7 +46,7 @@ def reinstall(
         )
         return EXIT_CODE_REINSTALL_INVALID_PYTHON
 
-    venv = Venv(venv_dir, verbose=verbose)
+    venv = Venv(venv_dir, verbose=verbose, backend=backend, env_backend=env_backend)
     venv.check_upgrade_shared_libs(
         pip_args=venv.pipx_metadata.main_package.pip_args, verbose=verbose, force_upgrade=force_reinstall_shared_libs
     )
@@ -79,6 +81,8 @@ def reinstall(
         preinstall_packages=[],
         suffix=venv.pipx_metadata.main_package.suffix,
         python_flag_passed=python_flag_passed,
+        backend=backend or venv.pipx_metadata.backend,
+        env_backend=env_backend,
     )
 
     # now install injected packages
@@ -96,6 +100,8 @@ def reinstall(
             include_apps=injected_package.include_apps,
             include_dependencies=injected_package.include_dependencies,
             force=True,
+            backend=backend or venv.pipx_metadata.backend,
+            env_backend=env_backend,
         )
 
     # Any failure to install will raise PipxError, otherwise success
@@ -111,6 +117,8 @@ def reinstall_all(
     *,
     skip: Sequence[str],
     python_flag_passed: bool = False,
+    backend: str | None = None,
+    env_backend: str | None = None,
 ) -> ExitCode:
     """Returns pipx exit code."""
     failed: list[str] = []
@@ -132,6 +140,8 @@ def reinstall_all(
                 verbose=verbose,
                 force_reinstall_shared_libs=first_reinstall,
                 python_flag_passed=python_flag_passed,
+                backend=backend,
+                env_backend=env_backend,
             )
         except PipxError as e:
             print(e, file=sys.stderr)
@@ -145,3 +155,9 @@ def reinstall_all(
         raise PipxError(f"The following package(s) failed to reinstall: {', '.join(failed)}")
     # Any failure to install will raise PipxError, otherwise success
     return EXIT_CODE_OK
+
+
+__all__ = [
+    "reinstall",
+    "reinstall_all",
+]

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -8,13 +8,15 @@ import urllib.parse
 import urllib.request
 from pathlib import Path
 from shutil import which
-from typing import NoReturn
+from typing import Final, NoReturn
 
 from packaging.requirements import InvalidRequirement, Requirement
 
 from pipx import paths
+from pipx.backends import UV, resolve_backend_name
 from pipx.commands.common import package_name_from_spec
 from pipx.commands.inject import inject_dep
+from pipx.commands.run_uv import run_script_via_uv_run, run_via_uv_tool_run
 from pipx.constants import TEMP_VENV_EXPIRATION_THRESHOLD_DAYS, WINDOWS
 from pipx.emojis import hazard
 from pipx.util import (
@@ -32,12 +34,11 @@ if sys.version_info < (3, 11):
 else:
     import tomllib
 
-logger = logging.getLogger(__name__)
+_LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
+_VENV_EXPIRED_FILENAME: Final[str] = "pipx_expired_venv"
 
-VENV_EXPIRED_FILENAME = "pipx_expired_venv"
-
-APP_NOT_FOUND_ERROR_MESSAGE = """\
+_APP_NOT_FOUND_ERROR_MESSAGE: Final[str] = """\
 '{app}' executable script not found in package '{package_name}'.
 Available executable scripts:
     {app_lines}"""
@@ -67,7 +68,7 @@ def maybe_script_content(app: str, is_path: bool) -> str | Path | None:
                 end with '.py'. To run from an SVN, try pipx --spec URL BINARY
                 """
             )
-        logger.info("Detected url. Downloading and executing as a Python file.")
+        _LOGGER.info("Detected url. Downloading and executing as a Python file.")
 
         return _http_get_request(app)
 
@@ -83,8 +84,51 @@ def run_script(
     venv_args: list[str],
     verbose: bool,
     use_cache: bool,
+    *,
+    backend: str | None = None,
+    env_backend: str | None = None,
+    resolved_backend: str | None = None,
+    script_source: Path | None = None,
+    dependencies: list[str] | None = None,
 ) -> NoReturn:
     requirements = _get_requirements_from_script(content)
+
+    if dependencies and not requirements:
+        # Plain scripts have nowhere to record extra requirements; the pip path
+        # silently dropped ``--with`` here, but a clear error is better.
+        raise PipxError(
+            "--with packages can only be applied to scripts with PEP 723 inline metadata "
+            "(`# /// script` block). Add the dependencies to the script's metadata or run "
+            "via `pipx run --spec`."
+        )
+
+    if resolved_backend == UV and requirements is not None:
+        if script_source is not None:
+            run_script_via_uv_run(
+                script_path=script_source,
+                app_args=app_args,
+                python=python,
+                pip_args=pip_args,
+                venv_args=venv_args,
+                use_cache=use_cache,
+                verbose=verbose,
+                dependencies=dependencies,
+            )
+        # URL / named-pipe content has no on-disk path for ``uv run --script``;
+        # warn so users on ``--backend uv`` notice they lose uv's cache and
+        # Python-managing semantics for this run.
+        _LOGGER.warning(
+            pipx_wrap(
+                f"""
+                {hazard}  Script content is not a local file; building a
+                pipx-managed venv via the uv backend instead of `uv run
+                --script`. The uv cache and uv-managed Python features
+                will not apply to this run.
+                """,
+                subsequent_indent=" " * 4,
+            )
+        )
+
     if not requirements:
         python_path = Path(python)
     else:
@@ -95,13 +139,13 @@ def run_script(
         # managed. The requirements are normalised (in
         # _get_requirements_from_script), so that irrelevant differences in
         # whitespace, and similar, don't prevent environment sharing.
-        venv_dir = _get_temporary_venv_path(requirements, python, pip_args, venv_args)
-        venv = Venv(venv_dir)
+        venv_dir = _get_temporary_venv_path(requirements, python, pip_args, venv_args, resolved_backend or "pip")
+        venv = Venv(venv_dir, backend=backend, env_backend=env_backend)
         _prepare_venv_cache(venv, None, use_cache)
         if venv_dir.exists():
-            logger.info(f"Reusing cached venv {venv_dir}")
+            _LOGGER.info(f"Reusing cached venv {venv_dir}")
         else:
-            venv = Venv(venv_dir, python=python, verbose=verbose)
+            venv = Venv(venv_dir, python=python, verbose=verbose, backend=backend, env_backend=env_backend)
             venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
             venv.create_venv(venv_args, pip_args)
             try:
@@ -110,7 +154,7 @@ def run_script(
                 # Package installation failed, so mark the cache as expired.
                 # This ensures an attempt is made to re-install requirements
                 # when `pipx run` is next executed, rather than just failing.
-                (venv_dir / VENV_EXPIRED_FILENAME).touch()
+                (venv_dir / _VENV_EXPIRED_FILENAME).touch()
                 raise
         python_path = venv.python_path
 
@@ -131,9 +175,13 @@ def run_package(
     pypackages: bool,
     verbose: bool,
     use_cache: bool,
+    *,
+    backend: str | None = None,
+    env_backend: str | None = None,
+    resolved_backend: str | None = None,
 ) -> NoReturn:
     if which(app):
-        logger.warning(
+        _LOGGER.warning(
             pipx_wrap(
                 f"""
                 {hazard}  {app} is already on your PATH and installed at
@@ -145,13 +193,13 @@ def run_package(
 
     if WINDOWS:
         app_filename = f"{app}.exe"
-        logger.info(f"Assuming app is {app_filename!r} (Windows only)")
+        _LOGGER.info(f"Assuming app is {app_filename!r} (Windows only)")
     else:
         app_filename = app
 
     pypackage_bin_path = get_pypackage_bin_path(app)
     if pypackage_bin_path.exists():
-        logger.info(f"Using app in local __pypackages__ directory at '{pypackage_bin_path}'")
+        _LOGGER.info(f"Using app in local __pypackages__ directory at '{pypackage_bin_path}'")
         run_pypackage_bin(pypackage_bin_path, app_args)
     if pypackages:
         raise PipxError(
@@ -162,16 +210,16 @@ def run_package(
             """
         )
 
-    venv_dir = _get_temporary_venv_path([package_or_url], python, pip_args, venv_args)
+    venv_dir = _get_temporary_venv_path([package_or_url], python, pip_args, venv_args, resolved_backend or "pip")
 
-    venv = Venv(venv_dir)
+    venv = Venv(venv_dir, backend=backend, env_backend=env_backend)
     bin_path = venv.bin_path / app_filename
     _prepare_venv_cache(venv, bin_path, use_cache)
 
     if venv.has_app(app, app_filename):
-        logger.info(f"Reusing cached venv {venv_dir}")
+        _LOGGER.info(f"Reusing cached venv {venv_dir}")
     else:
-        logger.info(f"venv location is {venv_dir}")
+        _LOGGER.info(f"venv location is {venv_dir}")
         venv, app, app_filename = _prepare_venv(
             Path(venv_dir),
             package_or_url,
@@ -182,18 +230,22 @@ def run_package(
             venv_args,
             use_cache,
             verbose,
+            backend=backend,
+            env_backend=env_backend,
         )
 
-    for dep in dependencies:
+    for dependency in dependencies:
         inject_dep(
             venv_dir=venv_dir,
             package_name=None,
-            package_spec=dep,
+            package_spec=dependency,
             pip_args=pip_args,
             verbose=verbose,
             include_apps=False,
             include_dependencies=False,
             force=False,
+            backend=backend,
+            env_backend=env_backend,
         )
     venv.run_app(app, app_filename, app_args)
 
@@ -210,6 +262,9 @@ def run(
     pypackages: bool,
     verbose: bool,
     use_cache: bool,
+    *,
+    backend: str | None = None,
+    env_backend: str | None = None,
 ) -> NoReturn:
     """Installs venv to temporary dir (or reuses cache), then runs app from
     package
@@ -223,9 +278,39 @@ def run(
         # we can't parse this as a package
         package_name = app
 
+    # ``resolved_backend`` only decides ROUTING (uv tool run vs Venv); cli/env
+    # stay separate when we hand off so the Venv's source-attribution stays right.
+    resolved_backend, _ = resolve_backend_name(cli_value=backend, env_value=env_backend)
+    use_uvx = resolved_backend == UV and not pypackages
+
     content = None if spec is not None else maybe_script_content(app, is_path)
     if content is not None:
-        run_script(content, app_args, python, pip_args, venv_args, verbose, use_cache)
+        run_script(
+            content,
+            app_args,
+            python,
+            pip_args,
+            venv_args,
+            verbose,
+            use_cache,
+            backend=backend,
+            env_backend=env_backend,
+            resolved_backend=resolved_backend,
+            script_source=Path(app) if isinstance(content, Path) else None,
+            dependencies=dependencies,
+        )
+    elif use_uvx:
+        run_via_uv_tool_run(
+            app=app,
+            package_or_url=spec if spec is not None else app,
+            dependencies=dependencies,
+            app_args=app_args,
+            python=python,
+            pip_args=pip_args,
+            venv_args=venv_args,
+            use_cache=use_cache,
+            verbose=verbose,
+        )
     else:
         package_or_url = spec if spec is not None else app
         run_package(
@@ -239,6 +324,9 @@ def run(
             pypackages,
             verbose,
             use_cache,
+            backend=backend,
+            env_backend=env_backend,
+            resolved_backend=resolved_backend,
         )
 
 
@@ -252,8 +340,11 @@ def _prepare_venv(
     venv_args: list[str],
     use_cache: bool,
     verbose: bool,
+    *,
+    backend: str | None = None,
+    env_backend: str | None = None,
 ) -> tuple[Venv, str, str]:
-    venv = Venv(venv_dir, python=python, verbose=verbose)
+    venv = Venv(venv_dir, python=python, verbose=verbose, backend=backend, env_backend=env_backend)
     venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
 
     if venv.pipx_metadata.main_package.package is not None:
@@ -282,13 +373,13 @@ def _prepare_venv(
             print(f"NOTE: running app {app!r} from {package_name!r}")
             if WINDOWS:
                 app_filename = f"{app}.exe"
-                logger.info(f"Assuming app is {app_filename!r} (Windows only)")
+                _LOGGER.info(f"Assuming app is {app_filename!r} (Windows only)")
             else:
                 app_filename = app
         else:
             all_apps = (f"{a} - usage: 'pipx run --spec {package_or_url} {a} [arguments?]'" for a in apps)
             raise PipxError(
-                APP_NOT_FOUND_ERROR_MESSAGE.format(
+                _APP_NOT_FOUND_ERROR_MESSAGE.format(
                     app=app,
                     package_name=package_name,
                     app_lines="\n    ".join(all_apps),
@@ -298,23 +389,30 @@ def _prepare_venv(
 
     if not use_cache:
         # Let future _remove_all_expired_venvs know to remove this
-        (venv_dir / VENV_EXPIRED_FILENAME).touch()
+        (venv_dir / _VENV_EXPIRED_FILENAME).touch()
 
     return venv, app, app_filename
 
 
-def _get_temporary_venv_path(requirements: list[str], python: str, pip_args: list[str], venv_args: list[str]) -> Path:
-    """Computes deterministic path using hashing function on arguments relevant
-    to virtual environment's end state. Arguments used should result in idempotent
-    virtual environment. (i.e. args passed to app aren't relevant, but args
-    passed to venv creation are.)
+def _get_temporary_venv_path(
+    requirements: list[str],
+    python: str,
+    pip_args: list[str],
+    venv_args: list[str],
+    backend: str,
+) -> Path:
+    """Hash venv-affecting inputs to a deterministic cache path.
+
+    ``backend`` is part of the key so pip- and uv-backed temp venvs for the
+    same package coexist instead of stomping on each other.
     """
-    m = hashlib.sha256()
-    m.update("".join(requirements).encode())
-    m.update(python.encode())
-    m.update("".join(pip_args).encode())
-    m.update("".join(venv_args).encode())
-    venv_folder_name = m.hexdigest()[:15]  # 15 chosen arbitrarily
+    digest = hashlib.sha256()
+    digest.update("".join(requirements).encode())
+    digest.update(python.encode())
+    digest.update("".join(pip_args).encode())
+    digest.update("".join(venv_args).encode())
+    digest.update(backend.encode())
+    venv_folder_name = digest.hexdigest()[:15]  # 15 chosen arbitrarily
     return Path(paths.ctx.venv_cache) / venv_folder_name
 
 
@@ -323,13 +421,13 @@ def _is_temporary_venv_expired(venv_dir: Path) -> bool:
     current_time_sec = time.mktime(datetime.datetime.now().timetuple())
     age = current_time_sec - created_time_sec
     expiration_threshold_sec = 60 * 60 * 24 * TEMP_VENV_EXPIRATION_THRESHOLD_DAYS
-    return age > expiration_threshold_sec or (venv_dir / VENV_EXPIRED_FILENAME).exists()
+    return age > expiration_threshold_sec or (venv_dir / _VENV_EXPIRED_FILENAME).exists()
 
 
 def _prepare_venv_cache(venv: Venv, bin_path: Path | None, use_cache: bool) -> None:
     venv_dir = venv.root
     if not use_cache and (bin_path is None or bin_path.exists()):
-        logger.info(f"Removing cached venv {venv_dir!s}")
+        _LOGGER.info(f"Removing cached venv {venv_dir!s}")
         rmdir(venv_dir)
     _remove_all_expired_venvs()
 
@@ -337,7 +435,7 @@ def _prepare_venv_cache(venv: Venv, bin_path: Path | None, use_cache: bool) -> N
 def _remove_all_expired_venvs() -> None:
     for venv_dir in Path(paths.ctx.venv_cache).iterdir():
         if _is_temporary_venv_expired(venv_dir):
-            logger.info(f"Removing expired venv {venv_dir!s}")
+            _LOGGER.info(f"Removing expired venv {venv_dir!s}")
             rmdir(venv_dir)
 
 
@@ -347,12 +445,19 @@ def _http_get_request(url: str) -> str:
         charset = res.headers.get_content_charset() or "utf-8"
         return res.read().decode(charset)
     except Exception as e:
-        logger.debug("Uncaught Exception:", exc_info=True)
+        _LOGGER.debug("Uncaught Exception:", exc_info=True)
         raise PipxError(str(e)) from e
 
 
-# This regex comes from the inline script metadata spec
-INLINE_SCRIPT_METADATA = re.compile(r"(?m)^# /// (?P<type>[a-zA-Z0-9-]+)$\s(?P<content>(^#(| .*)$\s)+)^# ///$")
+# Pattern from PEP 723 / inline script metadata spec.
+_INLINE_SCRIPT_METADATA: Final[re.Pattern[str]] = re.compile(
+    r"""
+    ^\#\ ///\ (?P<type>[a-zA-Z0-9-]+)$ \s   # opening fence: ``# /// <type>``
+    (?P<content> (^\#(|\ .*)$ \s)+ )        # body: lines starting with ``#`` or ``# ``
+    ^\#\ ///$                               # closing fence: ``# ///``
+    """,
+    re.VERBOSE | re.MULTILINE,
+)
 
 
 def _get_requirements_from_script(content: str | Path) -> list[str] | None:
@@ -368,12 +473,12 @@ def _get_requirements_from_script(content: str | Path) -> list[str] | None:
     # Windows is currently getting un-normalized line endings, so normalize
     content = content.replace("\r\n", "\n")
 
-    matches = [m for m in INLINE_SCRIPT_METADATA.finditer(content) if m.group("type") == name]
+    matches = [m for m in _INLINE_SCRIPT_METADATA.finditer(content) if m.group("type") == name]
 
     if not matches:
-        pyproject_matches = [m for m in INLINE_SCRIPT_METADATA.finditer(content) if m.group("type") == "pyproject"]
+        pyproject_matches = [m for m in _INLINE_SCRIPT_METADATA.finditer(content) if m.group("type") == "pyproject"]
         if pyproject_matches:
-            logger.error(
+            _LOGGER.error(
                 pipx_wrap(
                     f"""
                     {hazard}  Using old form of requirements table. Use updated PEP
@@ -398,13 +503,20 @@ def _get_requirements_from_script(content: str | Path) -> list[str] | None:
 
     requirements = []
     for requirement in pyproject.get("dependencies", []):
-        # Validate the requirement
         try:
-            req = Requirement(requirement)
-        except InvalidRequirement as e:
-            raise PipxError(f"Invalid requirement {requirement}: {e}") from e
+            parsed_requirement = Requirement(requirement)
+        except InvalidRequirement as exc:
+            raise PipxError(f"Invalid requirement {requirement}: {exc}") from exc
 
         # Use the normalised form of the requirement
-        requirements.append(str(req))
+        requirements.append(str(parsed_requirement))
 
     return requirements
+
+
+__all__ = [
+    "maybe_script_content",
+    "run",
+    "run_package",
+    "run_script",
+]

--- a/src/pipx/commands/run_uv.py
+++ b/src/pipx/commands/run_uv.py
@@ -1,0 +1,152 @@
+"""``pipx run`` delegation under the uv backend, kept out of ``run.py`` so the
+flag-translation surface doesn't bury the pip flow."""
+
+from __future__ import annotations
+
+import logging
+from shutil import which
+from typing import TYPE_CHECKING, Final, NoReturn
+
+from pipx.backends.uv import resolve_uv_binary
+from pipx.emojis import hazard
+from pipx.util import PipxError, exec_app, pipx_wrap
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
+
+# Pip flags translatable to ``uv tool run`` / ``uv run``; anything else errors.
+_UV_TRANSLATABLE_VALUE_FLAGS: Final[frozenset[str]] = frozenset(
+    {"--index-url", "-i", "--extra-index-url", "--find-links", "-f", "--no-binary", "--only-binary", "--trusted-host"}
+)
+_UV_TRANSLATABLE_BOOL_FLAGS: Final[dict[str, str]] = {
+    "--pre": "--prerelease=allow",
+    "--no-deps": "--no-deps",
+    "--no-cache-dir": "--no-cache",
+    "--upgrade": "--upgrade",
+    "-U": "--upgrade",
+}
+
+
+def _reject_venv_args(venv_args: list[str]) -> None:
+    # uv builds its own venv internally; silently dropping ``--venv-args``
+    # (e.g. ``--system-site-packages``) would diverge from the pip path.
+    if venv_args:
+        raise PipxError(
+            f"--venv-args ({' '.join(venv_args)}) is not supported by `pipx run --backend uv`.\n"
+            "Use `pipx run --backend pip` if those flags are required, or drop them."
+        )
+
+
+def run_via_uv_tool_run(
+    *,
+    app: str,
+    package_or_url: str,
+    dependencies: list[str],
+    app_args: list[str],
+    python: str,
+    pip_args: list[str],
+    venv_args: list[str],
+    use_cache: bool,
+    verbose: bool,
+) -> NoReturn:
+    _reject_venv_args(venv_args)
+    if existing_app_path := which(app):
+        _LOGGER.warning(
+            pipx_wrap(
+                f"""
+                {hazard}  {app} is already on your PATH and installed at
+                {existing_app_path}. Downloading and running anyway.
+                """,
+                subsequent_indent=" " * 4,
+            )
+        )
+
+    cmd: list[str] = [str(resolve_uv_binary()), "tool", "run"]
+    if package_or_url and package_or_url != app:
+        cmd += ["--from", package_or_url]
+    if python:
+        cmd += ["--python", python]
+    for dependency in dependencies:
+        cmd += ["--with", dependency]
+    if not use_cache:
+        cmd.append("--no-cache")
+    if verbose:
+        cmd.append("--verbose")
+    cmd += translate_pip_args_for_uv(pip_args)
+    cmd.append(app)
+    cmd += app_args
+    exec_app(cmd)
+
+
+def run_script_via_uv_run(
+    *,
+    script_path: Path,
+    app_args: list[str],
+    python: str,
+    pip_args: list[str],
+    venv_args: list[str],
+    use_cache: bool,
+    verbose: bool,
+    dependencies: list[str] | None = None,
+) -> NoReturn:
+    _reject_venv_args(venv_args)
+    cmd: list[str] = [str(resolve_uv_binary()), "run", "--script"]
+    if python:
+        cmd += ["--python", python]
+    if not use_cache:
+        cmd.append("--no-cache")
+    if verbose:
+        cmd.append("--verbose")
+    for dependency in dependencies or []:
+        cmd += ["--with", dependency]
+    cmd += translate_pip_args_for_uv(pip_args)
+    cmd += [str(script_path), *app_args]
+    exec_app(cmd)
+
+
+def translate_pip_args_for_uv(pip_args: list[str]) -> list[str]:
+    """Translate ``pip_args`` for ``uv tool run`` / ``uv run --script``.
+
+    Strict on this boundary because ``uv tool run`` exposes a smaller flag
+    surface than ``uv pip install``; the install path stays permissive (it
+    forwards everything to uv) since over-rejecting valid uv pip flags would
+    be more painful than the asymmetry.
+    """
+    translated: list[str] = []
+    iterator = iter(pip_args)
+    for arg in iterator:
+        if arg in ("-q", "-qq", "--quiet"):
+            continue
+        if arg in ("--editable", "-e"):
+            raise PipxError(
+                "`--editable` is not supported by `pipx run --backend uv`.\n"
+                "Use `pipx run --backend pip` for editable installs."
+            )
+        if (translated_bool := _UV_TRANSLATABLE_BOOL_FLAGS.get(arg)) is not None:
+            translated.append(translated_bool)
+            continue
+        if arg in _UV_TRANSLATABLE_VALUE_FLAGS:
+            try:
+                value = next(iterator)
+            except StopIteration as exc:
+                raise PipxError(f"Missing value for {arg!r} in --pip-args.") from exc
+            translated.extend([arg, value])
+            continue
+        # Bool flags must not accept ``=value`` (caught ``--pre=foo`` slipping through).
+        if "=" in arg and arg.split("=", 1)[0] in _UV_TRANSLATABLE_VALUE_FLAGS:
+            translated.append(arg)
+            continue
+        raise PipxError(
+            f"--pip-args contains {arg!r}, which has no `uv tool run` equivalent.\n"
+            "Use `--backend pip` if you need pip-only flags."
+        )
+    return translated
+
+
+__all__ = [
+    "run_script_via_uv_run",
+    "run_via_uv_tool_run",
+    "translate_pip_args_for_uv",
+]

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -3,6 +3,7 @@ import os
 import sys
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Final
 
 from pipx import commands, paths
 from pipx.colors import bold, red
@@ -10,10 +11,11 @@ from pipx.commands.common import expose_resources_globally
 from pipx.constants import EXIT_CODE_OK, ExitCode
 from pipx.emojis import sleep
 from pipx.package_specifier import parse_specifier_for_upgrade
+from pipx.shared_libs import shared_libs
 from pipx.util import PipxError, pipx_wrap
 from pipx.venv import Venv, VenvContainer
 
-logger = logging.getLogger(__name__)
+_LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
 
 def _upgrade_package(
@@ -31,12 +33,12 @@ def _upgrade_package(
         raise PipxError(f"Internal Error: package {package_name} has corrupt pipx metadata.")
     elif package_metadata.pinned:
         if package_metadata.package != venv.main_package_name:
-            logger.warning(
+            _LOGGER.warning(
                 f"Not upgrading pinned package {package_metadata.package} in venv {venv.name}. "
                 f"Run `pipx unpin {venv.name}` to unpin it."
             )
         else:
-            logger.warning(f"Not upgrading pinned package {venv.name}. Run `pipx unpin {venv.name}` to unpin it.")
+            _LOGGER.warning(f"Not upgrading pinned package {venv.name}. Run `pipx unpin {venv.name}` to unpin it.")
         return 0
 
     package_or_url = parse_specifier_for_upgrade(package_metadata.package_or_url)
@@ -116,8 +118,16 @@ def _upgrade_venv(
     venv_args: list[str] | None = None,
     python: str | None = None,
     python_flag_passed: bool = False,
+    backend: str | None = None,
+    env_backend: str | None = None,
+    venv: Venv | None = None,
+    shared_libs_already_checked: bool = False,
 ) -> int:
-    """Return number of packages with changed versions."""
+    """Return number of packages whose versions changed.
+
+    ``upgrade-all`` passes ``venv`` and ``shared_libs_already_checked=True``
+    after its own pre-checks to avoid re-running them per venv.
+    """
     if not venv_dir.is_dir():
         if install:
             if venv_args is None:
@@ -137,6 +147,8 @@ def _upgrade_venv(
                 include_dependencies=False,
                 preinstall_packages=None,
                 python_flag_passed=python_flag_passed,
+                backend=backend,
+                env_backend=env_backend,
             )
             return 0
         else:
@@ -148,15 +160,17 @@ def _upgrade_venv(
             )
 
     if venv_args and not install:
-        logger.info("Ignoring " + ", ".join(venv_args) + " as not combined with --install")
+        _LOGGER.info(f"Ignoring {', '.join(venv_args)} as not combined with --install")
 
     if python and not install:
-        logger.info("Ignoring --python as not combined with --install")
+        _LOGGER.info("Ignoring --python as not combined with --install")
 
-    venv = Venv(venv_dir, verbose=verbose)
+    if venv is None:
+        venv = Venv(venv_dir, verbose=verbose, backend=backend, env_backend=env_backend)
     if not pip_args:
         pip_args = venv.pipx_metadata.main_package.pip_args
-    venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
+    if not shared_libs_already_checked:
+        venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
 
     if not venv.python_path.is_file():
         raise PipxError(
@@ -217,6 +231,8 @@ def upgrade(
     force: bool,
     install: bool,
     python_flag_passed: bool = False,
+    backend: str | None = None,
+    env_backend: str | None = None,
 ) -> ExitCode:
     """Return pipx exit code."""
 
@@ -232,6 +248,8 @@ def upgrade(
             venv_args=venv_args,
             python=python,
             python_flag_passed=python_flag_passed,
+            backend=backend,
+            env_backend=env_backend,
         )
 
     # Any error in upgrade will raise PipxError (e.g. from venv.upgrade_package())
@@ -247,16 +265,22 @@ def upgrade_all(
     skip: Sequence[str],
     force: bool,
     python_flag_passed: bool = False,
+    backend: str | None = None,
+    env_backend: str | None = None,
 ) -> ExitCode:
     """Return pipx exit code."""
     failed: list[str] = []
     upgraded: list[str] = []
 
     for venv_dir in venv_container.iter_venv_dirs():
-        venv = Venv(venv_dir, verbose=verbose)
-        venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
-        if venv_dir.name in skip or "--editable" in venv.pipx_metadata.main_package.pip_args:
+        # Cheap skip-list check first so we don't pay metadata read +
+        # cross-backend warning + shared-libs health check on excluded venvs.
+        if venv_dir.name in skip:
             continue
+        venv = Venv(venv_dir, verbose=verbose, backend=backend, env_backend=env_backend)
+        if "--editable" in venv.pipx_metadata.main_package.pip_args:
+            continue
+        venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
         try:
             versions_updated = _upgrade_venv(
                 venv_dir,
@@ -266,6 +290,10 @@ def upgrade_all(
                 upgrading_all=True,
                 force=force,
                 python_flag_passed=python_flag_passed,
+                backend=backend,
+                env_backend=env_backend,
+                venv=venv,
+                shared_libs_already_checked=True,
             )
             if versions_updated > 0:
                 upgraded.append(venv_dir.name)
@@ -284,9 +312,14 @@ def upgrade_shared(
     verbose: bool,
     pip_args: list[str],
 ) -> ExitCode:
-    """Return pipx exit code."""
-    from pipx.shared_libs import shared_libs  # noqa: PLC0415
-
+    # Always refreshes: the next pip-backed install needs a fresh shared-libs
+    # venv even when all currently-installed venvs are uv-backed.
     shared_libs.upgrade(verbose=verbose, pip_args=pip_args, raises=True)
-
     return EXIT_CODE_OK
+
+
+__all__ = [
+    "upgrade",
+    "upgrade_all",
+    "upgrade_shared",
+]

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -23,6 +23,7 @@ from packaging.utils import canonicalize_name
 
 from pipx import commands, constants, paths
 from pipx.animate import hide_cursor, show_cursor
+from pipx.backends import KNOWN_BACKENDS, UV, env_default_backend, get_backend, resolve_backend_name
 from pipx.colors import bold, green
 from pipx.commands.environment import ENVIRONMENT_VALUE_CHOICES, ENVIRONMENT_VARIABLES
 from pipx.constants import (
@@ -100,6 +101,7 @@ PIPX_DESCRIPTION += pipx_wrap(
       PIPX_MAN_DIR           Overrides location of manual pages installations. Manual pages are symlinked or copied here.
       PIPX_GLOBAL_MAN_DIR    Used instead of PIPX_MAN_DIR when the `--global` option is given.
       PIPX_DEFAULT_PYTHON    Overrides default python used for commands.
+      PIPX_DEFAULT_BACKEND   Overrides which backend (`pip` or `uv`) is used for new venvs.
       PIPX_USE_EMOJI         Overrides emoji behavior. Default value varies based on platform.
       PIPX_HOME_ALLOW_SPACE  Overrides default warning on spaces in the home path
     """,
@@ -211,6 +213,10 @@ def get_venv_args(parsed_args: dict[str, str]) -> list[str]:
     return venv_args
 
 
+def get_backend_arg(parsed_args: dict[str, str]) -> str | None:
+    return parsed_args.get("backend") or None
+
+
 def package_is_url(package: str, raise_error: bool = True) -> bool:
     url_parse_package = urllib.parse.urlparse(package)
     if url_parse_package.scheme and url_parse_package.netloc:
@@ -258,7 +264,7 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:
     spec: str | None = getattr(args, "spec", None)
     if "package" in args and spec is not None:
         if package_is_url(spec, raise_error=False) and "#egg=" not in spec:
-            spec = spec + f"#egg={args.package}"
+            spec = f"{spec}#egg={args.package}"
 
     python = DEFAULT_PYTHON
     python_flag_passed = False
@@ -271,6 +277,10 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:
             print(pipx_wrap(f"{hazard} {e}", subsequent_indent=" " * 4))
             return EXIT_CODE_SPECIFIED_PYTHON_EXECUTABLE_NOT_FOUND
 
+    cli_backend = get_backend_arg(vars(args))
+    env_backend = env_default_backend()
+    _validate_backend_available(cli_backend, env_backend)
+
     ctx = DispatchContext(
         verbose=bool(args.verbose) if "verbose" in args else False,
         pip_args=get_pip_args(vars(args)),
@@ -280,8 +290,23 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:
         python=python,
         python_flag_passed=python_flag_passed,
         spec=spec,
+        backend=cli_backend,
+        env_backend=env_backend,
     )
     return args.func(args, ctx)
+
+
+def _validate_backend_available(cli_backend: str | None, env_backend: str | None) -> None:
+    """Eagerly surface a missing uv when ``--backend uv`` was passed.
+
+    Env-source and auto-detect stay silent so diagnostic commands (which never
+    instantiate a backend) keep working, and so unrelated PATH ``uv`` doesn't
+    pay a ``uv --version`` subprocess on every command.
+    """
+    name, source = resolve_backend_name(cli_value=cli_backend, env_value=env_backend)
+    logger.info(f"Backend resolved to {name} (source: {source})")
+    if name == UV and source == "cli":
+        get_backend(name)
 
 
 @dataclass(frozen=True)
@@ -294,6 +319,15 @@ class DispatchContext:
     python: str
     python_flag_passed: bool
     spec: str | None
+    backend: str | None = None
+    env_backend: str | None = None
+
+    @property
+    def effective_backend(self) -> str | None:
+        # Use ``backend`` and ``env_backend`` separately when building a
+        # :class:`pipx.venv.Venv`; this only collapses them for code paths
+        # without metadata to consult.
+        return self.backend or self.env_backend
 
 
 def add_pip_venv_args(parser: argparse.ArgumentParser) -> None:
@@ -311,7 +345,25 @@ def add_pip_venv_args(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--pip-args",
-        help="Arbitrary pip arguments to pass directly to pip install/upgrade commands",
+        help=(
+            "Arbitrary pip arguments to pass directly to pip install/upgrade commands. "
+            "Under the uv backend a small subset is translated (--index-url, --extra-index-url, "
+            "--find-links, --pre); other flags raise an error so behaviour stays explicit."
+        ),
+    )
+
+
+def add_backend_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--backend",
+        choices=list(KNOWN_BACKENDS),
+        default=None,
+        help=(
+            "Backend used for creating venvs and managing packages. Defaults to "
+            "PIPX_DEFAULT_BACKEND when set, else 'uv' when uv is available "
+            "(via the `pipx[uv]` extra or on PATH), else 'pip'. Existing venvs "
+            "always honor their recorded backend unless this flag is given."
+        ),
     )
 
 
@@ -400,6 +452,7 @@ def _add_install(subparsers: argparse._SubParsersAction, shared_parser: argparse
         ),
     )
     add_pip_venv_args(p)
+    add_backend_arg(p)
     p.set_defaults(func=_cmd_install)
 
 
@@ -420,6 +473,8 @@ def _cmd_install(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
         preinstall_packages=args.preinstall,
         suffix=args.suffix,
         python_flag_passed=ctx.python_flag_passed,
+        backend=ctx.backend,
+        env_backend=ctx.env_backend,
     )
 
 
@@ -440,6 +495,7 @@ def _add_install_all(subparsers: argparse._SubParsersAction, shared_parser: argp
     )
     add_python_options(p)
     add_pip_venv_args(p)
+    add_backend_arg(p)
     p.set_defaults(func=_cmd_install_all)
 
 
@@ -453,6 +509,8 @@ def _cmd_install_all(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode
         ctx.venv_args,
         ctx.verbose,
         force=args.force,
+        backend=ctx.backend,
+        env_backend=ctx.env_backend,
     )
 
 
@@ -507,6 +565,7 @@ def _add_inject(subparsers, venv_completer: VenvCompleter, shared_parser: argpar
         action="store_true",
         help="Add the suffix (if given) of the Virtual Environment to the packages to inject",
     )
+    add_backend_arg(p)
     p.set_defaults(func=_cmd_inject)
 
 
@@ -521,6 +580,8 @@ def _cmd_inject(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
         include_dependencies=args.include_deps,
         force=args.force,
         suffix=args.with_suffix,
+        backend=ctx.backend,
+        env_backend=ctx.env_backend,
     )
 
 
@@ -629,6 +690,7 @@ def _add_upgrade(subparsers, venv_completer: VenvCompleter, shared_parser: argpa
         help="Install package spec if missing",
     )
     add_python_options(p)
+    add_backend_arg(p)
     p.set_defaults(func=_cmd_upgrade)
 
 
@@ -643,6 +705,8 @@ def _cmd_upgrade(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
         force=args.force,
         install=args.install,
         python_flag_passed=ctx.python_flag_passed,
+        backend=ctx.backend,
+        env_backend=ctx.env_backend,
     )
 
 
@@ -666,6 +730,7 @@ def _add_upgrade_all(subparsers: argparse._SubParsersAction, shared_parser: argp
         help="Modify existing virtual environment and files in PIPX_BIN_DIR and PIPX_MAN_DIR",
     )
     add_pip_venv_args(p)
+    add_backend_arg(p)
     p.set_defaults(func=_cmd_upgrade_all)
 
 
@@ -678,6 +743,8 @@ def _cmd_upgrade_all(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode
         force=args.force,
         pip_args=ctx.pip_args,
         python_flag_passed=ctx.python_flag_passed,
+        backend=ctx.backend,
+        env_backend=ctx.env_backend,
     )
 
 
@@ -746,6 +813,7 @@ def _add_reinstall(subparsers, venv_completer: VenvCompleter, shared_parser: arg
     )
     p.add_argument("package").completer = venv_completer
     add_python_options(p)
+    add_backend_arg(p)
     p.set_defaults(func=_cmd_reinstall)
 
 
@@ -757,6 +825,8 @@ def _cmd_reinstall(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
         python=ctx.python,
         verbose=ctx.verbose,
         python_flag_passed=ctx.python_flag_passed,
+        backend=ctx.backend,
+        env_backend=ctx.env_backend,
     )
 
 
@@ -780,6 +850,7 @@ def _add_reinstall_all(subparsers: argparse._SubParsersAction, shared_parser: ar
     )
     add_python_options(p)
     p.add_argument("--skip", nargs="+", default=[], help="skip these packages")
+    add_backend_arg(p)
     p.set_defaults(func=_cmd_reinstall_all)
 
 
@@ -792,6 +863,8 @@ def _cmd_reinstall_all(args: argparse.Namespace, ctx: DispatchContext) -> ExitCo
         ctx.verbose,
         skip=ctx.skip_list,
         python_flag_passed=ctx.python_flag_passed,
+        backend=ctx.backend,
+        env_backend=ctx.env_backend,
     )
 
 
@@ -916,6 +989,7 @@ def _add_run(subparsers: argparse._SubParsersAction, shared_parser: argparse.Arg
     p.add_argument("--spec", help=SPEC_HELP)
     add_python_options(p)
     add_pip_venv_args(p)
+    add_backend_arg(p)
     p.set_defaults(subparser=p, func=_cmd_run)
 
     # modify usage text to show required app argument
@@ -937,6 +1011,8 @@ def _cmd_run(args: argparse.Namespace, ctx: DispatchContext) -> NoReturn:
         args.pypackages,
         ctx.verbose,
         not args.no_cache,
+        backend=ctx.backend,
+        env_backend=ctx.env_backend,
     )
 
 

--- a/src/pipx/pipx_metadata_file.py
+++ b/src/pipx/pipx_metadata_file.py
@@ -2,15 +2,64 @@ import json
 import logging
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Final, TypedDict
 
+from pipx.backends._base import KNOWN_BACKENDS
 from pipx.emojis import hazard
 from pipx.util import PipxError, pipx_wrap
 
-logger = logging.getLogger(__name__)
+_LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
 
 PIPX_INFO_FILENAME = "pipx_metadata.json"
+
+
+class _RawPackageInfo(TypedDict, total=False):
+    """JSON-on-disk shape for :class:`PackageInfo`.
+
+    ``total=False`` because the legacy-metadata migration runs against dumps
+    from older pipx versions that lacked some keys.
+    """
+
+    package: str | None
+    package_or_url: str | None
+    pip_args: list[str]
+    include_dependencies: bool
+    include_apps: bool
+    apps: list[str]
+    app_paths: list[Path]
+    apps_of_dependencies: list[str]
+    app_paths_of_dependencies: dict[str, list[Path]]
+    package_version: str
+    man_pages: list[str]
+    man_paths: list[Path]
+    man_pages_of_dependencies: list[str]
+    man_paths_of_dependencies: dict[str, list[Path]]
+    suffix: str
+    pinned: bool
+
+
+class _RawMetadata(TypedDict, total=False):
+    """JSON-on-disk shape for ``pipx_metadata.json``."""
+
+    main_package: _RawPackageInfo
+    python_version: str | None
+    source_interpreter: Path | None
+    venv_args: list[str]
+    injected_packages: dict[str, _RawPackageInfo]
+    backend: str
+    pipx_metadata_version: str
+    pinned: bool
+
+
+class _RawSpecVenvEntry(TypedDict):
+    metadata: _RawMetadata
+
+
+class _RawSpecFile(TypedDict, total=False):
+    # Wire format produced by ``pipx list --json`` and consumed by ``install-all``.
+    venvs: dict[str, _RawSpecVenvEntry]
+    pipx_spec_version: str
 
 
 class JsonEncoderHandlesPath(json.JSONEncoder):
@@ -54,15 +103,13 @@ class PipxMetadata:
     # V0.3 -> Add man pages fields
     # V0.4 -> Add source interpreter
     # V0.5 -> Add pinned
-    __METADATA_VERSION__: str = "0.5"
+    # V0.6 -> Add backend (pip|uv)
+    __METADATA_VERSION__: str = "0.6"
 
     def __init__(self, venv_dir: Path, read: bool = True):
         self.venv_dir = venv_dir
-        # We init this instance with reasonable fallback defaults for all
-        #   members, EXCEPT for those we cannot know:
-        #       self.main_package.package=None
-        #       self.main_package.package_or_url=None
-        #       self.python_version=None
+        # Reasonable defaults for everything except the fields the caller
+        # populates from the install spec (package, package_or_url, python_version).
         self.main_package = PackageInfo(
             package=None,
             package_or_url=None,
@@ -83,55 +130,78 @@ class PipxMetadata:
         self.source_interpreter: Path | None = None
         self.venv_args: list[str] = []
         self.injected_packages: dict[str, PackageInfo] = {}
+        self.backend: str = "pip"
+        # ``None`` until ``read()`` succeeds; lets callers tell a fresh
+        # instance from one with authoritative on-disk values.
+        self.read_metadata_version: str | None = None
 
         if read:
             self.read()
 
     def to_dict(self) -> dict[str, Any]:
+        # Plain dict over _RawMetadata: asdict() returns dict[str, Any] and
+        # consumers serialise straight to JSON.
         return {
             "main_package": asdict(self.main_package),
             "python_version": self.python_version,
             "source_interpreter": self.source_interpreter,
             "venv_args": self.venv_args,
             "injected_packages": {name: asdict(data) for (name, data) in self.injected_packages.items()},
+            "backend": self.backend,
             "pipx_metadata_version": self.__METADATA_VERSION__,
         }
 
-    def _convert_legacy_metadata(self, metadata_dict: dict[str, Any]) -> dict[str, Any]:
-        if metadata_dict["pipx_metadata_version"] in (self.__METADATA_VERSION__):
+    def _convert_legacy_metadata(self, metadata_dict: _RawMetadata) -> _RawMetadata:
+        version = metadata_dict["pipx_metadata_version"]
+        if version in (self.__METADATA_VERSION__, "0.5"):
             pass
-        elif metadata_dict["pipx_metadata_version"] == "0.4":
+        elif version == "0.4":
             metadata_dict["pinned"] = False
-        elif metadata_dict["pipx_metadata_version"] in ("0.2", "0.3"):
+        elif version in ("0.2", "0.3"):
             metadata_dict["source_interpreter"] = None
-        elif metadata_dict["pipx_metadata_version"] == "0.1":
+        elif version == "0.1":
             main_package_data = metadata_dict["main_package"]
-            if main_package_data["package"] != self.venv_dir.name:
+            package_name = main_package_data["package"]
+            if package_name is not None and package_name != self.venv_dir.name:
                 # handle older suffixed packages gracefully
-                main_package_data["suffix"] = self.venv_dir.name.replace(main_package_data["package"], "")
+                main_package_data["suffix"] = self.venv_dir.name.replace(package_name, "")
             metadata_dict["source_interpreter"] = None
         else:
             raise PipxError(
                 f"""
-                {self.venv_dir.name}: Unknown metadata version
-                {metadata_dict["pipx_metadata_version"]}. Perhaps it was
-                installed with a later version of pipx.
+                {self.venv_dir.name}: Unknown metadata version {version}.
+                Perhaps it was installed with a later version of pipx.
                 """
             )
+        # ``backend`` is absent from any pre-0.6 dump; default once here.
+        metadata_dict.setdefault("backend", "pip")
         return metadata_dict
 
-    def from_dict(self, input_dict: dict[str, Any]) -> None:
+    def from_dict(self, input_dict: _RawMetadata) -> None:
         input_dict = self._convert_legacy_metadata(input_dict)
         self.main_package = PackageInfo(**input_dict["main_package"])
-        self.python_version = input_dict["python_version"]
-        self.source_interpreter = (
-            Path(input_dict["source_interpreter"]) if input_dict.get("source_interpreter") else None
-        )
-        self.venv_args = input_dict["venv_args"]
+        self.python_version = input_dict.get("python_version")
+        source_interpreter_raw = input_dict.get("source_interpreter")
+        self.source_interpreter = Path(source_interpreter_raw) if source_interpreter_raw else None
+        self.venv_args = input_dict.get("venv_args", [])
         self.injected_packages = {
             f"{name}{data.get('suffix', '')}": PackageInfo(**data)
-            for (name, data) in input_dict["injected_packages"].items()
+            for (name, data) in input_dict.get("injected_packages", {}).items()
         }
+        # Permissive: an unknown ``backend`` (manual edit, post-downgrade
+        # dump from a newer pipx) falls back to pip with a warning so
+        # ``pipx list`` / ``pipx uninstall`` keep working. Strict validation
+        # still fires on write via :func:`pipx.backends.resolve_backend_name`.
+        recorded_backend = input_dict.get("backend") or "pip"
+        if recorded_backend not in KNOWN_BACKENDS:
+            _LOGGER.warning(
+                "%s: ignoring unknown recorded backend %r; treating as 'pip'.",
+                self.venv_dir.name,
+                recorded_backend,
+            )
+            recorded_backend = "pip"
+        self.backend = recorded_backend
+        self.read_metadata_version = input_dict.get("pipx_metadata_version")
 
     def _validate_before_write(self) -> None:
         if (
@@ -139,7 +209,7 @@ class PipxMetadata:
             or self.main_package.package_or_url is None
             or not self.main_package.include_apps
         ):
-            logger.debug(f"PipxMetadata corrupt:\n{self.to_dict()}")
+            _LOGGER.debug(f"PipxMetadata corrupt:\n{self.to_dict()}")
             raise PipxError("Internal Error: PipxMetadata is corrupt, cannot write.")
 
     def write(self) -> None:
@@ -154,7 +224,7 @@ class PipxMetadata:
                     cls=JsonEncoderHandlesPath,
                 )
         except OSError:
-            logger.warning(
+            _LOGGER.warning(
                 pipx_wrap(
                     f"""
                     {hazard}  Unable to write {PIPX_INFO_FILENAME} to
@@ -169,10 +239,11 @@ class PipxMetadata:
     def read(self, verbose: bool = False) -> None:
         try:
             with open(self.venv_dir / PIPX_INFO_FILENAME, "rb") as pipx_metadata_fh:
-                self.from_dict(json.load(pipx_metadata_fh, object_hook=_json_decoder_object_hook))
+                payload: _RawMetadata = json.load(pipx_metadata_fh, object_hook=_json_decoder_object_hook)
+                self.from_dict(payload)
         except OSError:  # Reset self if problem reading
             if verbose:
-                logger.warning(
+                _LOGGER.warning(
                     pipx_wrap(
                         f"""
                         {hazard}  Unable to read {PIPX_INFO_FILENAME} in
@@ -184,3 +255,19 @@ class PipxMetadata:
                     )
                 )
             return
+
+
+def load_spec_file(path: Path) -> "_RawSpecFile":
+    # Round-trips Path values through :class:`JsonEncoderHandlesPath`'s hook.
+    with open(path, encoding="utf-8") as handle:
+        payload: _RawSpecFile = json.load(handle, object_hook=_json_decoder_object_hook)
+    return payload
+
+
+__all__ = [
+    "PIPX_INFO_FILENAME",
+    "JsonEncoderHandlesPath",
+    "PackageInfo",
+    "PipxMetadata",
+    "load_spec_file",
+]

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from re import Pattern
 from typing import (
     Any,
+    Final,
     NoReturn,
 )
 
@@ -20,7 +21,7 @@ from pipx import paths
 from pipx.animate import show_cursor
 from pipx.constants import MINGW, WINDOWS
 
-logger = logging.getLogger(__name__)
+_LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
 
 class PipxError(Exception):
@@ -48,7 +49,7 @@ def rmdir(path: Path, safe_rm: bool = True) -> None:
     if not path.is_dir():
         return
 
-    logger.info(f"removing directory {path}")
+    _LOGGER.info(f"removing directory {path}")
     # Windows doesn't let us delete or overwrite files that are being run
     # But it does let us rename/move it. To get around this issue, we can move
     # the file to a temporary folder (to be deleted at a later time)
@@ -58,17 +59,17 @@ def rmdir(path: Path, safe_rm: bool = True) -> None:
     # move it to be deleted later if it still exists
     if path.is_dir():
         if safe_rm:
-            logger.warning(f"Failed to delete {path}. Will move it to a temp folder to delete later.")
+            _LOGGER.warning(f"Failed to delete {path}. Will move it to a temp folder to delete later.")
 
             path.rename(_get_trash_file(path))
         else:
-            logger.warning(f"Failed to delete {path}. You may need to delete it manually.")
+            _LOGGER.warning(f"Failed to delete {path}. You may need to delete it manually.")
 
 
 def mkdir(path: Path) -> None:
     if path.is_dir():
         return
-    logger.info(f"creating directory {path}")
+    _LOGGER.info(f"creating directory {path}")
     path.mkdir(parents=True, exist_ok=True)
 
 
@@ -162,14 +163,23 @@ def run_subprocess(
     log_stdout: bool = True,
     log_stderr: bool = True,
     run_dir: str | None = None,
+    env_overrides: dict[str, str | None] | None = None,
 ) -> "subprocess.CompletedProcess[str]":
-    """Run arbitrary command as subprocess, capturing stderr and stout"""
+    """Run a command as a subprocess, capturing stderr and stdout.
+
+    ``env_overrides`` keys map to a string (set/replace) or ``None`` (delete).
+    """
     env = dict(os.environ)
     env = _fix_subprocess_env(env)
+    for key, value in (env_overrides or {}).items():
+        if value is None:
+            env.pop(key, None)
+        else:
+            env[key] = value
 
     if log_cmd_str is None:
         log_cmd_str = " ".join(str(c) for c in cmd)
-    logger.info(f"running {log_cmd_str}")
+    _LOGGER.info(f"running {log_cmd_str}")
     if run_dir:
         os.makedirs(run_dir, exist_ok=True)
     # windows cannot take Path objects, only strings
@@ -194,10 +204,10 @@ def run_subprocess(
     )
 
     if capture_stdout and log_stdout:
-        logger.debug(f"stdout: {completed_process.stdout}".rstrip())
+        _LOGGER.debug(f"stdout: {completed_process.stdout}".rstrip())
     if capture_stderr and log_stderr:
-        logger.debug(f"stderr: {completed_process.stderr}".rstrip())
-    logger.debug(f"returncode: {completed_process.returncode}")
+        _LOGGER.debug(f"stderr: {completed_process.stderr}".rstrip())
+    _LOGGER.debug(f"returncode: {completed_process.returncode}")
 
     return completed_process
 
@@ -211,7 +221,7 @@ def subprocess_post_check(completed_process: "subprocess.CompletedProcess[str]",
         if raise_error:
             raise PipxError(f"{' '.join([str(x) for x in completed_process.args])!r} failed")
         else:
-            logger.info(f"{' '.join(completed_process.args)!r} failed")
+            _LOGGER.info(f"{' '.join(completed_process.args)!r} failed")
 
 
 def dedup_ordered(input_list: list[tuple[str, Any]]) -> list[tuple[str, Any]]:
@@ -302,15 +312,15 @@ def analyze_pip_output(pip_stdout: str, pip_stderr: str) -> None:
         failed_to_build_str = "\n    ".join(failed_build_stdout)
         plural_str = "s" if len(failed_build_stdout) > 1 else ""
         print("", file=sys.stderr)
-        logger.error(f"pip failed to build package{plural_str}:\n    {failed_to_build_str}")
+        _LOGGER.error(f"pip failed to build package{plural_str}:\n    {failed_to_build_str}")
     elif failed_build_stderr:
         failed_to_build_str = "\n    ".join(failed_build_stderr)
         plural_str = "s" if len(failed_build_stderr) > 1 else ""
         print("", file=sys.stderr)
-        logger.error(f"pip seemed to fail to build package{plural_str}:\n    {failed_to_build_str}")
+        _LOGGER.error(f"pip seemed to fail to build package{plural_str}:\n    {failed_to_build_str}")
     elif last_collecting_dep is not None:
         print("", file=sys.stderr)
-        logger.error(f"pip seemed to fail to build package:\n    {last_collecting_dep}")
+        _LOGGER.error(f"pip seemed to fail to build package:\n    {last_collecting_dep}")
 
     relevants_saved = dedup_ordered(relevants_saved)
 
@@ -329,25 +339,35 @@ def analyze_pip_output(pip_stdout: str, pip_stderr: str) -> None:
 
 def subprocess_post_check_handle_pip_error(
     completed_process: "subprocess.CompletedProcess[str]",
+    tool_name: str = "pip",
 ) -> None:
-    if completed_process.returncode:
-        logger.info(f"{' '.join(completed_process.args)!r} failed")
-        # Save STDOUT and STDERR to file in pipx/logs/
-        if paths.ctx.log_file is None:
-            raise PipxError("Pipx internal error: No log_file present.")
-        pip_error_file = paths.ctx.log_file.parent / (paths.ctx.log_file.stem + "_pip_errors.log")
-        with pip_error_file.open("a", encoding="utf-8") as pip_error_fh:
-            print("PIP STDOUT", file=pip_error_fh)
-            print("----------", file=pip_error_fh)
-            if completed_process.stdout is not None:
-                print(completed_process.stdout, file=pip_error_fh, end="")
-            print("\nPIP STDERR", file=pip_error_fh)
-            print("----------", file=pip_error_fh)
-            if completed_process.stderr is not None:
-                print(completed_process.stderr, file=pip_error_fh, end="")
+    """Persist subprocess output; run pip-specific heuristics for the pip path.
 
-        logger.error(f"Fatal error from pip prevented installation. Full pip output in file:\n    {pip_error_file}")
+    ``tool_name="pip"`` keeps the historical wording that log-scrapers /
+    tests built around. uv writes a uv-labelled log and skips the pip output
+    analyser, whose regexes don't match uv's error format.
+    """
+    if not completed_process.returncode:
+        return
+    _LOGGER.info(f"{' '.join(completed_process.args)!r} failed")
+    if paths.ctx.log_file is None:
+        raise PipxError("Pipx internal error: No log_file present.")
+    error_file = paths.ctx.log_file.parent / f"{paths.ctx.log_file.stem}_{tool_name}_errors.log"
+    upper_label = tool_name.upper()
+    with error_file.open("a", encoding="utf-8") as error_fh:
+        print(f"{upper_label} STDOUT", file=error_fh)
+        print("----------", file=error_fh)
+        if completed_process.stdout is not None:
+            print(completed_process.stdout, file=error_fh, end="")
+        print(f"\n{upper_label} STDERR", file=error_fh)
+        print("----------", file=error_fh)
+        if completed_process.stderr is not None:
+            print(completed_process.stderr, file=error_fh, end="")
 
+    _LOGGER.error(
+        f"Fatal error from {tool_name} prevented installation. Full {tool_name} output in file:\n    {error_file}"
+    )
+    if tool_name == "pip":
         analyze_pip_output(completed_process.stdout, completed_process.stderr)
 
 
@@ -374,7 +394,7 @@ def exec_app(
     # make sure we show cursor again before handing over control
     show_cursor()
 
-    logger.info("exec_app: " + " ".join([str(c) for c in cmd]))
+    _LOGGER.info(f"exec_app: {' '.join(str(c) for c in cmd)}")
 
     if WINDOWS:
         sys.exit(
@@ -428,3 +448,25 @@ def pipx_wrap(text: str, subsequent_indent: str = "", keep_newlines: bool = Fals
 
 def is_paths_relative(path: Path, parent: Path):
     return path.is_relative_to(parent)
+
+
+__all__ = [
+    "PipxError",
+    "RelevantSearch",
+    "analyze_pip_output",
+    "dedup_ordered",
+    "exec_app",
+    "full_package_description",
+    "get_pypackage_bin_path",
+    "get_site_packages",
+    "get_venv_paths",
+    "is_paths_relative",
+    "mkdir",
+    "pipx_wrap",
+    "rmdir",
+    "run_pypackage_bin",
+    "run_subprocess",
+    "safe_unlink",
+    "subprocess_post_check",
+    "subprocess_post_check_handle_pip_error",
+]

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -1,10 +1,9 @@
-import json
 import logging
 import shutil
 import time
 from collections.abc import Generator
 from pathlib import Path
-from typing import TYPE_CHECKING, NoReturn
+from typing import TYPE_CHECKING, Final, NoReturn
 
 if TYPE_CHECKING:
     from subprocess import CompletedProcess
@@ -17,6 +16,7 @@ except ImportError:
 from packaging.utils import canonicalize_name
 
 from pipx.animate import animate
+from pipx.backends import Backend, assert_not_pip_under_uv, env_default_backend, get_backend, resolve_backend_name
 from pipx.constants import PIPX_SHARED_PTH, ExitCode
 from pipx.emojis import hazard
 from pipx.interpreter import DEFAULT_PYTHON
@@ -38,11 +38,59 @@ from pipx.util import (
     rmdir,
     run_subprocess,
     subprocess_post_check,
-    subprocess_post_check_handle_pip_error,
 )
 from pipx.venv_inspect import VenvMetadata, inspect_venv
 
-logger = logging.getLogger(__name__)
+_LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
+
+# Keyed on full path so global vs user-local venvs with the same name don't
+# collide; deduped per-session because ``upgrade-all --backend uv`` against
+# many pip-backed venvs would otherwise repeat the multi-line warning per venv.
+_BACKEND_OVERRIDE_WARNED: Final[set[str]] = set()
+
+
+def reset_backend_override_warnings() -> None:
+    # Test-only: production callers never reset this.
+    _BACKEND_OVERRIDE_WARNED.clear()
+
+
+def _resolve_backend_for_venv(
+    *,
+    root: Path,
+    existing: bool,
+    metadata_backend: str | None,
+    cli_backend: str | None,
+    env_backend: str | None,
+) -> tuple[str, str]:
+    """Apply cli > metadata > env > auto precedence, warning on conflict.
+
+    Pulled out of ``Venv.__init__`` so the precedence rule is unit-testable
+    without instantiating a real venv.
+    """
+    # Existing venvs lock to their recorded backend: ``uv pip install`` against
+    # a pip-backed venv leaves it in an inconsistent state. ``pipx reinstall
+    # NAME --backend X`` is the supported flip.
+    if existing and cli_backend is not None and cli_backend != metadata_backend:
+        warning_key = str(root)
+        if warning_key not in _BACKEND_OVERRIDE_WARNED:
+            _BACKEND_OVERRIDE_WARNED.add(warning_key)
+            _LOGGER.warning(
+                pipx_wrap(
+                    f"""
+                    {hazard}  Ignoring --backend={cli_backend} for existing venv {root.name!r}
+                    (recorded backend is {metadata_backend!r}). Run
+                    `pipx reinstall {root.name} --backend {cli_backend}` to flip the venv.
+                    """,
+                    subsequent_indent=" " * 4,
+                )
+            )
+        cli_backend = None
+    # Direct ``Venv(...)`` callers (including unit tests) won't have threaded
+    # ``env_backend`` through; honor ``PIPX_DEFAULT_BACKEND`` so auto-detect
+    # doesn't fire when the operator already opted in via env.
+    if env_backend is None:
+        env_backend = env_default_backend()
+    return resolve_backend_name(cli_value=cli_backend, env_value=env_backend, metadata_value=metadata_backend)
 
 
 class VenvContainer:
@@ -74,7 +122,15 @@ class VenvContainer:
 class Venv:
     """Abstraction for a virtual environment with various useful methods for pipx"""
 
-    def __init__(self, path: Path, *, verbose: bool = False, python: str = DEFAULT_PYTHON) -> None:
+    def __init__(
+        self,
+        path: Path,
+        *,
+        verbose: bool = False,
+        python: str = DEFAULT_PYTHON,
+        backend: str | None = None,
+        env_backend: str | None = None,
+    ) -> None:
         self.root = path
         self.python = python
         self.bin_path, self.python_path, self.man_path = get_venv_paths(self.root)
@@ -85,6 +141,29 @@ class Venv:
             self._existing = self.root.exists() and bool(next(self.root.iterdir()))
         except StopIteration:
             self._existing = False
+        self._backend_name, self._backend_source = _resolve_backend_for_venv(
+            root=self.root,
+            existing=self._existing,
+            metadata_backend=self.pipx_metadata.backend if self._existing else None,
+            cli_backend=backend,
+            env_backend=env_backend,
+        )
+        self._backend: Backend | None = None
+        self._uses_shared_libs_cache: bool | None = None
+
+    @property
+    def backend(self) -> Backend:
+        if self._backend is None:
+            self._backend = get_backend(self._backend_name)
+        return self._backend
+
+    @property
+    def backend_name(self) -> str:
+        return self._backend_name
+
+    @property
+    def backend_source(self) -> str:
+        return self._backend_source
 
     def check_upgrade_shared_libs(self, verbose: bool, pip_args: list[str], force_upgrade: bool = False):
         """
@@ -125,12 +204,20 @@ class Venv:
 
     @property
     def uses_shared_libs(self) -> bool:
-        if self._existing:
-            pth_files = self.root.glob("**/" + PIPX_SHARED_PTH)
-            return next(pth_files, None) is not None
+        if not self._existing:
+            return self.backend.needs_shared_libs()
+        if self._uses_shared_libs_cache is not None:
+            return self._uses_shared_libs_cache
+        # Metadata 0.6+ records ``backend`` authoritatively; older recordings
+        # (or missing file) fall back to the .pth probe so legacy venvs still
+        # report correctly.
+        recorded_version = self.pipx_metadata.read_metadata_version
+        if recorded_version is not None and recorded_version >= "0.6":
+            answer = self.pipx_metadata.backend == "pip"
         else:
-            # always use shared libs when creating a new venv
-            return True
+            answer = next(self.root.glob(f"**/{PIPX_SHARED_PTH}"), None) is not None
+        self._uses_shared_libs_cache = answer
+        return answer
 
     @property
     def package_metadata(self) -> dict[str, PackageInfo]:
@@ -152,29 +239,23 @@ class Venv:
         """
         override_shared -- Override installing shared libraries to the pipx shared directory (default False)
         """
-        logger.info("Creating virtual environment")
-        with animate("creating virtual environment", self.do_animation):
-            cmd = [self.python, "-m", "venv"]
-            if not override_shared:
-                cmd.append("--without-pip")
-            venv_process = run_subprocess(cmd + venv_args + [str(self.root)], run_dir=str(self.root))
-        subprocess_post_check(venv_process)
-
-        shared_libs.create(verbose=self.verbose, pip_args=pip_args)
-        if not override_shared:
-            pipx_pth = get_site_packages(self.python_path) / PIPX_SHARED_PTH
-            # write path pointing to the shared libs site-packages directory
-            # example pipx_pth location:
-            #   ~/.local/share/pipx/venvs/black/lib/python3.8/site-packages/pipx_shared.pth
-            # example shared_libs.site_packages location:
-            #   ~/.local/share/pipx/shared/lib/python3.6/site-packages
-            #
-            # https://docs.python.org/3/library/site.html
-            # A path configuration file is a file whose name has the form 'name.pth'.
-            # its contents are additional items (one per line) to be added to sys.path
-            pipx_pth.write_text(f"{shared_libs.site_packages}\n")
+        _LOGGER.info("Creating virtual environment")
+        if override_shared:
+            assert_not_pip_under_uv("pip", self._backend_name)
+        self.backend.create_venv(
+            self.root,
+            python=self.python,
+            venv_args=venv_args,
+            pip_args=pip_args,
+            include_pip=override_shared,
+            verbose=self.verbose,
+        )
 
         self.pipx_metadata.venv_args = venv_args
+        # Persist the chosen backend on disk only when actually creating the venv.
+        # Runtime overrides on existing venvs (e.g. `--backend uv pipx upgrade ...`)
+        # must not silently flip the recorded backend.
+        self.pipx_metadata.backend = self._backend_name
         self.pipx_metadata.python_version = self.get_python_version()
         source_interpreter = shutil.which(self.python)
         if source_interpreter:
@@ -187,7 +268,7 @@ class Venv:
         if self.safe_to_remove():
             rmdir(self.root)
         else:
-            logger.warning(
+            _LOGGER.warning(
                 pipx_wrap(
                     f"""
                     {hazard}  Not removing existing venv {self.root} because it
@@ -200,19 +281,26 @@ class Venv:
     def upgrade_packaging_libraries(self, pip_args: list[str]) -> None:
         if self.uses_shared_libs:
             shared_libs.upgrade(pip_args=pip_args, verbose=self.verbose)
-        else:
-            # TODO: setuptools and wheel? Original code didn't bother
-            # but shared libs code does.
-            self.upgrade_package_no_metadata("pip", pip_args)
+            return
+        # Short-circuit before instantiating UvBackend so ``upgrade-all`` over
+        # uv venvs still works after uv has been uninstalled (the no-op upgrade
+        # would have happened anyway).
+        if self._backend_name == "uv":
+            return
+        self.backend.upgrade_packaging_libraries(self.python_path, pip_args, verbose=self.verbose)
 
     def uninstall_package(self, package: str, was_injected: bool = False):
         try:
-            logger.info("Uninstalling %s", package)
+            _LOGGER.info("Uninstalling %s", package)
             with animate(f"uninstalling {package}", self.do_animation):
-                cmd = ["uninstall", "-y"] + [package]
-                self._run_pip(cmd)
+                self.backend.uninstall(
+                    venv_root=self.root,
+                    venv_python=self.python_path,
+                    package=package,
+                    verbose=self.verbose,
+                )
         except PipxError as e:
-            logger.info(e)
+            _LOGGER.info(e)
             raise PipxError(f"Error uninstalling {package}.") from None
 
         if was_injected:
@@ -235,24 +323,16 @@ class Venv:
         # check syntax and clean up spec and pip_args
         (package_or_url, pip_args) = parse_specifier_for_install(package_or_url, pip_args)
 
-        logger.info("Installing %s", package_descr := full_package_description(package_name, package_or_url))
+        _LOGGER.info("Installing %s", package_descr := full_package_description(package_name, package_or_url))
         with animate(f"installing {package_descr}", self.do_animation):
-            # do not use -q with `pip install` so subprocess_post_check_pip_errors
-            #   has more information to analyze in case of failure.
-            cmd = [
-                str(self.python_path),
-                "-m",
-                "pip",
-                "--no-input",
-                "install",
-                *pip_args,
-                package_or_url,
-            ]
-            # no logging because any errors will be specially logged by
-            #   subprocess_post_check_handle_pip_error()
-            pip_process = run_subprocess(cmd, log_stdout=False, log_stderr=False, run_dir=str(self.root))
-        subprocess_post_check_handle_pip_error(pip_process)
-        if pip_process.returncode:
+            process = self.backend.install(
+                venv_root=self.root,
+                venv_python=self.python_path,
+                requirements=[package_or_url],
+                pip_args=pip_args,
+                verbose=self.verbose,
+            )
+        if process.returncode:
             raise PipxError(f"Error installing {full_package_description(package_name, package_or_url)}.")
 
         self.update_package_metadata(
@@ -277,42 +357,31 @@ class Venv:
 
     def install_unmanaged_packages(self, requirements: list[str], pip_args: list[str]) -> None:
         """Install packages in the venv, but do not record them in the metadata."""
-
-        # Note: We want to install everything at once, as that lets
-        # pip resolve conflicts correctly.
-        logger.info("Installing %s", package_descr := ", ".join(requirements))
+        _LOGGER.info("Installing %s", package_descr := ", ".join(requirements))
         with animate(f"installing {package_descr}", self.do_animation):
-            # do not use -q with `pip install` so subprocess_post_check_pip_errors
-            #   has more information to analyze in case of failure.
-            cmd = [
-                str(self.python_path),
-                "-m",
-                "pip",
-                "--no-input",
-                "install",
-                *pip_args,
-                *requirements,
-            ]
-            # no logging because any errors will be specially logged by
-            #   subprocess_post_check_handle_pip_error()
-            pip_process = run_subprocess(cmd, log_stdout=False, log_stderr=False, run_dir=str(self.root))
-        subprocess_post_check_handle_pip_error(pip_process)
-        if pip_process.returncode:
+            process = self.backend.install(
+                venv_root=self.root,
+                venv_python=self.python_path,
+                requirements=list(requirements),
+                pip_args=pip_args,
+                verbose=self.verbose,
+            )
+        if process.returncode:
             raise PipxError(f"Error installing {', '.join(requirements)}.")
 
     def install_package_no_deps(self, package_or_url: str, pip_args: list[str]) -> str:
         with animate(f"determining package name from {package_or_url!r}", self.do_animation):
             old_package_set = self.list_installed_packages()
-            cmd = [
-                "--no-input",
-                "install",
-                "--no-dependencies",
-                *pip_args,
-                package_or_url,
-            ]
-            pip_process = self._run_pip(cmd)
-        subprocess_post_check(pip_process, raise_error=False)
-        if pip_process.returncode:
+            process = self.backend.install(
+                venv_root=self.root,
+                venv_python=self.python_path,
+                requirements=[package_or_url],
+                pip_args=pip_args,
+                no_deps=True,
+                log_pip_errors=False,
+                verbose=self.verbose,
+            )
+        if process.returncode:
             raise PipxError(
                 f"""
                 Cannot determine package name from spec {package_or_url!r}.
@@ -323,10 +392,10 @@ class Venv:
         installed_packages = self.list_installed_packages() - old_package_set
         if len(installed_packages) == 1:
             package_name = installed_packages.pop()
-            logger.info(f"Determined package name: {package_name}")
+            _LOGGER.info(f"Determined package name: {package_name}")
         else:
-            logger.info(f"old_package_set = {old_package_set}")
-            logger.info(f"install_packages = {installed_packages}")
+            _LOGGER.info(f"old_package_set = {old_package_set}")
+            _LOGGER.info(f"install_packages = {installed_packages}")
             raise PipxError(
                 f"""
                 Cannot determine package name from spec {package_or_url!r}.
@@ -339,7 +408,7 @@ class Venv:
     def get_venv_metadata_for_package(self, package_name: str, package_extras: set[str]) -> VenvMetadata:
         data_start = time.time()
         venv_metadata = inspect_venv(package_name, package_extras, self.bin_path, self.python_path, self.man_path)
-        logger.info(f"get_venv_metadata_for_package: {1e3 * (time.time() - data_start):.0f}ms")
+        _LOGGER.info(f"get_venv_metadata_for_package: {1e3 * (time.time() - data_start):.0f}ms")
         return venv_metadata
 
     def update_package_metadata(
@@ -382,20 +451,12 @@ class Venv:
     def get_python_version(self) -> str:
         return run_subprocess([str(self.python_path), "--version"]).stdout.strip()
 
-    def list_installed_packages(self, not_required=False) -> set[str]:
-        cmd_run = run_subprocess(
-            [str(self.python_path), "-m", "pip", "list", "--format=json"] + (["--not-required"] if not_required else [])
+    def list_installed_packages(self, not_required: bool = False) -> set[str]:
+        return self.backend.list_installed(
+            venv_root=self.root,
+            venv_python=self.python_path,
+            not_required=not_required,
         )
-
-        if cmd_run.returncode != 0:
-            raise PipxError(
-                f"Failed to execute {cmd_run.args}.\n"
-                f"Process exited with return code {cmd_run.returncode}.\n"
-                f"stderr: {cmd_run.stderr}"
-            )
-
-        pip_list = json.loads(cmd_run.stdout.strip())
-        return {x["name"] for x in pip_list}
 
     def _find_entry_point(self, app: str) -> EntryPoint | None:
         if not self.python_path.exists():
@@ -420,7 +481,7 @@ class Venv:
             exec_app([str(self.bin_path / filename)] + app_args)
 
         # Evaluate and execute the entry point.
-        logger.info("Using discovered entry point for 'pipx run'")
+        _LOGGER.info("Using discovered entry point for 'pipx run'")
         module, attr = entry_point.module, entry_point.attr
         code = f"import sys, {module}\nsys.argv[0] = {entry_point.name!r}\nsys.exit({module}.{attr}())\n"
         exec_app([str(self.python_path), "-c", code] + app_args)
@@ -434,10 +495,18 @@ class Venv:
         return bool(list(Distribution.discover(name=package_name, path=[str(get_site_packages(self.python_path))])))
 
     def upgrade_package_no_metadata(self, package_name: str, pip_args: list[str]) -> None:
-        logger.info("Upgrading %s", package_descr := full_package_description(package_name, package_name))
+        _LOGGER.info("Upgrading %s", package_descr := full_package_description(package_name, package_name))
         with animate(f"upgrading {package_descr}", self.do_animation):
-            pip_process = self._run_pip(["--no-input", "install", "--upgrade"] + pip_args + [package_name])
-        subprocess_post_check(pip_process)
+            process = self.backend.install(
+                venv_root=self.root,
+                venv_python=self.python_path,
+                requirements=[package_name],
+                pip_args=pip_args,
+                upgrade=True,
+                log_pip_errors=False,
+                verbose=self.verbose,
+            )
+        subprocess_post_check(process)
 
     def upgrade_package(
         self,
@@ -449,10 +518,18 @@ class Venv:
         is_main_package: bool,
         suffix: str = "",
     ) -> None:
-        logger.info("Upgrading %s", package_descr := full_package_description(package_name, package_or_url))
+        _LOGGER.info("Upgrading %s", package_descr := full_package_description(package_name, package_or_url))
         with animate(f"upgrading {package_descr}", self.do_animation):
-            pip_process = self._run_pip(["--no-input", "install", "--upgrade"] + pip_args + [package_or_url])
-        subprocess_post_check(pip_process)
+            process = self.backend.install(
+                venv_root=self.root,
+                venv_python=self.python_path,
+                requirements=[package_or_url],
+                pip_args=pip_args,
+                upgrade=True,
+                log_pip_errors=False,
+                verbose=self.verbose,
+            )
+        subprocess_post_check(process)
 
         self.update_package_metadata(
             package_name=package_name,
@@ -465,17 +542,30 @@ class Venv:
         )
 
     def _run_pip(self, cmd: list[str]) -> "CompletedProcess[str]":
-        cmd = [str(self.python_path), "-m", "pip"] + cmd
-        if not self.verbose:
-            cmd.append("-q")
-        return run_subprocess(cmd, run_dir=str(self.root))
+        return self.backend.run_raw_pip(
+            venv_root=self.root,
+            venv_python=self.python_path,
+            args=cmd,
+            verbose=self.verbose,
+        )
 
     def run_pip_get_exit_code(self, cmd: list[str]) -> ExitCode:
-        cmd = [str(self.python_path), "-m", "pip"] + cmd
-        if not self.verbose:
-            cmd.append("-q")
-        returncode = run_subprocess(cmd, capture_stdout=False, capture_stderr=False).returncode
-        if returncode:
-            cmd_str = " ".join(str(c) for c in cmd)
-            logger.error(f"{cmd_str!r} failed")
-        return ExitCode(returncode)
+        process = self.backend.run_raw_pip(
+            venv_root=self.root,
+            venv_python=self.python_path,
+            args=cmd,
+            capture_stdout=False,
+            capture_stderr=False,
+            verbose=self.verbose,
+        )
+        if process.returncode:
+            cmd_str = " ".join(str(c) for c in process.args)
+            _LOGGER.error(f"{cmd_str!r} failed")
+        return ExitCode(process.returncode)
+
+
+__all__ = [
+    "Venv",
+    "VenvContainer",
+    "reset_backend_override_warnings",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import importlib
 import json
 import os
 import shutil
@@ -15,6 +16,16 @@ import pytest
 
 from helpers import WIN
 from pipx import commands, interpreter, paths, shared_libs, standalone_python, venv
+from pipx.backends import get_backend
+from pipx.backends import pip as _pip_backend_module
+from pipx.backends import uv as _uv_backend_module
+from pipx.backends.uv import find_uv_binary
+from pipx.venv import reset_backend_override_warnings
+
+# ``pipx.commands.__init__`` re-exports ``upgrade`` (the function), which
+# shadows the submodule on the package. ``import_module`` returns the module
+# regardless.
+_upgrade_module = importlib.import_module("pipx.commands.upgrade")
 
 PIPX_TESTS_DIR = Path(".pipx_tests")
 PIPX_TESTS_PACKAGE_LIST_DIR = Path("testdata/tests_packages")
@@ -23,6 +34,24 @@ PIPX_TESTS_PACKAGE_LIST_DIR = Path("testdata/tests_packages")
 @pytest.fixture(scope="session")
 def root() -> Path:
     return Path(__file__).parents[1]
+
+
+@pytest.fixture(autouse=True)
+def _backend_test_baseline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin every test to pip with empty backend caches.
+
+    Without the env pin, unit tests that build a ``Venv`` outside the
+    ``pipx_temp_env`` fixture would auto-detect uv from CI's PATH and fork a
+    real ``uv --version`` probe. Cache resets stop the previous test's
+    monkeypatched ``shutil.which`` from poisoning this one.
+
+    Uv-backend tests opt back in with ``--backend uv``.
+    """
+    monkeypatch.setenv("PIPX_DEFAULT_BACKEND", "pip")
+    find_uv_binary.cache_clear()
+    _uv_backend_module._check_uv_version.cache_clear()
+    get_backend.cache_clear()
+    reset_backend_override_warnings()
 
 
 @pytest.fixture()
@@ -84,14 +113,20 @@ def pipx_temp_env_helper(pipx_shared_dir, tmp_path, monkeypatch, request, utils_
     # Refresh paths.ctx to commit the overrides
     paths.ctx.make_local()
 
-    # Reset internal state of shared_libs
+    # Each consumer holds its own ``shared_libs`` reference (via
+    # ``from pipx.shared_libs import shared_libs``); patch every importer.
     monkeypatch.setattr(shared_libs, "shared_libs", shared_libs._SharedLibs())
     monkeypatch.setattr(venv, "shared_libs", shared_libs.shared_libs)
+    monkeypatch.setattr(_pip_backend_module, "shared_libs", shared_libs.shared_libs)
+    monkeypatch.setattr(_upgrade_module, "shared_libs", shared_libs.shared_libs)
 
     monkeypatch.setattr(interpreter, "DEFAULT_PYTHON", sys.executable)
 
     if "PIPX_DEFAULT_PYTHON" in os.environ:
         monkeypatch.delenv("PIPX_DEFAULT_PYTHON")
+    # CI runners ship uv on PATH; pin every legacy test to pip so the auto-
+    # detect doesn't silently flip them. Uv-backend tests opt in with --backend uv.
+    monkeypatch.setenv("PIPX_DEFAULT_BACKEND", "pip")
 
     # macOS needs /usr/bin in PATH to compile certain packages, but
     #   applications in /usr/bin cause test_install.py tests to raise warnings
@@ -111,6 +146,9 @@ def pipx_temp_env_helper(pipx_shared_dir, tmp_path, monkeypatch, request, utils_
         #   Using localhost on Windows creates enormous slowdowns
         #   (for some reason--perhaps IPV6/IPV4 tries, timeouts?)
         monkeypatch.setenv("PIP_INDEX_URL", pypi)
+        # uv ignores PIP_INDEX_URL; without UV_INDEX_URL the uv-backend tests
+        # would hit real PyPI on CI.
+        monkeypatch.setenv("UV_INDEX_URL", pypi)
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -189,10 +227,20 @@ def pipx_session_shared_dir(tmp_path_factory):
 @pytest.fixture(scope="session")
 def utils_temp_dir(tmp_path_factory):
     tmp_path = tmp_path_factory.mktemp("session_utilstempdir")
-    utils = ["git"]
-    for util in utils:
+    required = ["git"]
+    optional = ["uv"]  # exposed only when present so the uv-backend smoke test can find it
+    for util in required:
         at_path = shutil.which(util)
         assert at_path is not None
+        util_path = Path(at_path)
+        try:
+            (tmp_path / util_path.name).symlink_to(util_path)
+        except FileExistsError:
+            pass
+    for util in optional:
+        at_path = shutil.which(util)
+        if at_path is None:
+            continue
         util_path = Path(at_path)
         try:
             (tmp_path / util_path.name).symlink_to(util_path)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, TypedDict
+
+import pytest
+
+from pipx import backends, pipx_metadata_file
+from pipx.backends import (
+    KNOWN_BACKENDS,
+    PIP,
+    UV,
+    assert_not_pip_under_uv,
+    env_default_backend,
+    find_uv_binary,
+    resolve_backend_name,
+)
+from pipx.commands.run_uv import translate_pip_args_for_uv
+from pipx.main import _validate_backend_available
+from pipx.util import PipxError
+from pipx.venv import Venv, reset_backend_override_warnings
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+class _BackendResolveKwargs(TypedDict, total=False):
+    cli_value: str
+    env_value: str
+    metadata_value: str
+    auto: bool
+
+
+class _LegacyPackageInfo(TypedDict):
+    package: str
+    package_or_url: str
+    pip_args: list[str]
+    include_dependencies: bool
+    include_apps: bool
+    apps: list[str]
+    app_paths: list[str]
+    apps_of_dependencies: list[str]
+    app_paths_of_dependencies: dict[str, list[str]]
+    man_pages: list[str]
+    man_paths: list[str]
+    man_pages_of_dependencies: list[str]
+    man_paths_of_dependencies: dict[str, list[str]]
+    package_version: str
+    suffix: str
+    pinned: bool
+
+
+class _LegacyMetadata(TypedDict):
+    main_package: _LegacyPackageInfo
+    python_version: str
+    source_interpreter: None
+    venv_args: list[str]
+    injected_packages: dict[str, _LegacyPackageInfo]
+    pipx_metadata_version: str
+
+
+class _CurrentMetadata(_LegacyMetadata):
+    backend: str
+
+
+def test_known_backends() -> None:
+    assert KNOWN_BACKENDS == ("pip", "uv")
+
+
+@pytest.mark.parametrize(
+    ("env", "expected"),
+    [
+        pytest.param(None, None, id="unset"),
+        pytest.param("", None, id="empty"),
+        pytest.param("uv", "uv", id="uv"),
+        pytest.param("  pip  ", "pip", id="trims-whitespace"),
+    ],
+)
+def test_env_default_backend(monkeypatch: pytest.MonkeyPatch, env: str | None, expected: str | None) -> None:
+    if env is None:
+        monkeypatch.delenv("PIPX_DEFAULT_BACKEND", raising=False)
+    else:
+        monkeypatch.setenv("PIPX_DEFAULT_BACKEND", env)
+    assert env_default_backend() == expected
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_name", "expected_source"),
+    [
+        pytest.param({"cli_value": "pip"}, "pip", "cli", id="cli-pip"),
+        pytest.param({"cli_value": "uv"}, "uv", "cli", id="cli-uv"),
+        pytest.param({"env_value": "pip"}, "pip", "env", id="env-pip"),
+        pytest.param({"metadata_value": "uv"}, "uv", "metadata", id="metadata-uv"),
+        pytest.param(
+            {"cli_value": "pip", "env_value": "uv", "metadata_value": "uv"},
+            "pip",
+            "cli",
+            id="cli-wins",
+        ),
+        # The headline bug fix: env must NOT override an existing venv's metadata.
+        pytest.param(
+            {"env_value": "uv", "metadata_value": "pip"},
+            "pip",
+            "metadata",
+            id="metadata-locks-env-out",
+        ),
+        pytest.param({"env_value": "uv"}, "uv", "env", id="env-when-no-metadata"),
+    ],
+)
+def test_resolve_backend_name_precedence(
+    kwargs: _BackendResolveKwargs, expected_name: str, expected_source: str
+) -> None:
+    name, source = resolve_backend_name(**kwargs)
+    assert (name, source) == (expected_name, expected_source)
+
+
+def test_resolve_backend_name_rejects_unknown() -> None:
+    with pytest.raises(PipxError, match="Unknown backend"):
+        resolve_backend_name(cli_value="poetry")
+
+
+def test_resolve_backend_name_auto_uv_available(mocker: MockerFixture) -> None:
+    mocker.patch.object(backends, "find_uv_binary", return_value=(Path("/opt/uv"), "path"))
+    assert resolve_backend_name() == (UV, "auto-path")
+
+
+def test_resolve_backend_name_auto_no_uv(mocker: MockerFixture) -> None:
+    mocker.patch.object(backends, "find_uv_binary", return_value=(None, "missing"))
+    assert resolve_backend_name() == (PIP, "auto-pip")
+
+
+def test_resolve_backend_name_auto_disabled(mocker: MockerFixture) -> None:
+    mocker.patch.object(backends, "find_uv_binary", return_value=(Path("/opt/uv"), "path"))
+    assert resolve_backend_name(auto=False) == (PIP, "auto-pip")
+
+
+def test_find_uv_binary_prefers_bundled(mocker: MockerFixture, tmp_path: Path) -> None:
+    bundled = tmp_path / "bundled-uv"
+    bundled.write_text("")
+    mocker.patch("pipx.backends.uv._FIND_UV_BIN_FROM_EXTRA", lambda: str(bundled))
+    mocker.patch("shutil.which", return_value="/usr/local/bin/uv")
+    # Stub bundled isn't a real uv, so bypass the launch probe.
+    mocker.patch("pipx.backends.uv._binary_runs", return_value=True)
+    binary, source = find_uv_binary()
+    assert binary == bundled
+    assert source == "bundled"
+
+
+def test_find_uv_binary_skips_broken_bundled(mocker: MockerFixture, tmp_path: Path) -> None:
+    bundled = tmp_path / "bundled-uv"
+    bundled.write_text("")
+    mocker.patch("pipx.backends.uv._FIND_UV_BIN_FROM_EXTRA", lambda: str(bundled))
+    mocker.patch("pipx.backends.uv._binary_runs", return_value=False)
+    mocker.patch("shutil.which", return_value="/usr/local/bin/uv")
+    binary, source = find_uv_binary()
+    assert binary == Path("/usr/local/bin/uv")
+    assert source == "path"
+
+
+def test_find_uv_binary_falls_back_to_path(mocker: MockerFixture) -> None:
+    mocker.patch("pipx.backends.uv._FIND_UV_BIN_FROM_EXTRA", None)
+    mocker.patch("shutil.which", return_value="/usr/local/bin/uv")
+    binary, source = find_uv_binary()
+    assert binary == Path("/usr/local/bin/uv")
+    assert source == "path"
+
+
+def test_find_uv_binary_missing(mocker: MockerFixture) -> None:
+    mocker.patch("pipx.backends.uv._FIND_UV_BIN_FROM_EXTRA", None)
+    mocker.patch("shutil.which", return_value=None)
+    binary, source = find_uv_binary()
+    assert binary is None
+    assert source == "missing"
+
+
+def test_find_uv_binary_is_cached(mocker: MockerFixture) -> None:
+    # Self-contained cache reset: this test asserts hot-loop performance and
+    # must not rely on the autouse fixture's reset already having run.
+    find_uv_binary.cache_clear()
+    mocker.patch("pipx.backends.uv._FIND_UV_BIN_FROM_EXTRA", None)
+    which_mock = mocker.patch("shutil.which", return_value="/usr/local/bin/uv")
+    find_uv_binary()
+    find_uv_binary()
+    find_uv_binary()
+    assert which_mock.call_count == 1
+
+
+@pytest.mark.parametrize(
+    ("pip_args", "expected"),
+    [
+        pytest.param([], [], id="empty"),
+        pytest.param(["-q"], [], id="strip-quiet-short"),
+        pytest.param(["--quiet"], [], id="strip-quiet-long"),
+        pytest.param(
+            ["--index-url", "https://example.com/simple"],
+            ["--index-url", "https://example.com/simple"],
+            id="index-url",
+        ),
+        pytest.param(
+            ["--extra-index-url", "https://other.example/simple"],
+            ["--extra-index-url", "https://other.example/simple"],
+            id="extra-index",
+        ),
+        pytest.param(["--pre"], ["--prerelease=allow"], id="pre-to-prerelease"),
+        pytest.param(["--index-url=https://example.com"], ["--index-url=https://example.com"], id="equals-form"),
+    ],
+)
+def test_translate_pip_args_for_uv(pip_args: list[str], expected: list[str]) -> None:
+    assert translate_pip_args_for_uv(pip_args) == expected
+
+
+@pytest.mark.parametrize(
+    "pip_args",
+    [
+        pytest.param(["--editable"], id="editable"),
+        pytest.param(["-e"], id="editable-short"),
+        pytest.param(["--no-build-isolation"], id="unknown-flag"),
+        pytest.param(["--index-url"], id="missing-value"),
+    ],
+)
+def test_translate_pip_args_for_uv_errors(pip_args: list[str]) -> None:
+    with pytest.raises(PipxError):
+        translate_pip_args_for_uv(pip_args)
+
+
+def test_assert_not_pip_under_uv_blocks_pip_on_uv() -> None:
+    with pytest.raises(PipxError, match="cannot be installed or exposed via the uv backend"):
+        assert_not_pip_under_uv("pip", UV)
+
+
+def test_assert_not_pip_under_uv_allows_pip_on_pip() -> None:
+    assert_not_pip_under_uv("pip", PIP)  # does not raise
+
+
+def test_assert_not_pip_under_uv_allows_other_packages_on_uv() -> None:
+    assert_not_pip_under_uv("ruff", UV)  # does not raise
+
+
+def test_metadata_round_trip_includes_backend(tmp_path: Path) -> None:
+    venv_dir = tmp_path / "venv"
+    venv_dir.mkdir()
+
+    metadata = pipx_metadata_file.PipxMetadata(venv_dir, read=False)
+    metadata.main_package = pipx_metadata_file.PackageInfo(
+        package="demo",
+        package_or_url="demo",
+        pip_args=[],
+        include_dependencies=False,
+        include_apps=True,
+        apps=["demo"],
+        app_paths=[Path("demo")],
+        apps_of_dependencies=[],
+        app_paths_of_dependencies={},
+        package_version="1.0",
+    )
+    metadata.python_version = "3.12"
+    metadata.backend = "uv"
+    metadata.write()
+
+    raw_payload = json.loads((venv_dir / pipx_metadata_file.PIPX_INFO_FILENAME).read_text())
+    assert raw_payload["backend"] == "uv"
+
+    reread = pipx_metadata_file.PipxMetadata(venv_dir)
+    assert reread.backend == "uv"
+
+
+def test_legacy_metadata_defaults_to_pip(tmp_path: Path) -> None:
+    venv_dir = tmp_path / "venv"
+    venv_dir.mkdir()
+
+    legacy_payload: _LegacyMetadata = {
+        "main_package": {
+            "package": "demo",
+            "package_or_url": "demo",
+            "pip_args": [],
+            "include_dependencies": False,
+            "include_apps": True,
+            "apps": ["demo"],
+            "app_paths": [],
+            "apps_of_dependencies": [],
+            "app_paths_of_dependencies": {},
+            "man_pages": [],
+            "man_paths": [],
+            "man_pages_of_dependencies": [],
+            "man_paths_of_dependencies": {},
+            "package_version": "1.0",
+            "suffix": "",
+            "pinned": False,
+        },
+        "python_version": "3.12",
+        "source_interpreter": None,
+        "venv_args": [],
+        "injected_packages": {},
+        "pipx_metadata_version": "0.5",
+    }
+    (venv_dir / pipx_metadata_file.PIPX_INFO_FILENAME).write_text(json.dumps(legacy_payload))
+
+    metadata = pipx_metadata_file.PipxMetadata(venv_dir)
+    assert metadata.backend == "pip"
+
+
+def test_validate_backend_silent_on_env_uv_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Diagnostic commands (``pipx environment``/``list``) must keep working
+    # without a startup warning that would later contradict the actual error
+    # from ``UvBackend.__init__``.
+    # Patch both the source and the package-level re-export — either branch
+    # poisons the test if only one is mocked.
+    mocker.patch.object(backends, "find_uv_binary", return_value=(None, "missing"))
+    mocker.patch("pipx.backends.uv.find_uv_binary", return_value=(None, "missing"))
+    monkeypatch.setenv("PIPX_DEFAULT_BACKEND", "uv")
+    caplog.set_level("WARNING", logger="pipx.main")
+
+    _validate_backend_available(cli_backend=None, env_backend="uv")
+
+    assert not any("uv" in rec.message.lower() for rec in caplog.records)
+
+
+def test_validate_backend_raises_on_cli_uv_missing(mocker: MockerFixture) -> None:
+    mocker.patch.object(backends, "find_uv_binary", return_value=(None, "missing"))
+    mocker.patch("pipx.backends.uv.find_uv_binary", return_value=(None, "missing"))
+    with pytest.raises(PipxError, match="uv' executable could not be found"):
+        _validate_backend_available(cli_backend="uv", env_backend=None)
+
+
+def test_backend_override_warning_dedups_per_venv(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # ``upgrade-all --backend uv`` against many pip-backed venvs would
+    # otherwise emit a multi-line block per Venv construction.
+    venv_dir = tmp_path / "demo"
+    venv_dir.mkdir()
+    metadata_payload: _CurrentMetadata = {
+        "main_package": {
+            "package": "demo",
+            "package_or_url": "demo",
+            "pip_args": [],
+            "include_dependencies": False,
+            "include_apps": True,
+            "apps": ["demo"],
+            "app_paths": [],
+            "apps_of_dependencies": [],
+            "app_paths_of_dependencies": {},
+            "man_pages": [],
+            "man_paths": [],
+            "man_pages_of_dependencies": [],
+            "man_paths_of_dependencies": {},
+            "package_version": "1.0",
+            "suffix": "",
+            "pinned": False,
+        },
+        "python_version": "3.12",
+        "source_interpreter": None,
+        "venv_args": [],
+        "injected_packages": {},
+        "backend": "pip",
+        "pipx_metadata_version": "0.6",
+    }
+    (venv_dir / pipx_metadata_file.PIPX_INFO_FILENAME).write_text(json.dumps(metadata_payload))
+
+    reset_backend_override_warnings()
+    caplog.set_level("WARNING", logger="pipx.venv")
+
+    Venv(venv_dir, backend="uv")
+    Venv(venv_dir, backend="uv")
+    Venv(venv_dir, backend="uv")
+
+    warnings = [rec for rec in caplog.records if "Ignoring --backend=uv" in rec.message]
+    assert len(warnings) == 1

--- a/tests/test_backends_install.py
+++ b/tests/test_backends_install.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import shutil
+import sys
+
+import pytest
+
+from helpers import run_pipx_cli
+from pipx import paths
+
+
+def test_install_pip_with_uv_backend_errors(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = run_pipx_cli(["install", "pip", "--backend", "uv"])
+    captured = capsys.readouterr()
+    assert exit_code != 0
+    assert "'pip' package cannot be installed or exposed via the uv backend" in captured.err
+
+
+@pytest.mark.skipif(shutil.which("uv") is None, reason="uv binary not on PATH; skipping uv integration smoke")
+def test_uv_backend_install_uninstall_smoke(pipx_temp_env, capsys: pytest.CaptureFixture[str]) -> None:
+    # Asserts that a uv-built venv records ``backend="uv"``, exposes apps the
+    # same way pip venvs do, and uninstalls without re-invoking uv.
+    install_rc = run_pipx_cli(["install", "pycowsay", "--backend", "uv", "--python", sys.executable])
+    captured = capsys.readouterr()
+    assert install_rc == 0, captured.err
+
+    metadata_file = paths.ctx.venvs / "pycowsay" / "pipx_metadata.json"
+    assert metadata_file.is_file()
+    assert '"backend": "uv"' in metadata_file.read_text()
+
+    list_rc = run_pipx_cli(["list", "--short"])
+    list_out = capsys.readouterr().out
+    assert list_rc == 0
+    assert "pycowsay" in list_out
+
+    uninstall_rc = run_pipx_cli(["uninstall", "pycowsay"])
+    assert uninstall_rc == 0
+    assert not metadata_file.exists()

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -251,15 +251,11 @@ def test_list_installed_packages_error(monkeypatch, tmp_path, fake_process):
 
     fake_process.register(pip_list_args, returncode=1, stderr="unit test stderr")
 
-    # don't reformat the error message, so we can compare it to a known string
-    monkeypatch.setattr(venv, "PipxError", lambda m: PipxError(m, wrap_message=False))
-
     with pytest.raises(PipxError) as excinfo:
         fake_venv.list_installed_packages()
 
-    assert len(excinfo.value.args) == 1
-
-    actual = excinfo.value.args[0]
-    expected = f"Failed to execute {pip_list_args}.\nProcess exited with return code 1.\nstderr: unit test stderr"
-
-    assert actual == expected
+    # Collapse the wrapping pipx_wrap applies on render so we can assert on substrings.
+    rendered = " ".join(str(excinfo.value).split())
+    assert "Failed to execute" in rendered
+    assert "Process exited with return code 1" in rendered
+    assert "unit test stderr" in rendered

--- a/tests/test_run_uv.py
+++ b/tests/test_run_uv.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pipx.commands.run_uv import run_script_via_uv_run, run_via_uv_tool_run
+from pipx.util import PipxError
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+@pytest.fixture
+def fake_uv(mocker: MockerFixture) -> Path:
+    binary = Path("/opt/uv/bin/uv")
+    mocker.patch("pipx.commands.run_uv.resolve_uv_binary", return_value=binary)
+    return binary
+
+
+def test_run_via_uv_tool_run_basic(mocker: MockerFixture, fake_uv: Path) -> None:
+    exec_mock = mocker.patch("pipx.commands.run_uv.exec_app")
+    mocker.patch("pipx.commands.run_uv.which", return_value=None)
+    run_via_uv_tool_run(
+        app="black",
+        package_or_url="black",
+        dependencies=[],
+        app_args=["--check"],
+        python="python3.12",
+        pip_args=[],
+        venv_args=[],
+        use_cache=True,
+        verbose=False,
+    )
+    # ``mocker.patch`` keeps ``exec_app``'s ``NoReturn`` annotation, so pre-commit
+    # mypy flags everything below as unreachable; ``unused-ignore`` covers the
+    # local-checker case where the unreachable detection doesn't fire.
+    (cmd,), _ = exec_mock.call_args  # type: ignore[unreachable, unused-ignore]
+    assert cmd == [str(fake_uv), "tool", "run", "--python", "python3.12", "black", "--check"]
+
+
+def test_run_via_uv_tool_run_threads_spec_and_with(mocker: MockerFixture, fake_uv: Path) -> None:
+    exec_mock = mocker.patch("pipx.commands.run_uv.exec_app")
+    mocker.patch("pipx.commands.run_uv.which", return_value=None)
+    run_via_uv_tool_run(
+        app="rope",
+        package_or_url="git+https://example.com/rope.git",
+        dependencies=["rich", "click"],
+        app_args=["--version"],
+        python="python3.12",
+        pip_args=["--index-url", "https://example.com/simple", "--pre"],
+        venv_args=[],
+        use_cache=False,
+        verbose=True,
+    )
+    (cmd,), _ = exec_mock.call_args  # type: ignore[unreachable, unused-ignore]
+    assert cmd == [
+        str(fake_uv),
+        "tool",
+        "run",
+        "--from",
+        "git+https://example.com/rope.git",
+        "--python",
+        "python3.12",
+        "--with",
+        "rich",
+        "--with",
+        "click",
+        "--no-cache",
+        "--verbose",
+        "--index-url",
+        "https://example.com/simple",
+        "--prerelease=allow",
+        "rope",
+        "--version",
+    ]
+
+
+def test_run_via_uv_tool_run_omits_from_when_app_matches_spec(mocker: MockerFixture, fake_uv: Path) -> None:
+    exec_mock = mocker.patch("pipx.commands.run_uv.exec_app")
+    mocker.patch("pipx.commands.run_uv.which", return_value=None)
+    run_via_uv_tool_run(
+        app="black",
+        package_or_url="black",
+        dependencies=[],
+        app_args=[],
+        python="",
+        pip_args=[],
+        venv_args=[],
+        use_cache=True,
+        verbose=False,
+    )
+    (cmd,), _ = exec_mock.call_args  # type: ignore[unreachable, unused-ignore]
+    assert "--from" not in cmd
+
+
+def test_run_script_via_uv_run_uses_uv_run_script(mocker: MockerFixture, fake_uv: Path, tmp_path: Path) -> None:
+    exec_mock = mocker.patch("pipx.commands.run_uv.exec_app")
+    script = tmp_path / "demo.py"
+    script.write_text("print('hi')\n")
+    run_script_via_uv_run(
+        script_path=script,
+        app_args=["--quiet"],
+        python="python3.12",
+        pip_args=[],
+        venv_args=[],
+        use_cache=True,
+        verbose=False,
+    )
+    (cmd,), _ = exec_mock.call_args  # type: ignore[unreachable, unused-ignore]
+    assert cmd == [str(fake_uv), "run", "--script", "--python", "python3.12", str(script), "--quiet"]
+
+
+def test_run_via_uv_tool_run_rejects_venv_args(mocker: MockerFixture, fake_uv: Path) -> None:
+    mocker.patch("pipx.commands.run_uv.exec_app")
+    mocker.patch("pipx.commands.run_uv.which", return_value=None)
+    with pytest.raises(PipxError, match=r"--venv-args .* is not supported"):
+        run_via_uv_tool_run(
+            app="black",
+            package_or_url="black",
+            dependencies=[],
+            app_args=[],
+            python="",
+            pip_args=[],
+            venv_args=["--system-site-packages"],
+            use_cache=True,
+            verbose=False,
+        )


### PR DESCRIPTION
Closes #1370. Closes #1392.

pipx today shells out to `python -m venv` and `python -m pip` for every install, inject, upgrade, and ephemeral run. Users who already run `uv` for other workflows have been asking to share that toolchain, and so far the only way has been `uv tool`, which ships a smaller per-tool surface and stores state separately. This PR adds a backend abstraction so pipx can drive `uv venv` and `uv pip` internally while keeping its full CLI — `inject`, `runpip`, `--global`, `--suffix`, manual pages, `install-all`, `[pipx.run]` entry points — intact. ✨ `pipx install pipx[uv]` opts in; the binary is also picked up from `PATH` if installed independently.

## Backend selection

The backend choice is recorded per venv so existing pip-backed installs keep working unchanged. Resolution precedence is `--backend` > recorded venv metadata > `PIPX_DEFAULT_BACKEND` > auto-detect — the env var sits **below** metadata so setting `PIPX_DEFAULT_BACKEND=uv` does not silently retarget a fleet of pip-backed venvs.

```mermaid
flowchart LR
    A[pipx command] --> B{--backend flag?}
    B -->|yes| Cli[use that]
    B -->|no| C{existing venv with<br/>recorded metadata?}
    C -->|yes| Meta[use recorded backend]
    C -->|no| D{PIPX_DEFAULT_BACKEND<br/>set?}
    D -->|yes| Env[use env value]
    D -->|no| E{uv reachable?<br/>extra or PATH}
    E -->|yes| Uv[uv]
    E -->|no| Pip[pip]

    style A fill:#3f72af,color:#fff
    style Cli fill:#264653,color:#fff
    style Meta fill:#2a9d8f,color:#fff
    style Env fill:#e76f51,color:#fff
    style Uv fill:#f4a261,color:#000
    style Pip fill:#264653,color:#fff
```

`pipx install pip` always picks the pip backend regardless of opt-in source, since uv venvs ship without pip. `pipx run` execs `uv tool run` directly when the uv backend is selected; PEP 723 inline scripts route through `uv run --script`. `pipx environment` exposes the resolved backend and its source as `PIPX_RESOLVED_BACKEND` and `PIPX_BACKEND_SOURCE`.

## What changes per backend

The pip backend keeps the historical pipx layout: a `--without-pip` venv with a `.pth` file pointing at the shared-libs venv. The uv backend creates self-contained venvs without pip and skips the shared-libs dance entirely.

```mermaid
flowchart LR
    subgraph pip_backend[pip backend - default before]
        direction LR
        P1[pipx install X] --> P2[python -m venv<br/>--without-pip]
        P2 --> P3[shared venv<br/>pip + setuptools + wheel]
        P3 --> P4[.pth points at shared]
        P4 --> P5[python -m pip install X]
    end

    subgraph uv_backend[uv backend - new]
        direction LR
        U1[pipx install X] --> U2[uv venv]
        U2 --> U3[no pip, no .pth]
        U3 --> U4[uv pip install X]
    end

    style P1 fill:#3f72af,color:#fff
    style P2 fill:#2a9d8f,color:#fff
    style P3 fill:#2a9d8f,color:#fff
    style P4 fill:#2a9d8f,color:#fff
    style P5 fill:#2a9d8f,color:#fff
    style U1 fill:#3f72af,color:#fff
    style U2 fill:#f4a261,color:#000
    style U3 fill:#f4a261,color:#000
    style U4 fill:#f4a261,color:#000
```

`pipx run --backend uv` skips the temp-venv build entirely and execs `uv tool run` (or `uv run --script` for PEP 723 scripts), riding uv's content-addressed cache instead of pipx's 14-day temp-venv cache.

```mermaid
flowchart LR
    R1[pipx run X] --> Q{backend?}
    Q -->|pip| Rpip[temp venv under<br/>$PIPX_HOME/.cache] --> Rexec[exec X]
    Q -->|uv + script.py| Ruvs[uv run --script script.py] --> Rexec
    Q -->|uv + package| Ruvt[uv tool run X] --> Rexec

    style R1 fill:#3f72af,color:#fff
    style Q fill:#e9c46a,color:#000
    style Rpip fill:#2a9d8f,color:#fff
    style Ruvs fill:#f4a261,color:#000
    style Ruvt fill:#f4a261,color:#000
    style Rexec fill:#264653,color:#fff
```

## Robustness

Stale or missing uv handling is permissive: `PIPX_DEFAULT_BACKEND=uv` on a host where uv was uninstalled merely warns and falls back per command, so `pipx environment` and `pipx list` keep working; only an explicit `--backend uv` errors at startup. Read-only metadata paths tolerate an unrecognised recorded backend (downgraded pipx, manual edit) by warning and treating it as `pip`. The version probe and binary lookup are cached at module scope so `upgrade-all` over many venvs pays one `shutil.which` and one `uv --version` rather than one per venv. Errors from uv land in their own `*_uv_errors.log` rather than being mislabelled as pip output.

## Docs

`docs/how-to/use-uv-backend.md` walks through enable and opt-out paths. `docs/explanation/comparisons.md` gained a side-by-side `pipx vs uv tool` section covering state layout, subcommand mapping, only-in-each features, and the gotchas (`uvx` cache reuse, `uv tool` ignoring `.python-version`, patch-only `uv python upgrade`).