### PR TITLE
Update deprecation message in get-pipx.py; obsoleted, not deprecated

### DIFF
--- a/changelog.d/1813.feature.rst
+++ b/changelog.d/1813.feature.rst
@@ -1,0 +1,1 @@
+Update the error message in get-pipx.py; it is obsoleted, not deprecated.

--- a/get-pipx.py
+++ b/get-pipx.py
@@ -10,7 +10,7 @@ def fail(msg):
 
 def main():
     fail(
-        "This installation method has been deprecated. "
+        "This installation method has been obsoleted. "
         "See https://github.com/pypa/pipx for current installation "
         "instructions."
     )


### PR DESCRIPTION
This is obsoleted, not deprecated as it fails with return code 1.

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://pipx.pypa.io/latest/contributing/))

- [X] ran the linter to address style issues (`pre-commit run --all-files`)
- [X] wrote descriptive pull request text
- [X] ensured there are test(s) validating the fix
- [x] added news fragment in `changelog.d/` folder (choose a type: `feature`, `bugfix`, `doc`, `removal`, or `misc`)
- [X] updated/extended the documentation
