### PR TITLE
🐛 fix(ensurepath): configure global PATH

### DIFF
--- a/changelog.d/1452.bugfix.md
+++ b/changelog.d/1452.bugfix.md
@@ -1,0 +1,1 @@
+Make `ensurepath --global` update the system PATH configuration instead of root's shell profiles.

--- a/docs/how-to/configure-paths.md
+++ b/docs/how-to/configure-paths.md
@@ -63,7 +63,8 @@ sudo pipx --global install pycowsay
 
 Default global paths are `/usr/local/bin` for binaries, `/usr/local/share/man` for man pages, and `/opt/pipx` for
 virtual environments. Override them with `PIPX_GLOBAL_BIN_DIR`, `PIPX_GLOBAL_MAN_DIR`, and `PIPX_GLOBAL_HOME`. Run
-`sudo pipx ensurepath --global` to add the global binary directory to the system `PATH`.
+`sudo pipx ensurepath --global` to add the global binary directory to the system `PATH`. On Linux, this writes
+`/etc/profile.d/pipx.sh`. On macOS, it writes `/etc/paths.d/pipx`.
 
 The `--global` flag is not supported on Windows.
 

--- a/docs/how-to/install-pipx.md
+++ b/docs/how-to/install-pipx.md
@@ -23,7 +23,7 @@ pipx ensurepath
 
 #### Additional (optional) commands
 
-To allow pipx actions in global scope (requires pipx 1.5.0+):
+To add the global app directory to the system PATH (requires pipx 1.5.0+):
 
 ```
 sudo pipx ensurepath --global
@@ -81,7 +81,7 @@ python3 -m pipx ensurepath
 
 #### Additional (optional) commands
 
-To allow pipx actions in global scope (requires pipx 1.5.0+):
+To add the global app directory to the system PATH (requires pipx 1.5.0+):
 
 ```
 sudo pipx ensurepath --global

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -1,16 +1,20 @@
 import logging
+import shlex
 import site
 import sys
 from pathlib import Path
+from typing import Final
 
 import userpath  # type: ignore[import-not-found]
 
 from pipx import paths
-from pipx.constants import EXIT_CODE_OK, ExitCode
+from pipx.constants import EXIT_CODE_OK, MACOS, ExitCode
 from pipx.emojis import hazard, stars
 from pipx.util import pipx_wrap
 
 logger = logging.getLogger(__name__)
+
+_GLOBAL_PATH_FILE: Final[Path] = Path("/etc/paths.d/pipx" if MACOS else "/etc/profile.d/pipx.sh")
 
 
 def get_pipx_user_bin_path() -> Path | None:
@@ -112,8 +116,59 @@ def ensure_path(
     return (path_added, need_shell_restart)
 
 
-def ensure_pipx_paths(force: bool, prepend: bool = False, all_shells: bool = False, dry_run: bool = False) -> ExitCode:
+def _ensure_global_path(location: Path, *, force: bool, prepend: bool, dry_run: bool) -> bool:
+    config_file = _GLOBAL_PATH_FILE
+    if MACOS:
+        contents = f"{location}\n"
+    else:
+        quoted_location = shlex.quote(str(location))
+        assignment = f'export PATH={quoted_location}:"$PATH"' if prepend else f'export PATH="$PATH":{quoted_location}'
+        contents = f'case ":$PATH:" in *:{quoted_location}:*) ;; *) {assignment} ;; esac\n'
+
+    if not force and config_file.exists() and config_file.read_text(encoding="utf-8") == contents:
+        print(pipx_wrap(f"{location} is already in the system PATH configuration.", subsequent_indent=" " * 4))
+        return False
+
+    if dry_run:
+        print(
+            pipx_wrap(
+                f"Would write {location} to the system PATH configuration at {config_file}.",
+                subsequent_indent=" " * 4,
+            )
+        )
+        return False
+
+    config_file.write_text(contents, encoding="utf-8")
+    config_file.chmod(0o644)
+    print(
+        pipx_wrap(
+            f"Success! Added {location} to the system PATH configuration at {config_file}.",
+            subsequent_indent=" " * 4,
+        )
+    )
+    return True
+
+
+def ensure_pipx_paths(
+    force: bool,
+    prepend: bool = False,
+    all_shells: bool = False,
+    dry_run: bool = False,
+    is_global: bool = False,
+) -> ExitCode:
     """Returns pipx exit code."""
+    if is_global:
+        path_added = _ensure_global_path(paths.ctx.bin_dir, force=force, prepend=prepend, dry_run=dry_run)
+        print()
+
+        if dry_run:
+            print(pipx_wrap("This was a dry run; no changes were made to the system PATH configuration."))
+        elif path_added:
+            print(pipx_wrap("Users must open a new terminal or re-login for the PATH change to take effect.") + "\n")
+
+        print(f"Otherwise pipx is ready to go! {stars}")
+        return EXIT_CODE_OK
+
     bin_paths = {paths.ctx.bin_dir}
 
     pipx_user_bin_path = get_pipx_user_bin_path()

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -1056,8 +1056,8 @@ def _add_ensurepath(subparsers: argparse._SubParsersAction, shared_parser: argpa
             "Ensure directory where pipx stores apps is in your "
             "PATH environment variable. Also if pipx was installed via "
             "`pip install --user`, ensure pipx itself is in your PATH. "
-            "Note that running this may modify "
-            "your shell's configuration file(s) such as '~/.bashrc'."
+            "This command may modify your shell configuration, such as '~/.bashrc', "
+            "or the system PATH configuration when used with `--global`."
         ),
         parents=[shared_parser],
     )
@@ -1094,7 +1094,11 @@ def _add_ensurepath(subparsers: argparse._SubParsersAction, shared_parser: argpa
 def _cmd_ensurepath(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
     try:
         return commands.ensure_pipx_paths(
-            prepend=args.prepend, force=args.force, all_shells=args.all_shells, dry_run=args.dry_run
+            prepend=args.prepend,
+            force=args.force,
+            all_shells=args.all_shells,
+            dry_run=args.dry_run,
+            is_global=getattr(args, "is_global", False),
         )
     except Exception as e:
         logger.debug("Uncaught Exception:", exc_info=True)

--- a/tests/test_ensurepath.py
+++ b/tests/test_ensurepath.py
@@ -1,9 +1,13 @@
+import os
+import stat
 from pathlib import Path
 
 import pytest
+from pytest_mock import MockerFixture
 
+from helpers import run_pipx_cli
 from pipx.commands import ensure_path as ensure_path_module
-from pipx.constants import EXIT_CODE_OK
+from pipx.constants import EXIT_CODE_OK, WINDOWS
 
 
 class FakeUserpath:
@@ -75,3 +79,97 @@ def test_ensure_pipx_paths_dry_run_footer(mock_userpath: FakeUserpath, capsys: p
     out = capsys.readouterr().out.lower()
     assert "dry run" in out
     assert "no changes were made" in out
+
+
+@pytest.mark.parametrize(
+    ("macos", "prepend", "expected"),
+    [
+        pytest.param(
+            False,
+            False,
+            'case ":$PATH:" in *:/opt/pipx/bin:*) ;; *) export PATH="$PATH":/opt/pipx/bin ;; esac\n',
+            id="linux-append",
+        ),
+        pytest.param(
+            False,
+            True,
+            'case ":$PATH:" in *:/opt/pipx/bin:*) ;; *) export PATH=/opt/pipx/bin:"$PATH" ;; esac\n',
+            id="linux-prepend",
+        ),
+        pytest.param(True, False, "/opt/pipx/bin\n", id="macos"),
+    ],
+)
+def test_ensure_pipx_paths_global_updates_system_profile(
+    mocker: MockerFixture, tmp_path: Path, macos: bool, prepend: bool, expected: str
+) -> None:
+    location = Path("/opt/pipx/bin")
+    config_file = tmp_path / "etc/profile.d/pipx.sh"
+    config_file.parent.mkdir(parents=True)
+    mocker.patch.object(type(ensure_path_module.paths.ctx), "bin_dir", mocker.PropertyMock(return_value=location))
+    mocker.patch.object(ensure_path_module, "_GLOBAL_PATH_FILE", config_file)
+    mocker.patch.object(ensure_path_module, "MACOS", macos)
+
+    ensure_path_module.ensure_pipx_paths(force=False, prepend=prepend, is_global=True)
+
+    assert config_file.read_text() == expected
+
+
+def test_ensure_pipx_paths_global_skips_userpath(mocker: MockerFixture, tmp_path: Path) -> None:
+    config_file = tmp_path / "pipx.sh"
+    mocker.patch.object(ensure_path_module, "_GLOBAL_PATH_FILE", config_file)
+    append = mocker.patch.object(ensure_path_module.userpath, "append", autospec=True)
+
+    ensure_path_module.ensure_pipx_paths(force=False, is_global=True)
+
+    append.assert_not_called()
+
+
+def test_ensure_pipx_paths_global_dry_run_does_not_write(
+    mocker: MockerFixture, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_file = tmp_path / "pipx.sh"
+    mocker.patch.object(ensure_path_module, "_GLOBAL_PATH_FILE", config_file)
+
+    ensure_path_module.ensure_pipx_paths(force=False, dry_run=True, is_global=True)
+
+    assert not config_file.exists()
+    assert "no changes were made to the system PATH" in capsys.readouterr().out
+
+
+def test_ensure_pipx_paths_global_configuration_is_world_readable(mocker: MockerFixture, tmp_path: Path) -> None:
+    config_file = tmp_path / "pipx"
+    mocker.patch.object(ensure_path_module, "_GLOBAL_PATH_FILE", config_file)
+    previous_umask = os.umask(0o077)
+    try:
+        ensure_path_module.ensure_pipx_paths(force=False, is_global=True)
+    finally:
+        os.umask(previous_umask)
+
+    assert stat.S_IMODE(config_file.stat().st_mode) == 0o644
+
+
+def test_ensure_pipx_paths_global_reports_existing_configuration(
+    mocker: MockerFixture, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    location = ensure_path_module.paths.ctx.bin_dir
+    config_file = tmp_path / "pipx.sh"
+    config_file.write_text(f"{location}\n")
+    mocker.patch.object(ensure_path_module, "_GLOBAL_PATH_FILE", config_file)
+    mocker.patch.object(ensure_path_module, "MACOS", True)
+
+    ensure_path_module.ensure_pipx_paths(force=False, is_global=True)
+
+    assert "already in the system PATH" in capsys.readouterr().out
+
+
+@pytest.mark.skipif(WINDOWS, reason="The --global option is unavailable on Windows")
+def test_ensurepath_cli_global_writes_system_configuration(
+    mocker: MockerFixture, tmp_path: Path, pipx_temp_env: None
+) -> None:
+    config_file = tmp_path / "pipx"
+    mocker.patch.object(ensure_path_module, "_GLOBAL_PATH_FILE", config_file)
+
+    exit_code = run_pipx_cli(["ensurepath", "--global"])
+
+    assert exit_code == EXIT_CODE_OK
+    assert config_file.exists()

--- a/tests/test_ensurepath.py
+++ b/tests/test_ensurepath.py
@@ -1,6 +1,7 @@
 import os
 import stat
 from pathlib import Path
+from typing import Final
 
 import pytest
 from pytest_mock import MockerFixture
@@ -8,6 +9,8 @@ from pytest_mock import MockerFixture
 from helpers import run_pipx_cli
 from pipx.commands import ensure_path as ensure_path_module
 from pipx.constants import EXIT_CODE_OK, WINDOWS
+
+_SKIP_GLOBAL_ON_WINDOWS: Final = pytest.mark.skipif(WINDOWS, reason="System-wide ensurepath is unavailable on Windows")
 
 
 class FakeUserpath:
@@ -99,6 +102,7 @@ def test_ensure_pipx_paths_dry_run_footer(mock_userpath: FakeUserpath, capsys: p
         pytest.param(True, False, "/opt/pipx/bin\n", id="macos"),
     ],
 )
+@_SKIP_GLOBAL_ON_WINDOWS
 def test_ensure_pipx_paths_global_updates_system_profile(
     mocker: MockerFixture, tmp_path: Path, macos: bool, prepend: bool, expected: str
 ) -> None:
@@ -114,6 +118,7 @@ def test_ensure_pipx_paths_global_updates_system_profile(
     assert config_file.read_text() == expected
 
 
+@_SKIP_GLOBAL_ON_WINDOWS
 def test_ensure_pipx_paths_global_skips_userpath(mocker: MockerFixture, tmp_path: Path) -> None:
     config_file = tmp_path / "pipx.sh"
     mocker.patch.object(ensure_path_module, "_GLOBAL_PATH_FILE", config_file)
@@ -124,6 +129,7 @@ def test_ensure_pipx_paths_global_skips_userpath(mocker: MockerFixture, tmp_path
     append.assert_not_called()
 
 
+@_SKIP_GLOBAL_ON_WINDOWS
 def test_ensure_pipx_paths_global_dry_run_does_not_write(
     mocker: MockerFixture, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -136,6 +142,7 @@ def test_ensure_pipx_paths_global_dry_run_does_not_write(
     assert "no changes were made to the system PATH" in capsys.readouterr().out
 
 
+@_SKIP_GLOBAL_ON_WINDOWS
 def test_ensure_pipx_paths_global_configuration_is_world_readable(mocker: MockerFixture, tmp_path: Path) -> None:
     config_file = tmp_path / "pipx"
     mocker.patch.object(ensure_path_module, "_GLOBAL_PATH_FILE", config_file)
@@ -148,6 +155,7 @@ def test_ensure_pipx_paths_global_configuration_is_world_readable(mocker: Mocker
     assert stat.S_IMODE(config_file.stat().st_mode) == 0o644
 
 
+@_SKIP_GLOBAL_ON_WINDOWS
 def test_ensure_pipx_paths_global_reports_existing_configuration(
     mocker: MockerFixture, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -162,7 +170,7 @@ def test_ensure_pipx_paths_global_reports_existing_configuration(
     assert "already in the system PATH" in capsys.readouterr().out
 
 
-@pytest.mark.skipif(WINDOWS, reason="The --global option is unavailable on Windows")
+@_SKIP_GLOBAL_ON_WINDOWS
 def test_ensurepath_cli_global_writes_system_configuration(
     mocker: MockerFixture, tmp_path: Path, pipx_temp_env: None
 ) -> None:


### PR DESCRIPTION
Global `ensurepath` passes the global binary directory to `userpath`, which edits root's shell profiles under `sudo` instead of configuring PATH for every user. Custom global binary directories therefore remain unavailable to other accounts. Fixes #1452.

The command now writes `/etc/profile.d/pipx.sh` on Linux and `/etc/paths.d/pipx` on macOS. The Linux entry preserves prepend behavior and avoids duplicate PATH entries, while local `ensurepath` continues to use `userpath`.
