### PR TITLE
Preserve installer errors during package name detection

### DIFF
--- a/changelog.d/1567.bugfix.md
+++ b/changelog.d/1567.bugfix.md
@@ -1,0 +1,1 @@
+Preserve installer errors when package-name detection fails during local package installs.

--- a/src/pipx/backends/pip.py
+++ b/src/pipx/backends/pip.py
@@ -95,8 +95,6 @@ class PipBackend(Backend):
         )
         if log_pip_errors:
             subprocess_post_check_handle_pip_error(process)
-        else:
-            subprocess_post_check(process, raise_error=False)
         return process
 
     def uninstall(

--- a/src/pipx/backends/uv.py
+++ b/src/pipx/backends/uv.py
@@ -113,8 +113,6 @@ class UvBackend(Backend):
         )
         if log_pip_errors:
             subprocess_post_check_handle_pip_error(process, tool_name="uv")
-        else:
-            subprocess_post_check(process, raise_error=False)
         return process
 
     def uninstall(

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -390,10 +390,13 @@ class Venv:
                 verbose=self.verbose,
             )
         if process.returncode:
+            error_output = (process.stderr or process.stdout or "").strip()
+            if error_output:
+                raise PipxError(error_output, wrap_message=False)
             raise PipxError(
                 f"""
-                Cannot determine package name from spec {package_or_url!r}.
-                Check package spec for errors.
+                Error determining package name from spec {package_or_url!r}.
+                See installer output for details.
                 """
             )
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -10,6 +10,8 @@ import pytest
 from helpers import app_name, run_pipx_cli, skip_if_windows, unwrap_log_text
 from package_info import PKG
 from pipx import paths, shared_libs
+from pipx.util import PipxError
+from pipx.venv import Venv
 
 TEST_DATA_PATH = "./testdata/test_package_specifier"
 
@@ -263,7 +265,33 @@ def test_pip_args_forwarded_to_package_name_determination(pipx_temp_env, capsys)
         ]
     )
     captured = capsys.readouterr()
-    assert "Cannot determine package name from spec" in captured.err
+    assert "--asdf" in captured.err
+    assert "Cannot determine package name from spec" not in captured.err
+
+
+def test_package_name_determination_preserves_install_error(monkeypatch):
+    class FailingBackend:
+        def install(self, **kwargs):
+            return subprocess.CompletedProcess(
+                ["pip", "install", "requires-newer-python"],
+                1,
+                stdout="",
+                stderr="ERROR: Package 'requires-newer-python' requires a different Python\n",
+            )
+
+    def no_installed_packages():
+        return set()
+
+    venv = Venv(Path("requires-newer-python-venv"))
+    monkeypatch.setattr(venv, "_backend", FailingBackend())
+    monkeypatch.setattr(venv, "list_installed_packages", no_installed_packages)
+
+    with pytest.raises(PipxError) as excinfo:
+        venv.install_package_no_deps("requires-newer-python", [])
+
+    error = str(excinfo.value)
+    assert "requires a different Python" in error
+    assert "Cannot determine package name from spec" not in error
 
 
 @pytest.mark.skipif(not sys.platform.startswith("win"), reason="Windows only")


### PR DESCRIPTION
## Summary
- Preserve the real installer stderr/stdout when package-name detection fails during no-deps installs.
- Avoid replacing useful errors such as `requires a different Python` with the generic `Cannot determine package name from spec` message.
- Let callers that use `log_pip_errors=False` decide how to handle failed install processes, matching the existing post-check calls in upgrade paths.

Fixes #1567.

## Tests
- `python -m pytest --net-pypiserver -p no:cacheprovider tests/test_install.py::test_package_name_determination_preserves_install_error -q`
- `ruff check --no-cache src/pipx/backends/pip.py src/pipx/backends/uv.py src/pipx/venv.py tests/test_install.py`
- `ruff format --check --no-cache src/pipx/backends/pip.py src/pipx/backends/uv.py src/pipx/venv.py tests/test_install.py`
- `python -m compileall -q src/pipx/backends/pip.py src/pipx/backends/uv.py src/pipx/venv.py tests/test_install.py`