### PR TITLE
🐛 fix(spec): accept local VCS URLs

### DIFF
--- a/changelog.d/1583.bugfix.md
+++ b/changelog.d/1583.bugfix.md
@@ -1,0 +1,1 @@
+Accept bare local Git and Mercurial URLs such as `git+file:///path/to/repository@revision`.

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -11,6 +11,7 @@ import re
 import urllib.parse
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Final
 
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.specifiers import SpecifierSet
@@ -22,6 +23,7 @@ from pipx.util import PipxError, pipx_wrap
 logger = logging.getLogger(__name__)
 
 ARCHIVE_EXTENSIONS = (".whl", ".tar.gz", ".zip")
+_LOCAL_VCS_SCHEMES: Final[frozenset[str]] = frozenset({"git+file", "hg+file"})
 
 
 @dataclass(frozen=True)
@@ -78,7 +80,9 @@ def _parse_specifier(package_spec: str) -> ParsedPackage:
     # If this looks like a URL, treat it as such.
     if not valid_pep508:
         parsed_url = urllib.parse.urlsplit(package_spec)
-        if parsed_url.scheme and parsed_url.netloc:
+        if parsed_url.scheme and (
+            parsed_url.netloc or (parsed_url.scheme in _LOCAL_VCS_SCHEMES and parsed_url.path.startswith("/"))
+        ):
             valid_url = package_spec
 
     # Treat the input as a local path if it does not look like a PEP 508

--- a/tests/test_package_specifier.py
+++ b/tests/test_package_specifier.py
@@ -308,3 +308,15 @@ def test_parse_specifier_for_install_constraint_args(
 ) -> None:
     _, pip_args_out = parse_specifier_for_install("pipx", pip_args_in)
     assert pip_args_out == pip_args_expected
+
+
+@pytest.mark.parametrize(
+    "package_spec",
+    [
+        "git+file:///tmp/project@main",
+        "hg+file:///tmp/project@default",
+    ],
+    ids=["git", "mercurial"],
+)
+def test_parse_specifier_for_install_accepts_local_vcs_url(package_spec: str) -> None:
+    assert parse_specifier_for_install(package_spec, []) == (package_spec, [])


### PR DESCRIPTION
pipx rejects bare `git+file:///...` and `hg+file:///...` requirements before pip sees them because those URLs have no network location. pip supports both schemes for [local VCS installs](https://pip.pypa.io/en/stable/topics/vcs-support/), including revisions. Fixes #1583.

`_parse_specifier` accepts absolute paths for the two documented `+file` schemes. The host check for network URLs stays unchanged, so malformed inputs such as `https:/host/path` remain invalid.
