### PR TITLE
Install --with deps for PEP 723 scripts

### DIFF
--- a/changelog.d/1850.bugfix.md
+++ b/changelog.d/1850.bugfix.md
@@ -1,0 +1,1 @@
+Install `pipx run --with ...` packages for PEP 723 scripts on the pip backend.

--- a/docs/how-to/run-scripts.md
+++ b/docs/how-to/run-scripts.md
@@ -67,3 +67,10 @@ print(data["info"]["version"])
 
 pipx creates a cached virtual environment keyed to the script's dependency list. Changing the dependencies creates a
 fresh environment.
+
+Extra packages passed with `--with` are installed into that same script environment, so you can combine inline metadata
+with one-off additions:
+
+```
+pipx run --with rich test.py pipx
+```

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -92,6 +92,7 @@ def run_script(
     dependencies: list[str] | None = None,
 ) -> NoReturn:
     requirements = _get_requirements_from_script(content)
+    all_requirements = list(dict.fromkeys([*(requirements or []), *(dependencies or [])]))
 
     if dependencies and not requirements:
         # Plain scripts have nowhere to record extra requirements; the pip path
@@ -139,7 +140,7 @@ def run_script(
         # managed. The requirements are normalised (in
         # _get_requirements_from_script), so that irrelevant differences in
         # whitespace, and similar, don't prevent environment sharing.
-        venv_dir = _get_temporary_venv_path(requirements, python, pip_args, venv_args, resolved_backend or "pip")
+        venv_dir = _get_temporary_venv_path(all_requirements, python, pip_args, venv_args, resolved_backend or "pip")
         venv = Venv(venv_dir, backend=backend, env_backend=env_backend)
         _prepare_venv_cache(venv, None, use_cache)
         if venv_dir.exists():
@@ -149,7 +150,7 @@ def run_script(
             venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
             venv.create_venv(venv_args, pip_args)
             try:
-                venv.install_unmanaged_packages(requirements, pip_args)
+                venv.install_unmanaged_packages(all_requirements, pip_args)
             except:
                 # Package installation failed, so mark the cache as expired.
                 # This ensures an attempt is made to re-install requirements

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -347,6 +347,27 @@ def test_run_with_requirements_and_args(caplog, pipx_temp_env, tmp_path):
 
 
 @mock.patch("os.execvpe", new=execvpe_mock)
+def test_run_with_requirements_and_with_dependencies(caplog, pipx_temp_env, tmp_path):
+    script = tmp_path / "test.py"
+    out = tmp_path / "output.txt"
+    script.write_text(
+        textwrap.dedent(
+            f"""
+                # /// script
+                # dependencies = ["packaging"]
+                # ///
+                import packaging
+                import requests
+                from pathlib import Path
+                Path({str(out)!r}).write_text(requests.__version__)
+            """
+        ).strip()
+    )
+    run_pipx_cli_exit(["run", "--with", "requests==2.31.0", script.as_uri()])
+    assert out.read_text() == "2.31.0"
+
+
+@mock.patch("os.execvpe", new=execvpe_mock)
 def test_run_with_failing_requirements(capfd, pipx_temp_env, tmp_path):
     script = tmp_path / "test.py"
     script.write_text(


### PR DESCRIPTION
## Summary
Fix `pipx run --with ... script.py` on the pip backend when the script already has PEP 723 inline dependencies.

The current pip-backed script path only installs the dependencies declared in the `# /// script` block, then executes the script without installing the extra `--with` packages. That leaves imports from the one-off dependencies failing even though the same command works on the uv backend.

This change:
- installs both the inline script dependencies and the `--with` packages into the temp script environment on the pip backend
- includes the `--with` packages in the temp venv cache key so different one-off dependency sets do not reuse the same cached script venv
- adds a regression test for `--with` on a PEP 723 script, plus a short docs clarification and changelog entry

Fixes #1850.

## Verification
- `uv run --group test pytest tests/test_run.py -q -k 'test_run_with_requirements_and_with_dependencies or test_run_with_requirements_and_args or test_run_with_requirements'`
- `uv run --group lint pre-commit run --files src/pipx/commands/run.py tests/test_run.py docs/how-to/run-scripts.md changelog.d/1850.bugfix.md`
- Manual repro on `main` before the patch failed with `ModuleNotFoundError: No module named 'click'` for `pipx run --backend pip --with click demo.py`
- Manual repro after the patch showed `Installing packaging, click` and the command exited successfully

## Limitations
This only changes the pip-backed script path. The uv-backed path already forwards `--with` through `uv run --script`.
