### PR TITLE
Refresh metadata after runpip installs

### DIFF
--- a/changelog.d/1473.bugfix.md
+++ b/changelog.d/1473.bugfix.md
@@ -1,0 +1,2 @@
+Refresh `pipx_metadata.json` after `pipx runpip ... install` replaces the main package, so future `upgrade` and
+`reinstall` commands stop following a stale editable source path.

--- a/src/pipx/commands/run_pip.py
+++ b/src/pipx/commands/run_pip.py
@@ -1,8 +1,115 @@
 from pathlib import Path
 
+from packaging.utils import canonicalize_name
+
+from pipx.commands.common import package_name_from_spec
 from pipx.constants import ExitCode
 from pipx.util import PipxError
 from pipx.venv import Venv
+
+
+def _iter_install_specs(pip_args: list[str]) -> list[tuple[str, bool]]:
+    if not pip_args or pip_args[0] != "install":
+        return []
+
+    specs: list[tuple[str, bool]] = []
+    options_with_value = {
+        "-c",
+        "--constraint",
+        "--config-settings",
+        "-f",
+        "--find-links",
+        "-i",
+        "--index-url",
+        "--extra-index-url",
+        "--implementation",
+        "--platform",
+        "--prefix",
+        "--python-version",
+        "-r",
+        "--requirement",
+        "--report",
+        "--root",
+        "--src",
+        "--target",
+        "--trusted-host",
+    }
+    options_with_value_prefixes = (
+        "--constraint=",
+        "--config-settings=",
+        "--find-links=",
+        "--index-url=",
+        "--extra-index-url=",
+        "--implementation=",
+        "--platform=",
+        "--prefix=",
+        "--python-version=",
+        "--requirement=",
+        "--report=",
+        "--root=",
+        "--src=",
+        "--target=",
+        "--trusted-host=",
+    )
+
+    index = 1
+    while index < len(pip_args):
+        arg = pip_args[index]
+        if arg in {"-e", "--editable"}:
+            if index + 1 < len(pip_args):
+                specs.append((pip_args[index + 1], True))
+            index += 2
+            continue
+        if arg.startswith("--editable="):
+            specs.append((arg.split("=", 1)[1], True))
+            index += 1
+            continue
+        if arg in options_with_value:
+            index += 2
+            continue
+        if arg.startswith(options_with_value_prefixes) or arg.startswith("-"):
+            index += 1
+            continue
+        specs.append((arg, False))
+        index += 1
+
+    return specs
+
+
+def _updated_main_package_pip_args(existing_pip_args: list[str], editable: bool) -> list[str]:
+    pip_args = [arg for arg in existing_pip_args if arg not in {"-e", "--editable"}]
+    if editable:
+        pip_args.append("--editable")
+    return pip_args
+
+
+def _sync_main_package_metadata_after_runpip_install(venv: Venv, pip_args: list[str]) -> None:
+    main_package = venv.pipx_metadata.main_package
+    if main_package.package is None:
+        return
+
+    for package_spec, editable in _iter_install_specs(pip_args):
+        package_name = package_name_from_spec(
+            package_spec,
+            str(venv.python_path),
+            pip_args=["--editable"] if editable else [],
+            verbose=venv.verbose,
+            backend=venv.backend_name,
+        )
+        if canonicalize_name(package_name) != canonicalize_name(main_package.package):
+            continue
+
+        venv.update_package_metadata(
+            package_name=main_package.package,
+            package_or_url=package_spec,
+            pip_args=_updated_main_package_pip_args(main_package.pip_args, editable),
+            include_dependencies=main_package.include_dependencies,
+            include_apps=main_package.include_apps,
+            is_main_package=True,
+            suffix=main_package.suffix,
+            pinned=main_package.pinned,
+        )
+        return
 
 
 def run_pip(package: str, venv_dir: Path, pip_args: list[str], verbose: bool) -> ExitCode:
@@ -11,4 +118,7 @@ def run_pip(package: str, venv_dir: Path, pip_args: list[str], verbose: bool) ->
     if not venv.python_path.exists():
         raise PipxError(f"venv for {package!r} was not found. Was {package!r} installed with pipx?")
     venv.verbose = True
-    return venv.run_pip_get_exit_code(pip_args)
+    exit_code = venv.run_pip_get_exit_code(pip_args)
+    if exit_code == 0:
+        _sync_main_package_metadata_after_runpip_install(venv, pip_args)
+    return exit_code

--- a/tests/test_runpip.py
+++ b/tests/test_runpip.py
@@ -1,4 +1,9 @@
+import json
+import subprocess
+import sys
+
 from helpers import run_pipx_cli, skip_if_windows
+from pipx import paths
 
 
 def test_runpip(pipx_temp_env, monkeypatch, capsys):
@@ -15,3 +20,27 @@ def test_runpip_splits_single_argument(pipx_temp_env, monkeypatch, capsys):
 def test_runpip_global(pipx_temp_env, monkeypatch, capsys):
     assert not run_pipx_cli(["install", "--global", "pycowsay"])
     assert not run_pipx_cli(["runpip", "--global", "pycowsay", "list"])
+
+
+def test_runpip_install_refreshes_main_package_metadata(pipx_temp_env, root, tmp_path):
+    package_dir = root / "testdata" / "empty_project"
+    wheel_dir = tmp_path / "wheelhouse"
+    wheel_dir.mkdir()
+    subprocess.run(
+        [sys.executable, "-m", "pip", "wheel", str(package_dir), "--no-deps", "--wheel-dir", str(wheel_dir)],
+        check=True,
+    )
+    wheel_path = next(wheel_dir.glob("empty_project-*.whl"))
+
+    assert not run_pipx_cli(["install", "--editable", str(package_dir)])
+
+    metadata_path = paths.ctx.venvs / "empty-project" / "pipx_metadata.json"
+    before = json.loads(metadata_path.read_text())
+    assert before["main_package"]["package_or_url"] == str(package_dir.resolve())
+    assert before["main_package"]["pip_args"] == ["--editable"]
+
+    assert not run_pipx_cli(["runpip", "empty-project", "install", "--force-reinstall", str(wheel_path)])
+
+    after = json.loads(metadata_path.read_text())
+    assert after["main_package"]["package_or_url"] == str(wheel_path.resolve())
+    assert after["main_package"]["pip_args"] == []


### PR DESCRIPTION
## Summary
Fixes #1473.

When `pipx runpip <venv> install ...` replaces the main package, `pipx_metadata.json` keeps the old source path and editable flag. That leaves later `upgrade` and `reinstall` commands coupled to the stale install spec instead of the package that is actually installed now.

This change:
- inspects direct `pip install` specs passed through `runpip`
- refreshes main-package metadata when one of those specs replaces the main package
- keeps the stored editable flag in sync with the replacement install
- adds a regression test that swaps an editable local install to a wheel install and checks the metadata update
- adds a changelog fragment for the bugfix

## Testing
- `uv run --group test pytest tests/test_runpip.py -q -k 'runpip'`
- `uv run --group lint pre-commit run --files src/pipx/commands/run_pip.py tests/test_runpip.py changelog.d/1473.bugfix.md`

### Checklist
- [x] ran the linter to address style issues (`pre-commit run --all-files` equivalent on changed files)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `changelog.d/`
- [ ] updated/extended the documentation (not needed for this internal metadata sync)
