### PR TITLE
Fix release push auth with persist-credentials: false

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -41,3 +41,5 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Generate changelog, commit, tag, and push
         run: python scripts/release.py --version "${{ inputs.bump }}"
+        env:
+          GH_RELEASE_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from subprocess import call, check_call
+from urllib.parse import urlsplit, urlunsplit
 
 from git import Commit, Remote, Repo, TagReference  # type: ignore[import-not-found]
 from packaging.version import Version
@@ -24,11 +26,23 @@ def main(version_str: str, *, push: bool) -> None:
     release_commit = release_changelog(repo, version)
     tag = tag_release_commit(release_commit, repo, version)
     if push:
+        # The checkout uses persist-credentials: false, so no token lives in the git config;
+        # authenticate the push via GH_RELEASE_TOKEN embedded into the remote URL.
+        push_target = authenticated_url(remote)
         print("Pushing release commit")
-        repo.git.push(remote.name, "HEAD:main")
+        repo.git.push(push_target, "HEAD:main")
         print("Pushing release tag")
-        repo.git.push(remote.name, tag)
+        repo.git.push(push_target, str(tag))
     print("All done! ✨ 🍰 ✨")
+
+
+def authenticated_url(remote: Remote) -> str:
+    if (token := os.environ.get("GH_RELEASE_TOKEN")) is None:
+        return remote.name
+    split = urlsplit(next(iter(remote.urls)))
+    if split.scheme != "https":
+        return remote.name
+    return urlunsplit(split._replace(netloc=f"x-access-token:{token}@{split.hostname}"))
 
 
 def resolve_version(version_str: str, repo: Repo) -> Version:


### PR DESCRIPTION
## What

The [pre-release run](https://github.com/pypa/pipx/actions/runs/26932230752) failed at the push step:

```
fatal: could not read Username for 'https://github.com': No such device or address
  cmdline: git push origin HEAD:main
```

## Why

#1827 (zizmor findings) added `persist-credentials: false` to the pre-release checkout. That stops `actions/checkout` from writing `GH_RELEASE_TOKEN` into the git config, so `scripts/release.py`'s `git push` had no credentials.

## Fix

- Pass `GH_RELEASE_TOKEN` to the release step as an env var.
- In `release.py`, embed the token into the `https` remote URL for the push instead of relying on persisted credentials.

This keeps `persist-credentials: false` (no powerful PAT left in `.git/config` for later steps) while restoring the push. GitPython redacts userinfo in URLs, so the token is not exposed in logs. Falls back to the bare remote name when the token is absent or the remote is not `https` (local runs).