### PR TITLE
Fix inject option parsing with --force before dependencies

### DIFF
--- a/changelog.d/1444.bugfix.md
+++ b/changelog.d/1444.bugfix.md
@@ -1,0 +1,1 @@
+Add regression coverage for `pipx inject` accepting `--force` before or after injected dependencies.

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -1395,13 +1395,27 @@ def normalize_help_command(args: list[str]) -> list[str]:
     return args
 
 
+def _get_subparser(parser: argparse.ArgumentParser, command: str) -> argparse.ArgumentParser:
+    subparsers_action = next(action for action in parser._actions if isinstance(action, argparse._SubParsersAction))
+    return subparsers_action.choices[command]
+
+
+def parse_pipx_args(parser: argparse.ArgumentParser, args: list[str]) -> argparse.Namespace:
+    args = normalize_help_command(args)
+    if args and args[0] == "inject":
+        parsed_args = _get_subparser(parser, "inject").parse_intermixed_args(args[1:])
+        parsed_args.command = "inject"
+        return parsed_args
+    return parser.parse_args(args)
+
+
 def cli() -> ExitCode:
     """Entry point from command line"""
     try:
         hide_cursor()
         parser, _ = get_command_parser()
         argcomplete.autocomplete(parser, always_complete_options=False)
-        parsed_pipx_args = parser.parse_args(normalize_help_command(sys.argv[1:]))
+        parsed_pipx_args = parse_pipx_args(parser, sys.argv[1:])
         _validate_fetch_python()
         setup(parsed_pipx_args)
         check_args(parsed_pipx_args)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -71,6 +71,23 @@ def test_all_subcommands_have_func_registered():
                 assert callable(sub_parser._defaults.get("func")), f"{sub_name!r} missing callable func default"
 
 
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["inject", "ansible-core", "--force", "ansible"],
+        ["inject", "ansible-core", "ansible", "--force"],
+    ],
+)
+def test_inject_accepts_force_before_or_after_dependency(argv):
+    parser, _ = main.get_command_parser()
+
+    args = main.parse_pipx_args(parser, argv)
+
+    assert args.package == "ansible-core"
+    assert args.dependencies == ["ansible"]
+    assert args.force is True
+
+
 def test_package_is_path_ignores_existing_directory(tmp_path, monkeypatch):
     # Regression for #1778: a directory in CWD with the same name as a
     # package should not be treated as a path.


### PR DESCRIPTION
### Summary

Fixes #1444.

- parse the `inject` subcommand with `parse_intermixed_args` so options can appear between the venv name and injected dependencies
- add regression coverage for both `pipx inject ansible-core --force ansible` and `pipx inject ansible-core ansible --force`
- add a bugfix changelog fragment

### Tests

- `/tmp/pipx-parser-py310-env/bin/python -m pytest tests/test_main.py::test_inject_accepts_force_before_or_after_dependency -vv --net-pypiserver`
- `/tmp/pipx-parser-py310-env/bin/python -m pytest tests/test_main.py -q --net-pypiserver`
- `HOME=/tmp/precommit-empty-home GIT_CONFIG_NOSYSTEM=1 SKIP=check-added-large-files /tmp/pipx-parser-py310-env/bin/pre-commit run --files src/pipx/main.py tests/test_main.py changelog.d/1444.bugfix.md`

I also ran the same pre-commit command without `SKIP`; every relevant hook passed, but `check-added-large-files` raised an internal `IndexError` in this local environment with Git 1.8.3.1. The changed files are small (`src/pipx/main.py`, `tests/test_main.py`, and a 101-byte changelog fragment).

### Checklist

- [x] ran the linter to address style issues (`pre-commit run --all-files`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `changelog.d/` folder (choose a type: `feature`, `bugfix`, `doc`, `removal`, or `misc`)
- [ ] updated/extended the documentation (not needed; bug fix only)