### PR TITLE
Add zizmor workflow and address findings

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,4 +9,4 @@ updates:
         patterns:
           - "*"
     cooldown:
-      default-days: 3
+      default-days: 7

--- a/.github/workflows/create_tests_package_lists.yml
+++ b/.github/workflows/create_tests_package_lists.yml
@@ -21,6 +21,8 @@ jobs:
             python-version: "3.13"
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/create_tests_package_lists.yml
+++ b/.github/workflows/create_tests_package_lists.yml
@@ -20,11 +20,11 @@ jobs:
           - os: windows-latest
             python-version: "3.13"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -33,7 +33,7 @@ jobs:
       - name: Create lists
         run: nox --non-interactive --session create_test_package_list-${{ matrix.python-version }} -- ./new_tests_packages
       - name: Store reports as artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: lists-${{ matrix.os }}-${{ matrix.python-version }}
           path: ./new_tests_packages

--- a/.github/workflows/exhaustive_package_test.yml
+++ b/.github/workflows/exhaustive_package_test.yml
@@ -16,11 +16,11 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.12", "3.11", "3.10"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -30,7 +30,7 @@ jobs:
         continue-on-error: true
         run: nox --non-interactive --session test_all_packages-${{ matrix.python-version }}
       - name: Store reports as artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: reports-raw-${{ matrix.os }}-${{ matrix.python-version }}
           path: reports
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get report artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: reports-raw-*
           merge-multiple: true
@@ -59,7 +59,7 @@ jobs:
           cat all_packages_deps_errors_* > all_deps_errors_lf.txt
           tr -d '\r' < all_deps_errors_lf.txt > reports/all_deps_errors.txt
       - name: Store collated and raw reports as artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: reports-final
           path: reports

--- a/.github/workflows/exhaustive_package_test.yml
+++ b/.github/workflows/exhaustive_package_test.yml
@@ -17,6 +17,8 @@ jobs:
         python-version: ["3.12", "3.11", "3.10"]
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -22,13 +22,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_RELEASE_TOKEN }}
           persist-credentials: false
       - name: Set up Python ${{ env.default-python }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ env.default-python }}
       - name: Install dependencies

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_RELEASE_TOKEN }}
+          persist-credentials: false
       - name: Set up Python ${{ env.default-python }}
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout ${{ github.ref_name }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: "${{ github.ref_name }}"
           persist-credentials: false
       - name: Set up Python ${{ env.default-python }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ env.default-python }}
           cache: "pip"
@@ -33,7 +33,7 @@ jobs:
           pip install build
           python -m build
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
   create-release:
     name: Create a release on GitHub's UI
     needs: pypi-publish
@@ -41,11 +41,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - name: Create release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           generate_release_notes: true
           tag_name: "${{ github.ref_name }}"
@@ -57,12 +57,12 @@ jobs:
       contents: write
     steps:
       - name: Checkout ${{ github.ref_name }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: "${{ github.ref_name }}"
           persist-credentials: false
       - name: Set up Python ${{ env.default-python }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ env.default-python }}
           cache: "pip"
@@ -71,7 +71,7 @@ jobs:
       - name: Build zipapp
         run: tox run -e zipapp
       - name: Upload to release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           files: pipx.pyz
           tag_name: "${{ github.ref_name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: "${{ github.ref_name }}"
+          persist-credentials: false
       - name: Set up Python ${{ env.default-python }}
         uses: actions/setup-python@v6
         with:
@@ -41,6 +42,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Create release
         uses: softprops/action-gh-release@v3
         with:
@@ -57,6 +60,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: "${{ github.ref_name }}"
+          persist-credentials: false
       - name: Set up Python ${{ env.default-python }}
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,10 +44,11 @@ jobs:
         with:
           persist-credentials: false
       - name: Create release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
-        with:
-          generate_release_notes: true
-          tag_name: "${{ github.ref_name }}"
+        run: |
+          gh release create --repo pypa/pipx "${RELEASE_TAG}" --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
   upload-zipapp:
     name: Upload zipapp to GitHub Release
     needs: create-release
@@ -69,7 +70,8 @@ jobs:
       - name: Build zipapp
         run: tox run -e zipapp
       - name: Upload to release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
-        with:
-          files: pipx.pyz
-          tag_name: "${{ github.ref_name }}"
+        run: |
+          gh release upload --repo pypa/pipx "${RELEASE_TAG}" pipx.pyz
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,6 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ env.default-python }}
-          cache: "pip"
       - name: Build sdist and wheel
         run: |
           pip install build
@@ -65,7 +64,6 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ env.default-python }}
-          cache: "pip"
       - name: Install tox
         run: pip install tox
       - name: Build zipapp

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: 🚀 Install uv
         uses: astral-sh/setup-uv@v8.1.0
       - name: 🐍 Setup Python ${{ matrix.py }}
@@ -60,6 +61,8 @@ jobs:
     steps:
       - name: 📥 Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: 🚀 Install uv
         uses: astral-sh/setup-uv@v8.1.0
       - name: 📦 Install tox
@@ -74,6 +77,8 @@ jobs:
     steps:
       - name: 📥 Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: 🐍 Setup Python 3.10
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,20 +29,20 @@ jobs:
             py: "3.13"
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: 🚀 Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: 🐍 Setup Python ${{ matrix.py }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.py }}
       - name: 📦 Install tox
         run: uv tool install --python-preference only-managed --python 3.13 "tox>=4.45" --with tox-uv
       - name: Persistent .pipx_tests/package_cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ${{ github.workspace }}/.pipx_tests/package_cache/${{ matrix.py }}
           key: pipx-tests-package-cache-${{ runner.os }}-${{ matrix.py }}
@@ -60,11 +60,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - name: 🚀 Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: 📦 Install tox
         run: uv tool install --python-preference only-managed --python 3.13 "tox>=4.45" --with tox-uv
       - name: 📖 Build man page
@@ -76,11 +76,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - name: 🐍 Setup Python 3.10
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.10"
       - name: 📦 Build zipapp
@@ -90,7 +90,7 @@ jobs:
           ./pipx.pyz --version
       - name: Test zipapp by installing black
         run: python ./pipx.pyz install black
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pipx.pyz
           path: pipx.pyz

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,20 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+permissions: {}
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6


### PR DESCRIPTION
This PR adds a GH workflow running `zizmor` and addresses the findings from running it:
- Pin GH actions by hash
- Use `persist-credentials: false` for `actions/checkout`
- Increase dependabot cooldown from 3 to 7 days
- Don't use GHA cache when building release artifacts
- Replace 3rd party `softprops/action-gh-release` action with the `gh` CLI tool


cc @miketheman 