### PR TITLE
Add shared libs auto-upgrade opt-out

### DIFF
--- a/changelog.d/1650.feature.md
+++ b/changelog.d/1650.feature.md
@@ -1,0 +1,1 @@
+Add `PIPX_DISABLE_SHARED_LIBS_AUTO_UPGRADE` to skip automatic shared library upgrades.

--- a/docs/how-to/configure-paths.md
+++ b/docs/how-to/configure-paths.md
@@ -90,6 +90,9 @@ These variables also apply when pipx upgrades its shared libraries (`pipx upgrad
 in your shell profile or in pip's own config file (`pip.conf` / `pip.ini`). See the
 [pip configuration documentation](https://pip.pypa.io/en/stable/topics/configuration/) for details.
 
+Set `PIPX_DISABLE_SHARED_LIBS_AUTO_UPGRADE=1` to skip automatic shared library upgrades during commands such as
+`pipx install` and `pipx upgrade`. The explicit `pipx upgrade-shared` command still upgrades the shared libraries.
+
 Per-command pip options can be passed with `--pip-args`:
 
 ```

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -2,22 +2,23 @@
 
 pipx reads the following environment variables. All are optional.
 
-| Variable                    | Description                                                               | Default                                                                    |
-| --------------------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| `PIPX_HOME`                 | Root directory for pipx virtual environments.                             | `~/.local/share/pipx` (Linux), `~/.local/pipx` (macOS), `~\pipx` (Windows) |
-| `PIPX_BIN_DIR`              | Directory where application entry-point symlinks are placed.              | `~/.local/bin`                                                             |
-| `PIPX_MAN_DIR`              | Directory where man page symlinks are placed.                             | `~/.local/share/man`                                                       |
-| `PIPX_GLOBAL_HOME`          | Root directory for global (`--global`) virtual environments.              | `/opt/pipx`                                                                |
-| `PIPX_GLOBAL_BIN_DIR`       | Binary directory for global installs.                                     | `/usr/local/bin`                                                           |
-| `PIPX_GLOBAL_MAN_DIR`       | Man page directory for global installs.                                   | `/usr/local/share/man`                                                     |
-| `PIPX_DEFAULT_PYTHON`       | Python interpreter to use when `--python` is not passed.                  | `python3` (or `py` on Windows)                                             |
-| `PIPX_DEFAULT_BACKEND`      | Backend for new venvs: `pip` or `uv`.                                     | `uv` when uv is available, else `pip`                                      |
-| `PIPX_SHARED_LIBS`          | Override the shared libraries directory.                                  | `PIPX_HOME/shared`                                                         |
-| `PIPX_FETCH_PYTHON`         | When to fetch a standalone Python build: `always`, `missing`, or `never`. | `never`                                                                    |
-| `PIPX_FETCH_MISSING_PYTHON` | Deprecated, alias for `PIPX_FETCH_PYTHON=missing`.                        | _(unset)_                                                                  |
-| `PIPX_HOME_ALLOW_SPACE`     | Set to `true` to suppress the "space in PIPX_HOME" warning.               | _(unset)_                                                                  |
-| `PIPX_USE_EMOJI`            | Set to `0` to disable emoji output.                                       | `1`                                                                        |
-| `PIPX_MAX_LOGS`             | Maximum number of log files to keep in the logs directory.                | `10`                                                                       |
+| Variable                                | Description                                                               | Default                                                                    |
+| --------------------------------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `PIPX_HOME`                             | Root directory for pipx virtual environments.                             | `~/.local/share/pipx` (Linux), `~/.local/pipx` (macOS), `~\pipx` (Windows) |
+| `PIPX_BIN_DIR`                          | Directory where application entry-point symlinks are placed.              | `~/.local/bin`                                                             |
+| `PIPX_MAN_DIR`                          | Directory where man page symlinks are placed.                             | `~/.local/share/man`                                                       |
+| `PIPX_GLOBAL_HOME`                      | Root directory for global (`--global`) virtual environments.              | `/opt/pipx`                                                                |
+| `PIPX_GLOBAL_BIN_DIR`                   | Binary directory for global installs.                                     | `/usr/local/bin`                                                           |
+| `PIPX_GLOBAL_MAN_DIR`                   | Man page directory for global installs.                                   | `/usr/local/share/man`                                                     |
+| `PIPX_DEFAULT_PYTHON`                   | Python interpreter to use when `--python` is not passed.                  | `python3` (or `py` on Windows)                                             |
+| `PIPX_DEFAULT_BACKEND`                  | Backend for new venvs: `pip` or `uv`.                                     | `uv` when uv is available, else `pip`                                      |
+| `PIPX_SHARED_LIBS`                      | Override the shared libraries directory.                                  | `PIPX_HOME/shared`                                                         |
+| `PIPX_FETCH_PYTHON`                     | When to fetch a standalone Python build: `always`, `missing`, or `never`. | `never`                                                                    |
+| `PIPX_FETCH_MISSING_PYTHON`             | Deprecated, alias for `PIPX_FETCH_PYTHON=missing`.                        | _(unset)_                                                                  |
+| `PIPX_DISABLE_SHARED_LIBS_AUTO_UPGRADE` | Set to `1` to skip automatic shared library upgrades.                     | _(unset)_                                                                  |
+| `PIPX_HOME_ALLOW_SPACE`                 | Set to `true` to suppress the "space in PIPX_HOME" warning.               | _(unset)_                                                                  |
+| `PIPX_USE_EMOJI`                        | Set to `0` to disable emoji output.                                       | `1`                                                                        |
+| `PIPX_MAX_LOGS`                         | Maximum number of log files to keep in the logs directory.                | `10`                                                                       |
 
 ### Notes
 

--- a/src/pipx/commands/environment.py
+++ b/src/pipx/commands/environment.py
@@ -5,6 +5,10 @@ from pipx.backends import env_default_backend, find_uv_binary, resolve_backend_n
 from pipx.constants import EXIT_CODE_OK, ExitCode
 from pipx.emojis import EMOJI_SUPPORT
 from pipx.interpreter import DEFAULT_PYTHON
+from pipx.shared_libs import (
+    DISABLE_SHARED_LIBS_AUTO_UPGRADE,
+    shared_libs_auto_upgrade_disabled,
+)
 from pipx.util import PipxError
 
 ENVIRONMENT_VARIABLES = [
@@ -19,6 +23,7 @@ ENVIRONMENT_VARIABLES = [
     "PIPX_DEFAULT_BACKEND",
     "PIPX_FETCH_MISSING_PYTHON",
     "PIPX_FETCH_PYTHON",
+    DISABLE_SHARED_LIBS_AUTO_UPGRADE,
     "PIPX_USE_EMOJI",
     "PIPX_HOME_ALLOW_SPACE",
 ]
@@ -55,6 +60,7 @@ def environment(value: str) -> ExitCode:
         "PIPX_BACKEND_SOURCE": backend_source,
         "PIPX_UV_BINARY": str(uv_binary) if uv_binary else "",
         "UV_CACHE_DIR": os.environ.get("UV_CACHE_DIR", ""),
+        DISABLE_SHARED_LIBS_AUTO_UPGRADE: str(shared_libs_auto_upgrade_disabled()).lower(),
         "PIPX_USE_EMOJI": str(EMOJI_SUPPORT).lower(),
         "PIPX_HOME_ALLOW_SPACE": str(paths.ctx.allow_spaces_in_home_path).lower(),
     }

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -102,6 +102,8 @@ PIPX_DESCRIPTION += pipx_wrap(
       PIPX_GLOBAL_MAN_DIR    Used instead of PIPX_MAN_DIR when the `--global` option is given.
       PIPX_DEFAULT_PYTHON    Overrides default python used for commands.
       PIPX_DEFAULT_BACKEND   Overrides which backend (`pip` or `uv`) is used for new venvs.
+      PIPX_DISABLE_SHARED_LIBS_AUTO_UPGRADE
+                            Skips automatic shared library upgrades.
       PIPX_USE_EMOJI         Overrides emoji behavior. Default value varies based on platform.
       PIPX_HOME_ALLOW_SPACE  Overrides default warning on spaces in the home path
     """,

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import os
 import time
 from configparser import ConfigParser
 from contextlib import suppress
@@ -11,6 +12,7 @@ from packaging.specifiers import SpecifierSet
 from pipx import paths
 from pipx.animate import animate
 from pipx.constants import WINDOWS
+from pipx.emojis import strtobool
 from pipx.interpreter import DEFAULT_PYTHON
 from pipx.util import (
     get_site_packages,
@@ -23,6 +25,11 @@ logger = logging.getLogger(__name__)
 
 
 SHARED_LIBS_MAX_AGE_SEC = datetime.timedelta(days=30).total_seconds()
+DISABLE_SHARED_LIBS_AUTO_UPGRADE = "PIPX_DISABLE_SHARED_LIBS_AUTO_UPGRADE"
+
+
+def shared_libs_auto_upgrade_disabled() -> bool:
+    return strtobool(os.getenv(DISABLE_SHARED_LIBS_AUTO_UPGRADE, "0"))
 
 
 def _venv_python_is_valid(python_path: Path) -> bool:

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -27,7 +27,11 @@ from pipx.package_specifier import (
     parse_specifier_for_metadata,
 )
 from pipx.pipx_metadata_file import PackageInfo, PipxMetadata
-from pipx.shared_libs import shared_libs
+from pipx.shared_libs import (
+    DISABLE_SHARED_LIBS_AUTO_UPGRADE,
+    shared_libs,
+    shared_libs_auto_upgrade_disabled,
+)
 from pipx.util import (
     PipxError,
     exec_app,
@@ -176,7 +180,11 @@ class Venv:
         """
         if self._existing and self.uses_shared_libs:
             if shared_libs.is_valid:
-                if force_upgrade or shared_libs.needs_upgrade:
+                if force_upgrade:
+                    shared_libs.upgrade(verbose=verbose, pip_args=pip_args)
+                elif shared_libs_auto_upgrade_disabled():
+                    _LOGGER.info(f"Skipping shared libs auto-upgrade because {DISABLE_SHARED_LIBS_AUTO_UPGRADE} is set.")
+                elif shared_libs.needs_upgrade:
                     shared_libs.upgrade(verbose=verbose, pip_args=pip_args)
             else:
                 shared_libs.create(verbose=verbose, pip_args=pip_args)

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -35,6 +35,7 @@ def test_cli_with_args(monkeypatch, capsys):
     assert not run_pipx_cli(["environment", "--value", "PIPX_TRASH_DIR"])
     assert not run_pipx_cli(["environment", "--value", "PIPX_VENV_CACHEDIR"])
     assert not run_pipx_cli(["environment", "--value", "PIPX_DEFAULT_PYTHON"])
+    assert not run_pipx_cli(["environment", "--value", "PIPX_DISABLE_SHARED_LIBS_AUTO_UPGRADE"])
     assert not run_pipx_cli(["environment", "--value", "PIPX_USE_EMOJI"])
     assert not run_pipx_cli(["environment", "--value", "PIPX_HOME_ALLOW_SPACE"])
 

--- a/tests/test_shared_libs.py
+++ b/tests/test_shared_libs.py
@@ -8,7 +8,8 @@ from unittest.mock import patch
 import pytest
 
 from pipx import shared_libs
-from pipx.constants import WINDOWS
+from pipx.constants import PIPX_SHARED_PTH, WINDOWS
+from pipx.venv import Venv
 
 
 @pytest.mark.parametrize(
@@ -87,3 +88,47 @@ def test_venv_python_is_valid_non_windows() -> None:
     with patch.object(shared_libs, "WINDOWS", False):
         # Should return True regardless of the path
         assert shared_libs._venv_python_is_valid(Path("/fake/path/python")) is True
+
+
+@pytest.mark.parametrize(
+    ("env_value", "force_upgrade", "expected_calls"),
+    [
+        ("1", False, 0),
+        ("1", True, 1),
+        ("0", False, 1),
+    ],
+)
+def test_disable_shared_libs_auto_upgrade(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    env_value: str,
+    force_upgrade: bool,
+    expected_calls: int,
+) -> None:
+    venv_path = tmp_path / "venv"
+    site_packages = venv_path / "lib" / "python" / "site-packages"
+    site_packages.mkdir(parents=True)
+    (site_packages / PIPX_SHARED_PTH).write_text("")
+    venv = Venv(venv_path)
+
+    upgrade_calls = []
+    monkeypatch.setenv(shared_libs.DISABLE_SHARED_LIBS_AUTO_UPGRADE, env_value)
+    monkeypatch.setattr(
+        type(shared_libs.shared_libs),
+        "is_valid",
+        property(lambda self: True),
+    )
+    monkeypatch.setattr(
+        type(shared_libs.shared_libs),
+        "needs_upgrade",
+        property(lambda self: True),
+    )
+    monkeypatch.setattr(
+        shared_libs.shared_libs,
+        "upgrade",
+        lambda **kwargs: upgrade_calls.append(kwargs),
+    )
+
+    venv.check_upgrade_shared_libs(verbose=True, pip_args=[], force_upgrade=force_upgrade)
+
+    assert len(upgrade_calls) == expected_calls


### PR DESCRIPTION
Closes #1650.

Adds PIPX_DISABLE_SHARED_LIBS_AUTO_UPGRADE to skip automatic shared library upgrades during regular commands. pipx upgrade-shared still upgrades them explicitly.

Checks: targeted pytest and changed-file lint hooks.