### PR TITLE
Add --dry-run flag to pipx ensurepath

### DIFF
--- a/changelog.d/1014.feature.md
+++ b/changelog.d/1014.feature.md
@@ -1,0 +1,1 @@
+Add a `--dry-run` flag to `pipx ensurepath` that reports which directories would be added to `PATH` without modifying `PATH` or any shell configuration file.

--- a/changelog.d/1014.feature.md
+++ b/changelog.d/1014.feature.md
@@ -1,1 +1,2 @@
-Add a `--dry-run` flag to `pipx ensurepath` that reports which directories would be added to `PATH` without modifying `PATH` or any shell configuration file.
+Add a `--dry-run` flag to `pipx ensurepath` that reports which directories would be added to `PATH` without modifying
+`PATH` or any shell configuration file.

--- a/docs/how-to/configure-paths.md
+++ b/docs/how-to/configure-paths.md
@@ -73,6 +73,12 @@ The `--prepend` argument can be passed to the `pipx ensurepath` command to prepe
 user's PATH environment variable instead of appending to it. This can be useful if you want to prioritise
 `pipx`-installed binaries over system-installed binaries of the same name.
 
+#### `--dry-run` argument
+
+The `--dry-run` argument can be passed to the `pipx ensurepath` command to report which directories would be added to
+your PATH without modifying PATH or any shell configuration file. This lets you preview the changes before running
+`pipx ensurepath` for real.
+
 ### Configuring pip for pipx
 
 pipx uses pip internally for all package installs, including its own shared libraries (pip, setuptools). To point pip at

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -50,9 +50,13 @@ def get_pipx_user_bin_path() -> Path | None:
     return pipx_bin_path
 
 
-def ensure_path(location: Path, *, force: bool, prepend: bool = False, all_shells: bool = False) -> tuple[bool, bool]:
+def ensure_path(
+    location: Path, *, force: bool, prepend: bool = False, all_shells: bool = False, dry_run: bool = False
+) -> tuple[bool, bool]:
     """Ensure location is in user's PATH or add it to PATH.
     If prepend is True, location will be prepended to PATH, else appended.
+    If dry_run is True, report what would change without modifying PATH or
+    any shell configuration file.
     Returns True if location was added to PATH
     """
     location_str = str(location)
@@ -61,6 +65,15 @@ def ensure_path(location: Path, *, force: bool, prepend: bool = False, all_shell
     in_current_path = userpath.in_current_path(location_str)
 
     if force or (not in_current_path and not need_shell_restart):
+        if dry_run:
+            action = "prepend" if prepend else "append"
+            print(
+                pipx_wrap(
+                    f"Would {action} {location_str} to the PATH environment variable.",
+                    subsequent_indent=" " * 4,
+                )
+            )
+            return (False, False)
         if prepend:
             path_added = userpath.prepend(location_str, "pipx", all_shells=all_shells)
         else:
@@ -99,7 +112,7 @@ def ensure_path(location: Path, *, force: bool, prepend: bool = False, all_shell
     return (path_added, need_shell_restart)
 
 
-def ensure_pipx_paths(force: bool, prepend: bool = False, all_shells: bool = False) -> ExitCode:
+def ensure_pipx_paths(force: bool, prepend: bool = False, all_shells: bool = False, dry_run: bool = False) -> ExitCode:
     """Returns pipx exit code."""
     bin_paths = {paths.ctx.bin_dir}
 
@@ -113,12 +126,16 @@ def ensure_pipx_paths(force: bool, prepend: bool = False, all_shells: bool = Fal
 
     for bin_path in bin_paths:
         (path_added_current, need_shell_restart_current) = ensure_path(
-            bin_path, prepend=prepend, force=force, all_shells=all_shells
+            bin_path, prepend=prepend, force=force, all_shells=all_shells, dry_run=dry_run
         )
         path_added |= path_added_current
         need_shell_restart |= need_shell_restart_current
 
     print()
+
+    if dry_run:
+        print(pipx_wrap("This was a dry run; no changes were made to your PATH or shell configuration files."))
+        return EXIT_CODE_OK
 
     if path_added:
         print(

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -1083,12 +1083,19 @@ def _add_ensurepath(subparsers: argparse._SubParsersAction, shared_parser: argpa
         action="store_true",
         help=("Add directories to PATH in all shells instead of just the current one."),
     )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=("Report what would be added to PATH without modifying PATH or any shell configuration file."),
+    )
     p.set_defaults(func=_cmd_ensurepath)
 
 
 def _cmd_ensurepath(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
     try:
-        return commands.ensure_pipx_paths(prepend=args.prepend, force=args.force, all_shells=args.all_shells)
+        return commands.ensure_pipx_paths(
+            prepend=args.prepend, force=args.force, all_shells=args.all_shells, dry_run=args.dry_run
+        )
     except Exception as e:
         logger.debug("Uncaught Exception:", exc_info=True)
         raise PipxError(str(e), wrap_message=False) from None

--- a/tests/test_ensurepath.py
+++ b/tests/test_ensurepath.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+
+import pytest
+
+from pipx.commands import ensure_path as ensure_path_module
+from pipx.constants import EXIT_CODE_OK
+
+
+class FakeUserpath:
+    """Minimal stand-in for the ``userpath`` module used by ensure_path.
+
+    Records append/prepend calls so tests can assert that a dry run never
+    mutates PATH or any shell configuration file.
+    """
+
+    def __init__(self) -> None:
+        self.append_calls: list[str] = []
+        self.prepend_calls: list[str] = []
+        self.in_path = False
+        self.restart = False
+
+    def need_shell_restart(self, location: str) -> bool:
+        return self.restart
+
+    def in_current_path(self, location: str) -> bool:
+        return self.in_path
+
+    def append(self, location: str, app: str, all_shells: bool = False) -> bool:
+        self.append_calls.append(location)
+        return True
+
+    def prepend(self, location: str, app: str, all_shells: bool = False) -> bool:
+        self.prepend_calls.append(location)
+        return True
+
+
+@pytest.fixture
+def mock_userpath(monkeypatch: pytest.MonkeyPatch) -> FakeUserpath:
+    fake = FakeUserpath()
+    monkeypatch.setattr(ensure_path_module, "userpath", fake)
+    return fake
+
+
+def test_ensure_path_dry_run_does_not_append(mock_userpath: FakeUserpath, capsys: pytest.CaptureFixture[str]) -> None:
+    location = Path("/some/bin")
+    path_added, _ = ensure_path_module.ensure_path(location, force=True, dry_run=True)
+
+    assert path_added is False
+    assert mock_userpath.append_calls == []
+    assert mock_userpath.prepend_calls == []
+    assert "Would append" in capsys.readouterr().out
+
+
+def test_ensure_path_dry_run_reports_prepend(mock_userpath: FakeUserpath, capsys: pytest.CaptureFixture[str]) -> None:
+    location = Path("/some/bin")
+    ensure_path_module.ensure_path(location, force=True, prepend=True, dry_run=True)
+
+    assert mock_userpath.prepend_calls == []
+    assert "Would prepend" in capsys.readouterr().out
+
+
+def test_ensure_path_non_dry_run_still_appends(mock_userpath: FakeUserpath, capsys: pytest.CaptureFixture[str]) -> None:
+    location = Path("/some/bin")
+    ensure_path_module.ensure_path(location, force=True)
+
+    assert mock_userpath.append_calls == [str(location)]
+    assert "Success!" in capsys.readouterr().out
+
+
+def test_ensure_pipx_paths_dry_run_footer(mock_userpath: FakeUserpath, capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = ensure_path_module.ensure_pipx_paths(force=True, dry_run=True)
+
+    assert exit_code == EXIT_CODE_OK
+    assert mock_userpath.append_calls == []
+    out = capsys.readouterr().out.lower()
+    assert "dry run" in out
+    assert "no changes were made" in out


### PR DESCRIPTION
Adds a `--dry-run` flag to `pipx ensurepath` that reports which directories
would be added to `PATH` without modifying `PATH` or any shell configuration
file, so users can preview the change before running it for real (closes #1014).

The flag threads a `dry_run` parameter through `ensure_pipx_paths` →
`ensure_path`; in dry-run mode `userpath.append`/`prepend` are never called and
a "Would append/prepend ..." line plus a "no changes were made" footer are
printed instead.

- [x] ran the linter to address style issues (`pre-commit run --all-files`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `changelog.d/` folder (`feature`)
- [x] updated/extended the documentation

### Validation
- New `tests/test_ensurepath.py` (4 tests — first test file for this command):
  asserts dry-run never calls `userpath.append`/`prepend`, never mutates config,
  and checks the footer + `EXIT_CODE_OK`.
- `ruff check` + `ruff format --check` clean on all changed files.
- End-to-end `pipx ensurepath --dry-run --force` prints `Would append ...` and
  the no-changes footer without touching PATH.