### PR TITLE
Fix inject --force reinstall behavior

### DIFF
--- a/changelog.d/1545.bugfix.md
+++ b/changelog.d/1545.bugfix.md
@@ -1,0 +1,1 @@
+Ensure `pipx inject --force` reinstalls injected packages without persisting the force-reinstall option in package metadata.

--- a/changelog.d/1545.bugfix.md
+++ b/changelog.d/1545.bugfix.md
@@ -1,1 +1,2 @@
-Ensure `pipx inject --force` reinstalls injected packages without persisting the force-reinstall option in package metadata.
+Ensure `pipx inject --force` reinstalls injected packages without persisting the force-reinstall option in package
+metadata.

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -97,6 +97,7 @@ def inject_dep(
         package_name=package_name,
         package_or_url=package_spec,
         pip_args=pip_args,
+        install_only_pip_args=["--force-reinstall"] if force else None,
         include_dependencies=include_dependencies,
         include_apps=include_apps,
         is_main_package=False,

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -324,12 +324,14 @@ class Venv:
         include_apps: bool,
         is_main_package: bool,
         suffix: str = "",
+        install_only_pip_args: list[str] | None = None,
     ) -> None:
         # package_name in package specifier can mismatch URL due to user error
         package_or_url = fix_package_name(package_or_url, package_name)
 
         # check syntax and clean up spec and pip_args
         (package_or_url, pip_args) = parse_specifier_for_install(package_or_url, pip_args)
+        install_pip_args = [*(install_only_pip_args or []), *pip_args]
 
         _LOGGER.info("Installing %s", package_descr := full_package_description(package_name, package_or_url))
         with animate(f"installing {package_descr}", self.do_animation):
@@ -337,7 +339,7 @@ class Venv:
                 venv_root=self.root,
                 venv_python=self.python_path,
                 requirements=[package_or_url],
-                pip_args=pip_args,
+                pip_args=install_pip_args,
                 verbose=self.verbose,
             )
         if process.returncode:

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -6,6 +6,8 @@ import pytest
 
 from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli, skip_if_windows
 from package_info import PKG
+from pipx import paths
+from pipx.pipx_metadata_file import PipxMetadata
 
 
 # Note that this also checks that packages used in other tests can be injected individually
@@ -113,3 +115,25 @@ def test_inject_with_req_file(pipx_temp_env, capsys, caplog, tmp_path, with_pack
     captured = capsys.readouterr()
     injected = re.findall(r"injected package (.+?) into venv pycowsay", captured.out)
     assert set(injected) == {pkg for pkg, _ in packages}
+
+
+def test_force_inject_reinstalls_without_storing_force(pipx_temp_env, caplog):
+    assert not run_pipx_cli(["install", "pycowsay"])
+    assert not run_pipx_cli(["inject", "pycowsay", PKG["black"]["spec"], "--pip-args=--no-cache-dir"])
+
+    caplog.clear()
+    assert not run_pipx_cli(
+        [
+            "inject",
+            "pycowsay",
+            PKG["black"]["spec"],
+            "--force",
+            "--verbose",
+            "--pip-args=--no-cache-dir",
+        ]
+    )
+
+    assert "--force-reinstall" in caplog.text
+
+    metadata = PipxMetadata(paths.ctx.venvs / "pycowsay")
+    assert metadata.injected_packages["black"].pip_args == ["--no-cache-dir"]


### PR DESCRIPTION
Fixes #1545.

### Summary
- pass `--force-reinstall` to the actual `pip install` call when `pipx inject --force` targets an already injected package
- keep `--force-reinstall` out of stored package metadata so later upgrade/reinstall operations preserve the user's original pip args
- add a regression test covering both the pip invocation and persisted metadata

### Tests
- `python -m pytest tests\test_inject.py::test_force_inject_reinstalls_without_storing_force --net-pypiserver -q`
- `python -m pytest tests\test_inject.py --net-pypiserver -q`
- `python -m ruff check src\pipx\commands\inject.py src\pipx\venv.py tests\test_inject.py`
- `python -m ruff format --check src\pipx\commands\inject.py src\pipx\venv.py tests\test_inject.py`
- `git diff --check`

### Checklist
- [x] ran the linter to address style issues (`pre-commit run --all-files`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `changelog.d/` folder (choose a type: `feature`, `bugfix`, `doc`, `removal`, or `misc`)
- [ ] updated/extended the documentation - not applicable; this fixes existing `--force` behavior