### PR TITLE
Add --no-path-check to skip the on-PATH check in pipx run

### DIFF
--- a/changelog.d/1824.feature.md
+++ b/changelog.d/1824.feature.md
@@ -1,0 +1,2 @@
+Add `--no-path-check` to `pipx run` to skip the warning when the app is already on `PATH`. Useful for shim scripts that
+wrap `pipx run <app>` under the same name as the app.

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -179,8 +179,9 @@ def run_package(
     backend: str | None = None,
     env_backend: str | None = None,
     resolved_backend: str | None = None,
+    no_path_check: bool = False,
 ) -> NoReturn:
-    if which(app):
+    if not no_path_check and which(app):
         _LOGGER.warning(
             pipx_wrap(
                 f"""
@@ -263,6 +264,7 @@ def run(
     verbose: bool,
     use_cache: bool,
     *,
+    no_path_check: bool = False,
     backend: str | None = None,
     env_backend: str | None = None,
 ) -> NoReturn:
@@ -310,6 +312,7 @@ def run(
             venv_args=venv_args,
             use_cache=use_cache,
             verbose=verbose,
+            no_path_check=no_path_check,
         )
     else:
         package_or_url = spec if spec is not None else app
@@ -327,6 +330,7 @@ def run(
             backend=backend,
             env_backend=env_backend,
             resolved_backend=resolved_backend,
+            no_path_check=no_path_check,
         )
 
 

--- a/src/pipx/commands/run_uv.py
+++ b/src/pipx/commands/run_uv.py
@@ -50,9 +50,10 @@ def run_via_uv_tool_run(
     venv_args: list[str],
     use_cache: bool,
     verbose: bool,
+    no_path_check: bool = False,
 ) -> NoReturn:
     _reject_venv_args(venv_args)
-    if existing_app_path := which(app):
+    if not no_path_check and (existing_app_path := which(app)):
         _LOGGER.warning(
             pipx_wrap(
                 f"""

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -969,6 +969,11 @@ def _add_run(subparsers: argparse._SubParsersAction, shared_parser: argparse.Arg
         help="Do not reuse cached virtual environment if it exists",
     )
     p.add_argument(
+        "--no-path-check",
+        action="store_true",
+        help="Do not check whether the app is already on PATH",
+    )
+    p.add_argument(
         "app_with_args",
         metavar="app ...",
         nargs=argparse.REMAINDER,
@@ -1013,6 +1018,7 @@ def _cmd_run(args: argparse.Namespace, ctx: DispatchContext) -> NoReturn:
         args.pypackages,
         ctx.verbose,
         not args.no_cache,
+        no_path_check=args.no_path_check,
         backend=ctx.backend,
         env_backend=ctx.env_backend,
     )

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,3 +1,4 @@
+import importlib
 import logging
 import os
 import subprocess
@@ -60,6 +61,22 @@ def test_cache(pipx_temp_env, monkeypatch, capsys, caplog):
 
     run_pipx_cli_exit(["run", "--no-cache", "pycowsay", "cowsay", "args"])
     assert "Removing cached venv" in caplog.text
+
+
+@mock.patch("os.execvpe", new=execvpe_mock)
+def test_no_path_check(pipx_temp_env, monkeypatch, capsys, caplog):
+    def fake_which(_app):
+        return "/fake/bin/pycowsay"
+
+    for module_name in ("pipx.commands.run", "pipx.commands.run_uv"):
+        monkeypatch.setattr(importlib.import_module(module_name), "which", fake_which)
+
+    run_pipx_cli_exit(["run", "pycowsay", "cowsay", "args"])
+    assert "is already on your PATH" in caplog.text
+
+    caplog.clear()
+    run_pipx_cli_exit(["run", "--no-path-check", "pycowsay", "cowsay", "args"])
+    assert "is already on your PATH" not in caplog.text
 
 
 @mock.patch("os.execvpe", new=execvpe_mock)


### PR DESCRIPTION
For shim scripts that wrap `pipx run <app>` under the same name as the app, the on-PATH check fires on every invocation and is expected to print a warning.  `--quiet` silences it, but also drops every other warning.  `--no-path-check` skips just this check (and therefore its warning).

- fixes https://github.com/pypa/pipx/issues/1824

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://pipx.pypa.io/latest/contributing/))

- [x] ran the linter to address style issues (`pre-commit run --all-files`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `changelog.d/` folder (choose a type: `feature`, `bugfix`, `doc`, `removal`, or `misc`)
- [ ] updated/extended the documentation
