### PR TITLE
Fix pin --injected-only for pinned apps

### DIFF
--- a/changelog.d/1835.bugfix.md
+++ b/changelog.d/1835.bugfix.md
@@ -1,0 +1,1 @@
+Fixed `pipx pin <app> --injected-only` so it can pin injected packages when the main app is already pinned.

--- a/src/pipx/commands/pin.py
+++ b/src/pipx/commands/pin.py
@@ -38,9 +38,7 @@ def pin(
     except KeyError as e:
         raise PipxError(f"Package {venv.name} is not installed") from e
 
-    if main_package_metadata.pinned:
-        logger.warning(f"Package {main_package_metadata.package} already pinned {sleep}")
-    elif injected_only or skip:
+    if injected_only or skip:
         pinned_packages_count = 0
         pinned_packages_list = []
         for package_name in venv.package_metadata:
@@ -58,6 +56,8 @@ def pin(
             print(bold(f"Pinned {pinned_packages_count} packages in venv {venv.name}"))
             for package in pinned_packages_list:
                 print("  -", package)
+    elif main_package_metadata.pinned:
+        logger.warning(f"Package {main_package_metadata.package} already pinned {sleep}")
     else:
         for package_name in venv.package_metadata:
             if package_name == venv.main_package_name:

--- a/tests/test_pin.py
+++ b/tests/test_pin.py
@@ -51,6 +51,30 @@ def test_pin_injected_packages_only(capsys, pipx_temp_env, caplog):
     assert "Not upgrading pinned package pylint in venv pycowsay" in caplog.text
 
 
+def test_pin_injected_packages_only_when_main_package_pinned(capsys, pipx_temp_env, caplog):
+    assert not run_pipx_cli(["install", "pycowsay"])
+    assert not run_pipx_cli(["pin", "pycowsay"])
+    assert not run_pipx_cli(["inject", "pycowsay", "black", PKG["pylint"]["spec"]])
+
+    _ = capsys.readouterr()
+    caplog.clear()
+
+    assert not run_pipx_cli(["pin", "pycowsay", "--injected-only"])
+
+    captured = capsys.readouterr()
+
+    assert "Pinned 2 packages in venv pycowsay" in captured.out
+    assert "black" in captured.out
+    assert "pylint" in captured.out
+    assert "Package pycowsay already pinned" not in caplog.text
+
+    assert not run_pipx_cli(["upgrade", "pycowsay", "--include-injected"])
+
+    assert "Not upgrading pinned package pycowsay" in caplog.text
+    assert "Not upgrading pinned package black in venv pycowsay" in caplog.text
+    assert "Not upgrading pinned package pylint in venv pycowsay" in caplog.text
+
+
 def test_pin_injected_packages_with_skip(capsys, pipx_temp_env):
     assert not run_pipx_cli(["install", "black"])
     assert not run_pipx_cli(["inject", "black", PKG["pylint"]["spec"], PKG["isort"]["spec"]])


### PR DESCRIPTION
## Summary
- allow `pipx pin <app> --injected-only` to operate even when the main app is already pinned
- add a regression test for apps pinned before later injected packages are added

## Tests
- `.\.venv\Scripts\python.exe -m pytest tests/test_pin.py -q`
- `.\.venv\Scripts\python.exe -m pytest tests/test_upgrade.py::test_upgrade_include_injected tests/test_upgrade.py::test_upgrade_no_include_injected tests/test_upgrade.py::test_upgrade_injected_preserves_stored_pip_args tests/test_inject.py -q`
- `.\.venv\Scripts\python.exe -m compileall -q src\pipx\commands\pin.py tests\test_pin.py`
- `uvx ruff check src\pipx\commands\pin.py tests\test_pin.py`