### PR TITLE
Fix app script shebang isolation

### DIFF
--- a/changelog.d/1584.bugfix.md
+++ b/changelog.d/1584.bugfix.md
@@ -1,0 +1,1 @@
+Install app scripts with shebangs that ignore `PYTHONPATH`.

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -60,6 +60,8 @@ def expose_resources_globally(
     suffix: str = "",
 ) -> None:
     for path in paths:
+        if resource_type == "app":
+            _add_ignore_environment_to_python_shebang(path)
         src = path.resolve()
         if resource_type == "man":
             dest_dir = local_resource_dir / src.parent.name
@@ -100,6 +102,28 @@ def can_symlink(local_resource_dir: Path) -> bool:
                 _can_symlink_cache[local_resource_dir] = False
 
     return _can_symlink_cache[local_resource_dir]
+
+
+def _add_ignore_environment_to_python_shebang(path: Path) -> None:
+    if WINDOWS or not path.is_file():
+        return
+
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return
+
+    first_line, separator, rest = data.partition(b"\n")
+    if not first_line.startswith(b"#!"):
+        return
+
+    interpreter = first_line[2:]
+    if interpreter.endswith(b" -E"):
+        return
+    if b"python" not in interpreter.lower() or b" " in interpreter or b"\t" in interpreter:
+        return
+
+    path.write_bytes(first_line + b" -E" + separator + rest)
 
 
 def _copy_package_resource(dest_dir: Path, path: Path, suffix: str = "") -> None:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,5 +1,9 @@
+import os
+import subprocess
+import sys
+
 from helpers import skip_if_windows
-from pipx.commands.common import get_exposed_paths_for_package
+from pipx.commands.common import expose_resources_globally, get_exposed_paths_for_package
 
 
 @skip_if_windows
@@ -14,3 +18,35 @@ def test_get_exposed_paths_ignores_recursive_symlink(tmp_path):
     exposed = get_exposed_paths_for_package(venv_resource_path, local_resource_dir)
 
     assert loop not in exposed
+
+
+@skip_if_windows
+def test_expose_app_scripts_ignores_pythonpath(tmp_path):
+    venv_resource_path = tmp_path / "venv_bin"
+    venv_resource_path.mkdir()
+    local_resource_dir = tmp_path / "bin"
+    shadow_path = tmp_path / "shadow"
+    shadow_path.mkdir()
+
+    app_path = venv_resource_path / "demo"
+    app_path.write_text(
+        f"#!{sys.executable}\n"
+        "import sys\n"
+        f"if {str(shadow_path)!r} in sys.path:\n"
+        "    raise SystemExit('PYTHONPATH leaked into app script')\n"
+        "print('ok')\n"
+    )
+    app_path.chmod(0o755)
+
+    expose_resources_globally("app", local_resource_dir, [app_path], force=False)
+
+    assert app_path.read_text().splitlines()[0] == f"#!{sys.executable} -E"
+
+    result = subprocess.run(
+        [app_path],
+        check=True,
+        capture_output=True,
+        env={**os.environ, "PYTHONPATH": str(shadow_path)},
+        text=True,
+    )
+    assert result.stdout == "ok\n"


### PR DESCRIPTION
### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://pipx.pypa.io/latest/contributing/))

- [x] ran the linter to address style issues (`pre-commit run --all-files`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `changelog.d/` folder (choose a type: `feature`, `bugfix`, `doc`, `removal`, or `misc`)
- [x] updated/extended the documentation (not applicable)

## Summary

Fix #1584.

When pipx exposes an installed Python app, its generated script could still honor an ambient `PYTHONPATH`. That lets unrelated caller environments shadow modules inside the app process. This updates app script shebangs to include `-E` before exposing them, so the installed app ignores Python environment variables while keeping the existing symlink/copy behavior.

The change is limited to non-Windows app scripts with direct Python shebangs. Manual pages, non-Python executables, existing shebangs with arguments, and Windows launchers are left unchanged.

## Testing

- `uv run --group test pytest tests/test_common.py -k ignores_pythonpath --net-pypiserver -q`
- `uv run --group test pytest tests/test_common.py --net-pypiserver -q`
- `uv run --group test pytest tests/test_install.py -k 'test_install_easy_packages' -q`
- `uv run --group lint pre-commit run ruff-check --files src/pipx/commands/common.py tests/test_common.py`
- `uv run --group lint pre-commit run ruff-format --files src/pipx/commands/common.py tests/test_common.py`
- `uv run --group lint pre-commit run --all-files`
- `python3 -m py_compile src/pipx/commands/common.py tests/test_common.py`
- `git diff --check`

The new regression test failed before the fix because the exposed app script kept the original shebang without `-E`.
