### PR TITLE
Avoid uv --not-required failures in uninject

### DIFF
--- a/changelog.d/1841.bugfix.md
+++ b/changelog.d/1841.bugfix.md
@@ -1,0 +1,1 @@
+Handle uv backends without `--not-required` support during `pipx uninject`.

--- a/src/pipx/backends/uv.py
+++ b/src/pipx/backends/uv.py
@@ -141,6 +141,10 @@ class UvBackend(Backend):
         if not_required:
             cmd.append("--not-required")
         process = run_subprocess(cmd, run_dir=str(venv_root), env_overrides=_UV_ENV_OVERRIDES)
+        stderr = process.stderr or ""
+        if process.returncode != 0 and not_required and "--not-required" in stderr and "unexpected argument" in stderr:
+            _LOGGER.info("uv pip list does not support --not-required yet; skipping dependency cleanup")
+            return set()
         if process.returncode != 0:
             raise PipxError(
                 f"Failed to execute {process.args}.\n"

--- a/tests/test_uninject.py
+++ b/tests/test_uninject.py
@@ -1,3 +1,8 @@
+import shutil
+import sys
+
+import pytest
+
 from helpers import run_pipx_cli, skip_if_windows
 from package_info import PKG
 
@@ -61,3 +66,12 @@ def test_uninject_preserves_shared_deps(pipx_temp_env, capsys):
     captured = capsys.readouterr()
     assert "pylint" in captured.out
     assert "black" not in captured.out
+
+
+@pytest.mark.skipif(shutil.which("uv") is None, reason="uv binary not on PATH; skipping uv integration smoke")
+def test_uninject_with_uv_backend(pipx_temp_env, capsys):
+    assert not run_pipx_cli(["install", "pycowsay", "--backend", "uv", "--python", sys.executable])
+    assert not run_pipx_cli(["inject", "pycowsay", PKG["black"]["spec"]])
+    assert not run_pipx_cli(["uninject", "pycowsay", "black"])
+    captured = capsys.readouterr()
+    assert "Uninjected package black" in captured.out


### PR DESCRIPTION
pipx uninject currently calls uv pip list --not-required, but uv does not implement that flag yet. That made uninject fail before removing the injected package.

This change handles that specific uv error and continues by skipping dependency cleanup instead of aborting.

It also adds a uv backend regression test for uninject and includes a changelog fragment.

Fixes #1841

Verification:
- /opt/homebrew/bin/python3.12 -m venv .venv
- .venv/bin/pip install -e .
- .venv/bin/pip install "pytest>=8" "pytest-mock>=3.11.1" "pypiserver[cache,passlib]>=2.3.2" "watchdog>=4"
- .venv/bin/pytest tests/test_uninject.py -k test_uninject_with_uv_backend
- .venv/bin/python -m pip install ruff
- .venv/bin/ruff check src/pipx/backends/uv.py tests/test_uninject.py