### PR TITLE
Fix uninject leaving man page symlinks behind

### DIFF
--- a/changelog.d/1853.bugfix.md
+++ b/changelog.d/1853.bugfix.md
@@ -1,0 +1,1 @@
+Fix `pipx uninject` leaving the injected package's man page symlinks behind.

--- a/src/pipx/commands/uninject.py
+++ b/src/pipx/commands/uninject.py
@@ -159,7 +159,7 @@ def get_include_resource_paths(package_name: str, venv: Venv, local_bin_dir: Pat
     for man_path in man_paths:
         path = Path(man_path.parent.name) / man_path.name
         if str(path) in all_man_pages:
-            need_to_remove.add(path)
+            need_to_remove.add(man_path)
 
     return need_to_remove
 

--- a/tests/test_uninject.py
+++ b/tests/test_uninject.py
@@ -1,5 +1,11 @@
 from helpers import run_pipx_cli, skip_if_windows
 from package_info import PKG
+from pipx import paths
+
+
+def file_or_symlink(filepath):
+    # True for a regular file or a symlink (broken or not), False otherwise.
+    return filepath.exists() or filepath.is_symlink()
 
 
 def test_uninject_simple(pipx_temp_env, capsys):
@@ -30,6 +36,19 @@ def test_uninject_with_include_apps(pipx_temp_env, capsys, caplog):
     assert not run_pipx_cli(["inject", "pycowsay", PKG["black"]["spec"], "--include-deps", "--include-apps"])
     assert not run_pipx_cli(["uninject", "pycowsay", "black", "--verbose"])
     assert "removed file" in caplog.text
+
+
+def test_uninject_man_page(pipx_temp_env):
+    # Regression: uninject must remove the injected package's man page symlinks,
+    # not only its app symlinks. pycowsay ships man6/pycowsay.6.
+    man_page_paths = [paths.ctx.man_dir / man_page for man_page in PKG["pycowsay"]["man_pages"]]
+    assert not run_pipx_cli(["install", PKG["black"]["spec"]])
+    assert not run_pipx_cli(["inject", "black", "pycowsay", "--include-apps"])
+    for man_page_path in man_page_paths:
+        assert man_page_path.exists()
+    assert not run_pipx_cli(["uninject", "black", "pycowsay"])
+    for man_page_path in man_page_paths:
+        assert not file_or_symlink(man_page_path)
 
 
 def test_uninject_removes_dependency_app_symlinks(pipx_temp_env, capsys, caplog):


### PR DESCRIPTION
Refs #1853.

`uninject` removed an injected package's app symlinks but not its man page
symlinks. In `get_include_resource_paths` the man branch added the relative
path (`man6/pycowsay.6`) to the removal set, while the app branch added the
absolute path. `os.unlink` then gets the relative path, fails with
`FileNotFoundError`, and the error is ignored, so the symlink stays.
`uninstall` handles the same file correctly because it uses the absolute path.
The man branch has stored the relative path since it was added in #1767.

Fix: add the absolute `man_path`; the relative path stays for the `man_pages`
membership check. Adds `test_uninject_man_page`.

### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://pipx.pypa.io/latest/contributing/))

- [x] ran the linter to address style issues (`pre-commit run --all-files`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `changelog.d/` folder (choose a type: `feature`, `bugfix`, `doc`, `removal`, or `misc`)
- [ ] updated/extended the documentation
