### PR TITLE
Fix uninject for uv-backed venvs

### DIFF
--- a/changelog.d/1841.bugfix
+++ b/changelog.d/1841.bugfix
@@ -1,0 +1,1 @@
+Fix `pipx uninject` for uv-backed environments by avoiding uv's unsupported `pip list --not-required` option.

--- a/changelog.d/1841.bugfix
+++ b/changelog.d/1841.bugfix
@@ -1,1 +1,1 @@
-Fix `pipx uninject` for uv-backed environments by avoiding uv's unsupported `pip list --not-required` option.
+Fix `pipx uninject` for uv-backed environments, where uv lacks pip's `list --not-required` option. Both backends now derive the not-required set from installed distribution metadata, so they behave identically, and a dependency pulled in only by another package's extra is kept instead of being treated as removable.

--- a/src/pipx/backends/pip.py
+++ b/src/pipx/backends/pip.py
@@ -16,6 +16,7 @@ from pipx.util import (
     subprocess_post_check,
     subprocess_post_check_handle_pip_error,
 )
+from pipx.venv_inspect import list_not_required_packages
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -120,9 +121,9 @@ class PipBackend(Backend):
         not_required: bool = False,
     ) -> set[str]:
         del venv_root
-        cmd = [str(venv_python), "-m", "pip", "list", "--format=json"]
         if not_required:
-            cmd.append("--not-required")
+            return list_not_required_packages(venv_python)
+        cmd = [str(venv_python), "-m", "pip", "list", "--format=json"]
         process = run_subprocess(cmd)
         if process.returncode != 0:
             raise PipxError(

--- a/src/pipx/backends/uv.py
+++ b/src/pipx/backends/uv.py
@@ -6,9 +6,11 @@ import re
 import shutil
 import subprocess
 from functools import cache
+from importlib import metadata
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
+from packaging.utils import canonicalize_name
 from packaging.version import InvalidVersion, Version
 
 from pipx.animate import animate
@@ -19,6 +21,7 @@ from pipx.util import (
     subprocess_post_check,
     subprocess_post_check_handle_pip_error,
 )
+from pipx.venv_inspect import fetch_info_in_venv, get_package_dependencies
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -136,10 +139,11 @@ class UvBackend(Backend):
         venv_python: Path,
         not_required: bool = False,
     ) -> set[str]:
+        if not_required:
+            return _list_not_required_from_metadata(venv_python)
+
         cmd = self._uv_pip_command("list", venv_python, verbose=False)
         cmd += ["--format", "json"]
-        if not_required:
-            cmd.append("--not-required")
         process = run_subprocess(cmd, run_dir=str(venv_root), env_overrides=_UV_ENV_OVERRIDES)
         if process.returncode != 0:
             raise PipxError(
@@ -179,6 +183,20 @@ class UvBackend(Backend):
         cmd: list[str | Path] = [self._binary, "pip", subcommand, "--python", str(venv_python)]
         cmd.append("--verbose" if verbose else "--quiet")
         return cmd
+
+
+def _list_not_required_from_metadata(venv_python: Path) -> set[str]:
+    venv_sys_path, venv_env, _ = fetch_info_in_venv(venv_python)
+    distributions = tuple(metadata.distributions(path=venv_sys_path))
+    installed_packages = {
+        str(canonicalize_name(name)) for dist in distributions if (name := dist.metadata.get("Name")) is not None
+    }
+    required_packages = {
+        str(canonicalize_name(requirement.name))
+        for dist in distributions
+        for requirement in get_package_dependencies(dist, set(), venv_env)
+    }
+    return installed_packages - required_packages
 
 
 def resolve_uv_binary() -> Path:

--- a/src/pipx/backends/uv.py
+++ b/src/pipx/backends/uv.py
@@ -6,11 +6,9 @@ import re
 import shutil
 import subprocess
 from functools import cache
-from importlib import metadata
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
-from packaging.utils import canonicalize_name
 from packaging.version import InvalidVersion, Version
 
 from pipx.animate import animate
@@ -21,7 +19,7 @@ from pipx.util import (
     subprocess_post_check,
     subprocess_post_check_handle_pip_error,
 )
-from pipx.venv_inspect import fetch_info_in_venv, get_package_dependencies
+from pipx.venv_inspect import list_not_required_packages
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -140,7 +138,7 @@ class UvBackend(Backend):
         not_required: bool = False,
     ) -> set[str]:
         if not_required:
-            return _list_not_required_from_metadata(venv_python)
+            return list_not_required_packages(venv_python)
 
         cmd = self._uv_pip_command("list", venv_python, verbose=False)
         cmd += ["--format", "json"]
@@ -183,20 +181,6 @@ class UvBackend(Backend):
         cmd: list[str | Path] = [self._binary, "pip", subcommand, "--python", str(venv_python)]
         cmd.append("--verbose" if verbose else "--quiet")
         return cmd
-
-
-def _list_not_required_from_metadata(venv_python: Path) -> set[str]:
-    venv_sys_path, venv_env, _ = fetch_info_in_venv(venv_python)
-    distributions = tuple(metadata.distributions(path=venv_sys_path))
-    installed_packages = {
-        str(canonicalize_name(name)) for dist in distributions if (name := dist.metadata.get("Name")) is not None
-    }
-    required_packages = {
-        str(canonicalize_name(requirement.name))
-        for dist in distributions
-        for requirement in get_package_dependencies(dist, set(), venv_env)
-    }
-    return installed_packages - required_packages
 
 
 def resolve_uv_binary() -> Path:

--- a/src/pipx/commands/uninject.py
+++ b/src/pipx/commands/uninject.py
@@ -19,7 +19,7 @@ from pipx.constants import (
 from pipx.emojis import stars
 from pipx.util import PipxError, pipx_wrap
 from pipx.venv import Venv
-from pipx.venv_inspect import fetch_info_in_venv, get_dist, get_package_dependencies
+from pipx.venv_inspect import fetch_info_in_venv, get_dist, get_required_dependency_names
 
 logger = logging.getLogger(__name__)
 
@@ -193,6 +193,6 @@ def _collect_transitive_deps(
         return visited
     visited.add(canonical)
     if dist := get_dist(package_name, distributions):
-        for dep_req in get_package_dependencies(dist, set(), env):
-            _collect_transitive_deps(dep_req.name, distributions, env, visited)
+        for dep_name in get_required_dependency_names(dist, env):
+            _collect_transitive_deps(dep_name, distributions, env, visited)
     return visited

--- a/src/pipx/venv_inspect.py
+++ b/src/pipx/venv_inspect.py
@@ -76,6 +76,34 @@ def get_package_dependencies(dist: metadata.Distribution, extras: set[str], env:
     return dependencies
 
 
+def get_required_dependency_names(dist: metadata.Distribution, env: dict[str, str]) -> set[str]:
+    """Canonical names ``dist`` depends on, including dependencies behind its declared extras.
+
+    Considering every declared extra is deliberately conservative: a dependency that is only pulled
+    in by an extra is still treated as required, so it is never reported as removable while the
+    package declaring it stays installed.
+    """
+    extras = set(dist.metadata.get_all("Provides-Extra") or [])
+    return {canonicalize_name(req.name) for req in get_package_dependencies(dist, extras, env)}
+
+
+def list_not_required_packages(venv_python: Path) -> set[str]:
+    """Canonical names of installed packages that no other installed package requires.
+
+    Mirrors ``pip list --not-required`` from installed distribution metadata so every backend
+    (including uv, which lacks the flag) computes the same result.
+    """
+    venv_sys_path, venv_env, _ = fetch_info_in_venv(venv_python)
+    distributions = tuple(metadata.distributions(path=venv_sys_path))
+    installed: set[str] = set()
+    required: set[str] = set()
+    for dist in distributions:
+        if (name := dist.metadata["Name"]) is not None:
+            installed.add(canonicalize_name(name))
+        required |= get_required_dependency_names(dist, venv_env)
+    return installed - required
+
+
 def get_apps_from_entry_points(dist: metadata.Distribution, bin_path: Path):
     app_names = set()
     sections = {"console_scripts", "gui_scripts"}

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -16,6 +16,7 @@ from pipx.backends import (
     find_uv_binary,
     resolve_backend_name,
 )
+from pipx.backends.uv import UvBackend
 from pipx.commands.run_uv import translate_pip_args_for_uv
 from pipx.main import _validate_backend_available
 from pipx.util import PipxError
@@ -62,6 +63,14 @@ class _LegacyMetadata(TypedDict):
 
 class _CurrentMetadata(_LegacyMetadata):
     backend: str
+
+
+def _write_dist_info(site_packages: Path, name: str, requires: list[str] | None = None) -> None:
+    dist_info = site_packages / f"{name}-1.0.dist-info"
+    dist_info.mkdir()
+    metadata = [f"Name: {name}", "Version: 1.0"]
+    metadata += [f"Requires-Dist: {requirement}" for requirement in requires or []]
+    (dist_info / "METADATA").write_text("\n".join(metadata), encoding="utf-8")
 
 
 def test_known_backends() -> None:
@@ -235,6 +244,35 @@ def test_assert_not_pip_under_uv_allows_pip_on_pip() -> None:
 
 def test_assert_not_pip_under_uv_allows_other_packages_on_uv() -> None:
     assert_not_pip_under_uv("ruff", UV)  # does not raise
+
+
+def test_uv_list_installed_not_required_uses_distribution_metadata(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir()
+    _write_dist_info(site_packages, "root-package")
+    _write_dist_info(site_packages, "top-package", ["child-package>=1"])
+    _write_dist_info(site_packages, "child-package")
+
+    def fail_run_subprocess(*args: object, **kwargs: object) -> None:
+        pytest.fail("uv pip list should not be invoked with --not-required")
+
+    monkeypatch.setattr("pipx.backends.uv.run_subprocess", fail_run_subprocess)
+    monkeypatch.setattr(
+        "pipx.backends.uv.fetch_info_in_venv",
+        lambda venv_python: ([str(site_packages)], {}, "Python 3.13.0"),
+        raising=False,
+    )
+
+    backend = UvBackend.__new__(UvBackend)
+    backend._binary = tmp_path / "uv"
+
+    assert backend.list_installed(
+        venv_root=tmp_path,
+        venv_python=tmp_path / "bin" / "python",
+        not_required=True,
+    ) == {"root-package", "top-package"}
 
 
 def test_metadata_round_trip_includes_backend(tmp_path: Path) -> None:

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -21,6 +21,7 @@ from pipx.commands.run_uv import translate_pip_args_for_uv
 from pipx.main import _validate_backend_available
 from pipx.util import PipxError
 from pipx.venv import Venv, reset_backend_override_warnings
+from pipx.venv_inspect import list_not_required_packages
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -65,10 +66,13 @@ class _CurrentMetadata(_LegacyMetadata):
     backend: str
 
 
-def _write_dist_info(site_packages: Path, name: str, requires: list[str] | None = None) -> None:
+def _write_dist_info(
+    site_packages: Path, name: str, requires: list[str] | None = None, provides_extra: list[str] | None = None
+) -> None:
     dist_info = site_packages / f"{name}-1.0.dist-info"
     dist_info.mkdir()
     metadata = [f"Name: {name}", "Version: 1.0"]
+    metadata += [f"Provides-Extra: {extra}" for extra in provides_extra or []]
     metadata += [f"Requires-Dist: {requirement}" for requirement in requires or []]
     (dist_info / "METADATA").write_text("\n".join(metadata), encoding="utf-8")
 
@@ -260,7 +264,7 @@ def test_uv_list_installed_not_required_uses_distribution_metadata(
 
     monkeypatch.setattr("pipx.backends.uv.run_subprocess", fail_run_subprocess)
     monkeypatch.setattr(
-        "pipx.backends.uv.fetch_info_in_venv",
+        "pipx.venv_inspect.fetch_info_in_venv",
         lambda venv_python: ([str(site_packages)], {}, "Python 3.13.0"),
         raising=False,
     )
@@ -273,6 +277,25 @@ def test_uv_list_installed_not_required_uses_distribution_metadata(
         venv_python=tmp_path / "bin" / "python",
         not_required=True,
     ) == {"root-package", "top-package"}
+
+
+def test_list_not_required_packages_treats_extra_dependencies_as_required(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # ``child-package`` is required only via ``top-package``'s ``extra == "cli"`` dependency; it must
+    # still be reported as required (not removable) while top-package stays installed.
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir()
+    _write_dist_info(site_packages, "top-package", ['child-package>=1; extra == "cli"'], provides_extra=["cli"])
+    _write_dist_info(site_packages, "child-package")
+
+    monkeypatch.setattr(
+        "pipx.venv_inspect.fetch_info_in_venv",
+        lambda venv_python: ([str(site_packages)], {}, "Python 3.13.0"),
+        raising=False,
+    )
+
+    assert list_not_required_packages(tmp_path / "bin" / "python") == {"top-package"}
 
 
 def test_metadata_round_trip_includes_backend(tmp_path: Path) -> None:


### PR DESCRIPTION
### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://pipx.pypa.io/latest/contributing/))

- [x] ran the linter to address style issues (`pre-commit run --files src/pipx/backends/uv.py tests/test_backends.py changelog.d/1841.bugfix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `changelog.d/` folder (choose a type: `feature`, `bugfix`, `doc`, `removal`, or `misc`)
- [ ] updated/extended the documentation (not needed for this bug fix)

## Summary

Fixes #1841.

`pipx uninject` asks the backend for packages that are not required by any other installed package. The uv backend passed pip's `--not-required` flag through to `uv pip list`, but uv does not support that option, so uninject failed before uninstalling the injected package.

This changes the uv backend to compute that top-level package set from installed distribution metadata instead of calling uv with the unsupported flag. Normal `uv pip list --format json` behavior is unchanged.

## Changes

- Avoid `uv pip list --not-required` for uv-backed venvs.
- Add regression coverage that verifies the uv backend uses distribution metadata for `not_required=True`.
- Add a bugfix news fragment.

## Testing

- `pytest tests/test_backends.py::test_uv_list_installed_not_required_uses_distribution_metadata --net-pypiserver -q`
- `pytest tests/test_backends.py --net-pypiserver -q`
- `python -m compileall -q src/pipx tests/test_backends.py`
- `pre-commit run --files src/pipx/backends/uv.py tests/test_backends.py changelog.d/1841.bugfix`
- `PIPX_HOME="$tmp/home" PIPX_BIN_DIR="$tmp/bin" PIPX_MAN_DIR="$tmp/man" PIPX_DEFAULT_BACKEND=uv .venv/bin/python -m pipx install pycowsay --python "$(command -v python3)" && PIPX_HOME="$tmp/home" PIPX_BIN_DIR="$tmp/bin" PIPX_MAN_DIR="$tmp/man" PIPX_DEFAULT_BACKEND=uv .venv/bin/python -m pipx inject pycowsay requests && PIPX_HOME="$tmp/home" PIPX_BIN_DIR="$tmp/bin" PIPX_MAN_DIR="$tmp/man" PIPX_DEFAULT_BACKEND=uv .venv/bin/python -m pipx uninject --verbose pycowsay requests`

Note: I used Codex while preparing this change, reviewed the final diff, and ran the listed checks locally.