### PR TITLE
Fix pipx.util import cycle

### DIFF
--- a/changelog.d/1333.bugfix.md
+++ b/changelog.d/1333.bugfix.md
@@ -1,0 +1,1 @@
+Allow importing `pipx.util` before `pipx.paths`.

--- a/src/pipx/paths.py
+++ b/src/pipx/paths.py
@@ -6,7 +6,7 @@ from platformdirs import user_cache_path, user_data_path, user_log_path
 
 from pipx.constants import LINUX, WINDOWS
 from pipx.emojis import hazard, strtobool
-from pipx.util import pipx_wrap
+from pipx.wrap import pipx_wrap
 
 if LINUX:
     DEFAULT_PIPX_HOME = Path(user_data_path("pipx"))

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -6,7 +6,6 @@ import shutil
 import string
 import subprocess
 import sys
-import textwrap
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -20,6 +19,7 @@ from typing import (
 from pipx import paths
 from pipx.animate import show_cursor
 from pipx.constants import MINGW, WINDOWS
+from pipx.wrap import pipx_wrap
 
 _LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
@@ -417,33 +417,6 @@ def full_package_description(package_name: str, package_spec: str) -> str:
         return package_name
     else:
         return f"{package_name} from spec {package_spec!r}"
-
-
-def pipx_wrap(text: str, subsequent_indent: str = "", keep_newlines: bool = False) -> str:
-    """Dedent, strip, wrap to shell width. Don't break on hyphens, only spaces"""
-    minimum_width = 40
-    width = max(shutil.get_terminal_size((80, 40)).columns, minimum_width) - 2
-
-    text = textwrap.dedent(text).strip()
-    if keep_newlines:
-        return "\n".join(
-            [
-                textwrap.fill(
-                    line,
-                    width=width,
-                    subsequent_indent=subsequent_indent,
-                    break_on_hyphens=False,
-                )
-                for line in text.splitlines()
-            ]
-        )
-    else:
-        return textwrap.fill(
-            text,
-            width=width,
-            subsequent_indent=subsequent_indent,
-            break_on_hyphens=False,
-        )
 
 
 def is_paths_relative(path: Path, parent: Path):

--- a/src/pipx/wrap.py
+++ b/src/pipx/wrap.py
@@ -1,0 +1,29 @@
+import shutil
+import textwrap
+
+
+def pipx_wrap(text: str, subsequent_indent: str = "", keep_newlines: bool = False) -> str:
+    """Dedent, strip, wrap to shell width. Don't break on hyphens, only spaces"""
+    minimum_width = 40
+    width = max(shutil.get_terminal_size((80, 40)).columns, minimum_width) - 2
+
+    text = textwrap.dedent(text).strip()
+    if keep_newlines:
+        return "\n".join(
+            [
+                textwrap.fill(
+                    line,
+                    width=width,
+                    subsequent_indent=subsequent_indent,
+                    break_on_hyphens=False,
+                )
+                for line in text.splitlines()
+            ]
+        )
+    else:
+        return textwrap.fill(
+            text,
+            width=width,
+            subsequent_indent=subsequent_indent,
+            break_on_hyphens=False,
+        )

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,19 @@
+import os
+import subprocess
+import sys
+
+
+def test_importing_util_first_succeeds(root):
+    env = {**os.environ, "PYTHONPATH": str(root / "src")}
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import pipx.util; print('Success!')"],
+        check=False,
+        capture_output=True,
+        cwd=root,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "Success!\n"


### PR DESCRIPTION
Fixes #1333.

## What changed
- Move `pipx_wrap` into dependency-light `pipx.wrap`.
- Keep `pipx.util.pipx_wrap` available by importing/re-exporting it from `pipx.util`.
- Add import-order regression coverage and changelog fragment.

## Verification
- `$env:PYTHONPATH='src'; .venv\Scripts\python.exe -m pytest tests\test_imports.py tests\test_util.py --net-pypiserver -q`
- `.venv\Scripts\python.exe -m ruff check src\pipx\wrap.py src\pipx\util.py src\pipx\paths.py tests\test_imports.py`
- `.venv\Scripts\python.exe -m ruff format --check src\pipx\wrap.py src\pipx\util.py src\pipx\paths.py tests\test_imports.py`
- `.venv\Scripts\python.exe -B -m py_compile src\pipx\wrap.py src\pipx\util.py src\pipx\paths.py tests\test_imports.py`
- `git diff --check origin/main...HEAD`