### PR TITLE
🐛 fix(install): resolve local find-links

### DIFF
--- a/changelog.d/1637.bugfix.md
+++ b/changelog.d/1637.bugfix.md
@@ -1,0 +1,1 @@
+Resolve local `--find-links` paths before pipx changes the working directory.

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 ARCHIVE_EXTENSIONS = (".whl", ".tar.gz", ".zip")
 _LOCAL_VCS_SCHEMES: Final[frozenset[str]] = frozenset({"git+file", "hg+file"})
+_PIP_PATH_OPTIONS: Final[frozenset[str]] = frozenset({"-c", "--constraint", "-f", "--find-links"})
 
 
 @dataclass(frozen=True)
@@ -167,20 +168,18 @@ def parse_specifier_for_install(package_spec: str, pip_args: list[str]) -> tuple
         pip_args.remove("--editable")
 
     for index, option in enumerate(pip_args):
-        if not option.startswith(("-c", "--constraint")):
+        option_name, separator, value = option.partition("=")
+        if option_name not in _PIP_PATH_OPTIONS:
             continue
 
-        if option in ("-c", "--constraint"):
-            argument_index = index + 1
-            if argument_index < len(pip_args) and not urllib.parse.urlsplit(pip_args[argument_index]).scheme:
-                pip_args[argument_index] = str(Path(pip_args[argument_index]).expanduser().resolve())
-
-        elif (option_list := option.split("=", maxsplit=1)) and len(option_list) == 2:
-            key, value = option_list
+        if separator:
             if not urllib.parse.urlsplit(value).scheme:
-                pip_args[index] = f"{key}={Path(value).expanduser().resolve()}"
+                pip_args[index] = f"{option_name}={Path(value).expanduser().resolve()}"
+            continue
 
-        break
+        argument_index = index + 1
+        if argument_index < len(pip_args) and not urllib.parse.urlsplit(pip_args[argument_index]).scheme:
+            pip_args[argument_index] = str(Path(pip_args[argument_index]).expanduser().resolve())
 
     return package_or_url, pip_args
 

--- a/tests/test_package_specifier.py
+++ b/tests/test_package_specifier.py
@@ -320,3 +320,36 @@ def test_parse_specifier_for_install_constraint_args(
 )
 def test_parse_specifier_for_install_accepts_local_vcs_url(package_spec: str) -> None:
     assert parse_specifier_for_install(package_spec, []) == (package_spec, [])
+
+
+@pytest.mark.parametrize(
+    "pip_args_in,pip_args_expected",
+    [
+        (
+            ["-f", "https://example.com/wheels"],
+            ["-f", "https://example.com/wheels"],
+        ),
+        (
+            ["--find-links", "https://example.com/wheels"],
+            ["--find-links", "https://example.com/wheels"],
+        ),
+        (
+            ["--find-links=https://example.com/wheels"],
+            ["--find-links=https://example.com/wheels"],
+        ),
+        (
+            ["-f", "wheels"],
+            ["-f", str(Path("wheels").resolve())],
+        ),
+        (
+            ["--find-links=wheels"],
+            [f"--find-links={Path('wheels').resolve()}"],
+        ),
+    ],
+)
+def test_parse_specifier_for_install_find_links_args(
+    pip_args_in: list[str],
+    pip_args_expected: list[str],
+) -> None:
+    _, pip_args_out = parse_specifier_for_install("pipx", pip_args_in)
+    assert pip_args_out == pip_args_expected


### PR DESCRIPTION
pipx passes relative `--find-links` values to pip after changing working directories for temporary and shared virtual environments. With `--pip-args="-f . --no-index"`, pip searches the wrong directory and cannot find pip or application dependencies. Fixes #1637.

The package-spec parser resolves local constraint and find-links values before those directory changes. URL values stay unchanged, and both split and `--option=value` forms work.
