### PR TITLE
ci: declare workflow-level contents: read on 3 remaining workflows

### DIFF
--- a/.github/workflows/create_tests_package_lists.yml
+++ b/.github/workflows/create_tests_package_lists.yml
@@ -4,6 +4,8 @@ on:
 concurrency:
   group: create-tests-package-lists-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 jobs:
   create_package_lists:
     name: Create package lists

--- a/.github/workflows/exhaustive_package_test.yml
+++ b/.github/workflows/exhaustive_package_test.yml
@@ -4,6 +4,8 @@ on:
 concurrency:
   group: exhaustive-package-test-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 jobs:
   test_all_packages:
     name: Exhaustive Package Test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 jobs:
   test:
     name: 🧪 test ${{ matrix.py }} - ${{ matrix.os }}


### PR DESCRIPTION
Adds explicit `permissions: contents: read` at workflow scope to the three workflows still relying on the repo default. The existing `pre-release.yml` and `release.yml` already declare per-job `permissions:`, so this just brings the rest of `.github/workflows/` in line.

The three touched files are `tests.yml` (the regular CI matrix), `exhaustive_package_test.yml` (the slow cross-OS / cross-Python install matrix), and `create_tests_package_lists.yml` (generates the offline test fixtures). None of them calls a GitHub API beyond the initial checkout, so `contents: read` is enough and nothing else is granted.

Motivation is CVE-2025-30066, the March 2025 `tj-actions/changed-files` compromise that exfiltrated `GITHUB_TOKEN` from workflow logs with whatever scope it had been issued. Declaring the scope per workflow caps that runtime authority regardless of the repo or org default, protects against drift if the default ever widens, and is what the OpenSSF Scorecard `Token-Permissions` check looks for.

This replaces #1812, which I had to close: a force-push from a stale local base orphaned that branch's history (no common ancestor with `main`), and GitHub would not re-sync the PR head. This branch is rebuilt cleanly on current `main` as a single signed commit, and the `permissions:` block is placed with no surrounding blank lines so `yamlfmt` is happy (that was the pre-commit failure @gaborbernat flagged).