### PR TITLE
Fix `--with` being dropped for PEP 723 scripts on the pip backend

### DIFF
--- a/changelog.d/1850.bugfix.md
+++ b/changelog.d/1850.bugfix.md
@@ -1,0 +1,1 @@
+Fix `pipx run --with` being silently dropped for PEP 723 scripts on the pip backend; the extra packages are now installed into the temporary venv.

--- a/changelog.d/1850.bugfix.md
+++ b/changelog.d/1850.bugfix.md
@@ -1,1 +1,2 @@
-Fix `pipx run --with` being silently dropped for PEP 723 scripts on the pip backend; the extra packages are now installed into the temporary venv.
+Fix `pipx run --with` being silently dropped for PEP 723 scripts on the pip backend; the extra packages are now
+installed into the temporary venv.

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -93,14 +93,16 @@ def run_script(
 ) -> NoReturn:
     requirements = _get_requirements_from_script(content)
 
-    if dependencies and not requirements:
-        # Plain scripts have nowhere to record extra requirements; the pip path
-        # silently dropped ``--with`` here, but a clear error is better.
-        raise PipxError(
-            "--with packages can only be applied to scripts with PEP 723 inline metadata "
-            "(`# /// script` block). Add the dependencies to the script's metadata or run "
-            "via `pipx run --spec`."
-        )
+    if dependencies:
+        if requirements is None:
+            # Plain scripts have nowhere to record extra requirements; the pip path
+            # silently dropped ``--with`` here, but a clear error is better.
+            raise PipxError(
+                "--with packages can only be applied to scripts with PEP 723 inline metadata "
+                "(`# /// script` block). Add the dependencies to the script's metadata or run "
+                "via `pipx run --spec`."
+            )
+        requirements = [*requirements, *dependencies]
 
     if resolved_backend == UV and requirements is not None:
         if script_source is not None:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -265,6 +265,38 @@ def test_run_with_requirements(script_text, expected_output, caplog, pipx_temp_e
 
 
 @mock.patch("os.execvpe", new=execvpe_mock)
+def test_run_with_requirements_and_cli_with_pip_backend(pipx_temp_env, tmp_path):
+    script = tmp_path / "test.py"
+    out = tmp_path / "output.txt"
+    script.write_text(
+        textwrap.dedent(
+            f"""
+            # /// script
+            # dependencies = ["requests==2.31.0"]
+            # ///
+
+            import black
+            import requests
+            from pathlib import Path
+
+            Path({str(out)!r}).write_text(f"requests={{requests.__version__}}, package={{black.__name__}}")
+            """
+        ).strip(),
+        encoding="utf-8",
+    )
+
+    run_pipx_cli_exit(
+        ["run", "--backend", "pip", "--with", PKG["black"]["spec"], script.as_uri()],
+        assert_exit=0,
+    )
+    assert out.read_text() == "requests=2.31.0, package=black"
+
+    out.unlink()
+    run_pipx_cli_exit(["run", "--backend", "pip", script.as_uri()], assert_exit=1)
+    assert not out.exists()
+
+
+@mock.patch("os.execvpe", new=execvpe_mock)
 def test_run_with_requirements_old(caplog, pipx_temp_env, tmp_path):
     script = tmp_path / "test.py"
     out = tmp_path / "output.txt"


### PR DESCRIPTION
Fixes #1850.

On the pip backend, `--with` packages were forwarded only to the `uv run` path and never merged into the requirements that build the temporary venv, so PEP 723 scripts silently dropped them.

### Checklist
- [x] ran the linter to address style issues (`pre-commit run --files src/pipx/commands/run.py tests/test_run.py changelog.d/1850.bugfix.md`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `changelog.d/` folder (choose a type: `feature`, `bugfix`, `doc`, `removal`, or `misc`)
- [ ] updated/extended the documentation — not needed for this bug fix