### PR TITLE
docs: fix self-managed ensurepath command

### DIFF
--- a/changelog.d/1481.doc.md
+++ b/changelog.d/1481.doc.md
@@ -1,0 +1,1 @@
+Use the bootstrap pipx executable when adding PATH in self-managed installs.

--- a/docs/how-to/install-pipx.md
+++ b/docs/how-to/install-pipx.md
@@ -166,8 +166,8 @@ relying on distro packages that may ship older versions. Bootstrap it with a tem
 python3 -m venv /tmp/bootstrap
 /tmp/bootstrap/bin/pip install pipx
 /tmp/bootstrap/bin/pipx install pipx
+/tmp/bootstrap/bin/pipx ensurepath
 rm -rf /tmp/bootstrap
-pipx ensurepath
 ```
 
 After this, `pipx upgrade pipx` upgrades pipx like any other pipx-managed application. On Windows, pipx cannot delete


### PR DESCRIPTION
## Summary

Refs #1481.

The self-managed pipx instructions installed pipx with a temporary bootstrap environment, removed that environment, and then ran `pipx ensurepath`.

On a fresh setup, the newly installed `pipx` command may not be on `PATH` yet, so that final command can fail. This updates the instructions to run `ensurepath` through the bootstrap executable before deleting `/tmp/bootstrap`, while it is still definitely available.

## Test plan

- `uv run --group lint pre-commit run --files docs/how-to/install-pipx.md changelog.d/1481.doc.md`
- `uv run --group docs mkdocs build --strict --site-dir $env:TEMP\pipx-docs-build`

## Pull Request Checklist

- [x] ran the linter to address style issues (`pre-commit run --all-files` equivalent for changed docs files)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix (docs build)
- [x] added news fragment in `changelog.d/` folder (choose a type: `feature`, `bugfix`, `doc`, `removal`, or `misc`)
- [x] updated/extended the documentation