### PR TITLE
🐛 fix(paths): discover self-managed install

### DIFF
--- a/changelog.d/774.bugfix.md
+++ b/changelog.d/774.bugfix.md
@@ -1,0 +1,1 @@
+Recover custom paths when pipx manages its own installation on Unix.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -5,8 +5,8 @@ pipx reads the following environment variables. All are optional.
 | Variable                                | Description                                                               | Default                                                                    |
 | --------------------------------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
 | `PIPX_HOME`                             | Root directory for pipx virtual environments.                             | `~/.local/share/pipx` (Linux), `~/.local/pipx` (macOS), `~\pipx` (Windows) |
-| `PIPX_BIN_DIR`                          | Directory where application entry-point symlinks are placed.              | `~/.local/bin`                                                             |
-| `PIPX_MAN_DIR`                          | Directory where man page symlinks are placed.                             | `~/.local/share/man`                                                       |
+| `PIPX_BIN_DIR`                          | Directory where pipx places application entry-point symlinks.             | `~/.local/bin`                                                             |
+| `PIPX_MAN_DIR`                          | Directory where pipx places man page symlinks.                            | `~/.local/share/man`                                                       |
 | `PIPX_GLOBAL_HOME`                      | Root directory for global (`--global`) virtual environments.              | `/opt/pipx`                                                                |
 | `PIPX_GLOBAL_BIN_DIR`                   | Binary directory for global installs.                                     | `/usr/local/bin`                                                           |
 | `PIPX_GLOBAL_MAN_DIR`                   | Man page directory for global installs.                                   | `/usr/local/share/man`                                                     |
@@ -26,9 +26,10 @@ pipx reads the following environment variables. All are optional.
 pipx uses it instead of the new default. See [Configure Paths](../how-to/configure-paths.md) for details.
 
 On Unix, a pipx installation that manages itself recovers `PIPX_HOME`, `PIPX_BIN_DIR`, and `PIPX_DEFAULT_PYTHON` from
-its virtual environment when those variables are unset. This keeps the managed installation usable in later shells.
+its virtual environment when those variables are unset. The recovered values keep later shells attached to the same
+installation.
 
-Standard `PIP_*` environment variables (e.g. `PIP_INDEX_URL`) are forwarded to pip when pipx invokes it. See
+pipx forwards standard `PIP_*` environment variables (e.g. `PIP_INDEX_URL`) when it invokes pip. See
 [Troubleshooting](../how-to/troubleshoot.md#check-for-pip_-environment-variables) if unexpected pip behaviour occurs.
 
-Run `pipx environment` to see the resolved value of every directory variable on your system.
+Run `pipx environment` to see the resolved value of all directory variables on your system.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -25,6 +25,9 @@ pipx reads the following environment variables. All are optional.
 `PIPX_HOME` has platform-specific fallback logic. If a legacy directory (e.g. `~/.local/pipx` on Linux) already exists,
 pipx uses it instead of the new default. See [Configure Paths](../how-to/configure-paths.md) for details.
 
+On Unix, a pipx installation that manages itself recovers `PIPX_HOME`, `PIPX_BIN_DIR`, and `PIPX_DEFAULT_PYTHON` from
+its virtual environment when those variables are unset. This keeps the managed installation usable in later shells.
+
 Standard `PIP_*` environment variables (e.g. `PIP_INDEX_URL`) are forwarded to pip when pipx invokes it. See
 [Troubleshooting](../how-to/troubleshoot.md#check-for-pip_-environment-variables) if unexpected pip behaviour occurs.
 

--- a/src/pipx/interpreter.py
+++ b/src/pipx/interpreter.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from packaging import version
 
 from pipx.constants import WINDOWS, FetchPythonOptions
+from pipx.self_install import get_environment_value
 from pipx.standalone_python import download_python_build_standalone
 from pipx.util import PipxError
 
@@ -196,7 +197,7 @@ def _resolve_python(python: str) -> str:
     raise InterpreterResolutionError(source="PIPX_DEFAULT_PYTHON", version=python)
 
 
-env_default_python = os.environ.get("PIPX_DEFAULT_PYTHON")
+env_default_python = get_environment_value("PIPX_DEFAULT_PYTHON")
 
 if not env_default_python:
     DEFAULT_PYTHON = _get_sys_executable()

--- a/src/pipx/paths.py
+++ b/src/pipx/paths.py
@@ -6,6 +6,7 @@ from platformdirs import user_cache_path, user_data_path, user_log_path
 
 from pipx.constants import LINUX, WINDOWS
 from pipx.emojis import hazard, strtobool
+from pipx.self_install import get_environment_value
 from pipx.wrap import pipx_wrap
 
 if LINUX:
@@ -37,7 +38,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_expanded_environ(env_name: str) -> Path | None:
-    val = os.environ.get(env_name)
+    val = get_environment_value(env_name)
     if val is not None:
         return Path(val).expanduser().resolve()
     return val

--- a/src/pipx/self_install.py
+++ b/src/pipx/self_install.py
@@ -1,0 +1,60 @@
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import Final
+
+__all__ = ["SELF_MANAGED_ENVIRONMENT", "discover_self_managed_environment", "get_environment_value"]
+
+
+def _invoked_executable(executable: str) -> Path | None:
+    if os.sep in executable or (os.altsep is not None and os.altsep in executable):
+        return Path(executable).absolute()
+    if found := shutil.which(executable):
+        return Path(found)
+    return None
+
+
+def discover_self_managed_environment(
+    prefix: Path | None = None,
+    executable: str | None = None,
+) -> dict[str, str]:
+    if os.name == "nt":
+        return {}
+
+    prefix = Path(sys.prefix) if prefix is None else prefix
+    if prefix.parent.name != "venvs":
+        return {}
+
+    try:
+        metadata: object = json.loads((prefix / "pipx_metadata.json").read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return {}
+    if not isinstance(metadata, dict):
+        return {}
+    main_package = metadata.get("main_package")
+    if not isinstance(main_package, dict) or main_package.get("package") != "pipx":
+        return {}
+
+    environment: dict[str, str] = {"PIPX_HOME": str(prefix.parent.parent)}
+    invoked_executable = _invoked_executable(sys.argv[0] if executable is None else executable)
+    if (
+        invoked_executable is not None
+        and not invoked_executable.is_relative_to(prefix)
+        and invoked_executable.resolve().is_relative_to(prefix)
+    ):
+        environment["PIPX_BIN_DIR"] = str(invoked_executable.parent)
+
+    source_interpreter = metadata.get("source_interpreter")
+    if isinstance(source_interpreter, dict) and source_interpreter.get("__type__") == "Path":
+        if isinstance(source_path := source_interpreter.get("__Path__"), str):
+            environment["PIPX_DEFAULT_PYTHON"] = source_path
+    return environment
+
+
+SELF_MANAGED_ENVIRONMENT: Final[dict[str, str]] = discover_self_managed_environment()
+
+
+def get_environment_value(name: str) -> str | None:
+    return os.environ.get(name, SELF_MANAGED_ENVIRONMENT.get(name))

--- a/src/pipx/self_install.py
+++ b/src/pipx/self_install.py
@@ -3,17 +3,10 @@ import os
 import shutil
 import sys
 from pathlib import Path
-from typing import Final
+from typing import Final, TypeAlias, cast
 
-__all__ = ["SELF_MANAGED_ENVIRONMENT", "discover_self_managed_environment", "get_environment_value"]
-
-
-def _invoked_executable(executable: str) -> Path | None:
-    if os.sep in executable or (os.altsep is not None and os.altsep in executable):
-        return Path(executable).absolute()
-    if found := shutil.which(executable):
-        return Path(found)
-    return None
+_JsonValue: TypeAlias = None | bool | int | float | str | list["_JsonValue"] | dict[str, "_JsonValue"]
+_PIPX_METADATA_FILENAME: Final[str] = "pipx_metadata.json"
 
 
 def discover_self_managed_environment(
@@ -23,12 +16,15 @@ def discover_self_managed_environment(
     if os.name == "nt":
         return {}
 
-    prefix = Path(sys.prefix) if prefix is None else prefix
-    if prefix.parent.name != "venvs":
+    venv = Path(sys.prefix) if prefix is None else prefix
+    if venv.parent.name != "venvs":
         return {}
 
     try:
-        metadata: object = json.loads((prefix / "pipx_metadata.json").read_text(encoding="utf-8"))
+        metadata = cast(
+            "_JsonValue",
+            json.loads((venv / _PIPX_METADATA_FILENAME).read_text(encoding="utf-8")),
+        )
     except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return {}
     if not isinstance(metadata, dict):
@@ -37,12 +33,12 @@ def discover_self_managed_environment(
     if not isinstance(main_package, dict) or main_package.get("package") != "pipx":
         return {}
 
-    environment: dict[str, str] = {"PIPX_HOME": str(prefix.parent.parent)}
+    environment: dict[str, str] = {"PIPX_HOME": str(venv.parent.parent)}
     invoked_executable = _invoked_executable(sys.argv[0] if executable is None else executable)
     if (
         invoked_executable is not None
-        and not invoked_executable.is_relative_to(prefix)
-        and invoked_executable.resolve().is_relative_to(prefix)
+        and not invoked_executable.is_relative_to(venv)
+        and invoked_executable.resolve().is_relative_to(venv)
     ):
         environment["PIPX_BIN_DIR"] = str(invoked_executable.parent)
 
@@ -53,8 +49,23 @@ def discover_self_managed_environment(
     return environment
 
 
+def _invoked_executable(executable: str) -> Path | None:
+    if os.sep in executable or (os.altsep is not None and os.altsep in executable):
+        return Path(executable).absolute()
+    if found := shutil.which(executable):
+        return Path(found)
+    return None
+
+
 SELF_MANAGED_ENVIRONMENT: Final[dict[str, str]] = discover_self_managed_environment()
 
 
 def get_environment_value(name: str) -> str | None:
     return os.environ.get(name, SELF_MANAGED_ENVIRONMENT.get(name))
+
+
+__all__ = [
+    "SELF_MANAGED_ENVIRONMENT",
+    "discover_self_managed_environment",
+    "get_environment_value",
+]

--- a/tests/test_self_managed.py
+++ b/tests/test_self_managed.py
@@ -1,54 +1,155 @@
+from __future__ import annotations
+
 import json
 import os
 import subprocess
 import sys
-from collections.abc import Mapping
 from pathlib import Path
-from typing import Final, NamedTuple
+from typing import TYPE_CHECKING, Final, NamedTuple
 
 import pytest
 
+from pipx.pipx_metadata_file import PIPX_INFO_FILENAME
 from pipx.self_install import discover_self_managed_environment
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 _SKIP_ON_WINDOWS: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     os.name == "nt", reason="Self-managed path discovery is only supported on Unix"
 )
 
 
-class SelfManagedInstallation(NamedTuple):
-    home: Path
-    bin_dir: Path
-    venv: Path
-    executable: Path
-    source_interpreter: Path
+@_SKIP_ON_WINDOWS
+@pytest.mark.parametrize(
+    ("name", "attribute"),
+    [
+        pytest.param("PIPX_HOME", "home", id="home"),
+        pytest.param("PIPX_BIN_DIR", "bin_dir", id="bin-dir"),
+        pytest.param("PIPX_DEFAULT_PYTHON", "source_interpreter", id="default-python"),
+    ],
+)
+def test_self_managed_value_is_discovered(
+    self_managed_installation: _SelfManagedInstallation,
+    name: str,
+    attribute: str,
+) -> None:
+    assert _get_environment_value(self_managed_installation, name) == getattr(self_managed_installation, attribute)
 
 
-@pytest.fixture
-def self_managed_installation(tmp_path: Path) -> SelfManagedInstallation:
-    home = tmp_path / "custom" / "pipx"
-    venv = home / "venvs" / "pipx"
-    (venv / "bin").mkdir(parents=True)
-    (venv / "bin" / "pipx").touch(mode=0o755)
-    source_interpreter = tmp_path / "python-custom"
-    source_interpreter.touch(mode=0o755)
-    (venv / "pipx_metadata.json").write_text(
-        json.dumps(
-            {
-                "main_package": {"package": "pipx"},
-                "source_interpreter": {"__type__": "Path", "__Path__": str(source_interpreter)},
-            }
-        ),
-        encoding="utf-8",
+@_SKIP_ON_WINDOWS
+def test_self_managed_explicit_environment_wins(self_managed_installation: _SelfManagedInstallation) -> None:
+    explicit_home = self_managed_installation.home.parent / "explicit"
+    assert (
+        _get_environment_value(
+            self_managed_installation,
+            "PIPX_HOME",
+            {"PIPX_HOME": str(explicit_home)},
+        )
+        == explicit_home
     )
-    bin_dir = home / "bin"
-    bin_dir.mkdir()
-    executable = bin_dir / "pipx"
-    executable.symlink_to(Path("../venvs/pipx/bin/pipx"))
-    return SelfManagedInstallation(home, bin_dir, venv, executable, source_interpreter)
+
+
+@_SKIP_ON_WINDOWS
+@pytest.mark.parametrize(
+    ("name", "attribute"),
+    [
+        pytest.param("PIPX_HOME", "home", id="home"),
+        pytest.param("PIPX_BIN_DIR", "bin_dir", id="bin-dir"),
+    ],
+)
+def test_self_managed_moved_value_is_discovered(
+    self_managed_installation: _SelfManagedInstallation,
+    name: str,
+    attribute: str,
+) -> None:
+    moved_home = self_managed_installation.home.parent.parent / "moved"
+    self_managed_installation.home.rename(moved_home)
+    moved_installation = self_managed_installation._replace(
+        home=moved_home,
+        bin_dir=moved_home / "bin",
+        venv=moved_home / "venvs" / "pipx",
+        executable=moved_home / "bin" / "pipx",
+    )
+    assert _get_environment_value(moved_installation, name) == getattr(moved_installation, attribute)
+
+
+@_SKIP_ON_WINDOWS
+def test_self_managed_direct_venv_script_does_not_set_bin_dir(
+    self_managed_installation: _SelfManagedInstallation,
+) -> None:
+    assert "PIPX_BIN_DIR" not in discover_self_managed_environment(
+        prefix=self_managed_installation.venv,
+        executable=str(self_managed_installation.venv / "bin" / "pipx"),
+    )
+
+
+@_SKIP_ON_WINDOWS
+def test_self_managed_executable_on_path_sets_bin_dir(
+    self_managed_installation: _SelfManagedInstallation,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PATH", f"{self_managed_installation.bin_dir}{os.pathsep}{os.environ['PATH']}")
+    assert discover_self_managed_environment(prefix=self_managed_installation.venv, executable="pipx")[
+        "PIPX_BIN_DIR"
+    ] == str(self_managed_installation.bin_dir)
+
+
+@_SKIP_ON_WINDOWS
+def test_self_managed_missing_executable_does_not_set_bin_dir(
+    self_managed_installation: _SelfManagedInstallation,
+) -> None:
+    assert "PIPX_BIN_DIR" not in discover_self_managed_environment(
+        prefix=self_managed_installation.venv,
+        executable="pipx-command-that-does-not-exist",
+    )
+
+
+def test_self_managed_windows_is_ignored(
+    self_managed_installation: _SelfManagedInstallation,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(os, "name", "nt")
+    assert (
+        discover_self_managed_environment(
+            prefix=self_managed_installation.venv,
+            executable=str(self_managed_installation.executable),
+        )
+        == {}
+    )
+
+
+@_SKIP_ON_WINDOWS
+def test_self_managed_missing_metadata_is_ignored(tmp_path: Path) -> None:
+    venv = tmp_path / "pipx" / "venvs" / "pipx"
+    venv.mkdir(parents=True)
+    assert discover_self_managed_environment(prefix=venv, executable="pipx") == {}
+
+
+@_SKIP_ON_WINDOWS
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        pytest.param([], id="non-object"),
+        pytest.param({"main_package": {"package": "black"}}, id="different-package"),
+    ],
+)
+def test_self_managed_invalid_metadata_is_ignored(
+    self_managed_installation: _SelfManagedInstallation,
+    metadata: list[None] | dict[str, dict[str, str]],
+) -> None:
+    (self_managed_installation.venv / PIPX_INFO_FILENAME).write_text(json.dumps(metadata), encoding="utf-8")
+    assert (
+        discover_self_managed_environment(
+            prefix=self_managed_installation.venv,
+            executable=str(self_managed_installation.executable),
+        )
+        == {}
+    )
 
 
 def _get_environment_value(
-    installation: SelfManagedInstallation,
+    installation: _SelfManagedInstallation,
     name: str,
     overrides: Mapping[str, str] | None = None,
 ) -> Path:
@@ -68,121 +169,33 @@ def _get_environment_value(
     return Path(result.stdout.strip())
 
 
-@_SKIP_ON_WINDOWS
-@pytest.mark.parametrize(
-    ("name", "attribute"),
-    [
-        ("PIPX_HOME", "home"),
-        ("PIPX_BIN_DIR", "bin_dir"),
-        ("PIPX_DEFAULT_PYTHON", "source_interpreter"),
-    ],
-    ids=["home", "bin-dir", "default-python"],
-)
-def test_self_managed_value_is_discovered(
-    self_managed_installation: SelfManagedInstallation,
-    name: str,
-    attribute: str,
-) -> None:
-    assert _get_environment_value(self_managed_installation, name) == getattr(self_managed_installation, attribute)
-
-
-@_SKIP_ON_WINDOWS
-def test_self_managed_explicit_environment_wins(self_managed_installation: SelfManagedInstallation) -> None:
-    explicit_home = self_managed_installation.home.parent / "explicit"
-    assert (
-        _get_environment_value(
-            self_managed_installation,
-            "PIPX_HOME",
-            {"PIPX_HOME": str(explicit_home)},
-        )
-        == explicit_home
+@pytest.fixture
+def self_managed_installation(tmp_path: Path) -> _SelfManagedInstallation:
+    home = tmp_path / "custom" / "pipx"
+    venv = home / "venvs" / "pipx"
+    (venv / "bin").mkdir(parents=True)
+    (venv / "bin" / "pipx").touch(mode=0o755)
+    source_interpreter = tmp_path / "python-custom"
+    source_interpreter.touch(mode=0o755)
+    (venv / PIPX_INFO_FILENAME).write_text(
+        json.dumps(
+            {
+                "main_package": {"package": "pipx"},
+                "source_interpreter": {"__type__": "Path", "__Path__": str(source_interpreter)},
+            }
+        ),
+        encoding="utf-8",
     )
+    bin_dir = home / "bin"
+    bin_dir.mkdir()
+    executable = bin_dir / "pipx"
+    executable.symlink_to(Path("../venvs/pipx/bin/pipx"))
+    return _SelfManagedInstallation(home, bin_dir, venv, executable, source_interpreter)
 
 
-@_SKIP_ON_WINDOWS
-@pytest.mark.parametrize(
-    ("name", "attribute"),
-    [("PIPX_HOME", "home"), ("PIPX_BIN_DIR", "bin_dir")],
-    ids=["home", "bin-dir"],
-)
-def test_self_managed_moved_value_is_discovered(
-    self_managed_installation: SelfManagedInstallation,
-    name: str,
-    attribute: str,
-) -> None:
-    moved_home = self_managed_installation.home.parent.parent / "moved"
-    self_managed_installation.home.rename(moved_home)
-    moved_installation = self_managed_installation._replace(
-        home=moved_home,
-        bin_dir=moved_home / "bin",
-        venv=moved_home / "venvs" / "pipx",
-        executable=moved_home / "bin" / "pipx",
-    )
-    assert _get_environment_value(moved_installation, name) == getattr(moved_installation, attribute)
-
-
-@_SKIP_ON_WINDOWS
-def test_self_managed_direct_venv_script_does_not_set_bin_dir(
-    self_managed_installation: SelfManagedInstallation,
-) -> None:
-    environment = discover_self_managed_environment(
-        prefix=self_managed_installation.venv,
-        executable=str(self_managed_installation.venv / "bin" / "pipx"),
-    )
-    assert "PIPX_BIN_DIR" not in environment
-
-
-@_SKIP_ON_WINDOWS
-def test_self_managed_executable_on_path_sets_bin_dir(
-    self_managed_installation: SelfManagedInstallation,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("PATH", f"{self_managed_installation.bin_dir}{os.pathsep}{os.environ['PATH']}")
-    environment = discover_self_managed_environment(prefix=self_managed_installation.venv, executable="pipx")
-    assert environment["PIPX_BIN_DIR"] == str(self_managed_installation.bin_dir)
-
-
-@_SKIP_ON_WINDOWS
-def test_self_managed_missing_executable_does_not_set_bin_dir(
-    self_managed_installation: SelfManagedInstallation,
-) -> None:
-    environment = discover_self_managed_environment(
-        prefix=self_managed_installation.venv,
-        executable="pipx-command-that-does-not-exist",
-    )
-    assert "PIPX_BIN_DIR" not in environment
-
-
-def test_self_managed_windows_is_ignored(
-    self_managed_installation: SelfManagedInstallation,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(os, "name", "nt")
-    assert not discover_self_managed_environment(
-        prefix=self_managed_installation.venv,
-        executable=str(self_managed_installation.executable),
-    )
-
-
-@_SKIP_ON_WINDOWS
-def test_self_managed_missing_metadata_is_ignored(tmp_path: Path) -> None:
-    venv = tmp_path / "pipx" / "venvs" / "pipx"
-    venv.mkdir(parents=True)
-    assert not discover_self_managed_environment(prefix=venv, executable="pipx")
-
-
-@_SKIP_ON_WINDOWS
-@pytest.mark.parametrize(
-    "metadata",
-    [[], {"main_package": {"package": "black"}}],
-    ids=["non-object", "different-package"],
-)
-def test_self_managed_invalid_metadata_is_ignored(
-    self_managed_installation: SelfManagedInstallation,
-    metadata: object,
-) -> None:
-    (self_managed_installation.venv / "pipx_metadata.json").write_text(json.dumps(metadata), encoding="utf-8")
-    assert not discover_self_managed_environment(
-        prefix=self_managed_installation.venv,
-        executable=str(self_managed_installation.executable),
-    )
+class _SelfManagedInstallation(NamedTuple):
+    home: Path
+    bin_dir: Path
+    venv: Path
+    executable: Path
+    source_interpreter: Path

--- a/tests/test_self_managed.py
+++ b/tests/test_self_managed.py
@@ -1,0 +1,188 @@
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Final, NamedTuple
+
+import pytest
+
+from pipx.self_install import discover_self_managed_environment
+
+_SKIP_ON_WINDOWS: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    os.name == "nt", reason="Self-managed path discovery is only supported on Unix"
+)
+
+
+class SelfManagedInstallation(NamedTuple):
+    home: Path
+    bin_dir: Path
+    venv: Path
+    executable: Path
+    source_interpreter: Path
+
+
+@pytest.fixture
+def self_managed_installation(tmp_path: Path) -> SelfManagedInstallation:
+    home = tmp_path / "custom" / "pipx"
+    venv = home / "venvs" / "pipx"
+    (venv / "bin").mkdir(parents=True)
+    (venv / "bin" / "pipx").touch(mode=0o755)
+    source_interpreter = tmp_path / "python-custom"
+    source_interpreter.touch(mode=0o755)
+    (venv / "pipx_metadata.json").write_text(
+        json.dumps(
+            {
+                "main_package": {"package": "pipx"},
+                "source_interpreter": {"__type__": "Path", "__Path__": str(source_interpreter)},
+            }
+        ),
+        encoding="utf-8",
+    )
+    bin_dir = home / "bin"
+    bin_dir.mkdir()
+    executable = bin_dir / "pipx"
+    executable.symlink_to(Path("../venvs/pipx/bin/pipx"))
+    return SelfManagedInstallation(home, bin_dir, venv, executable, source_interpreter)
+
+
+def _get_environment_value(
+    installation: SelfManagedInstallation,
+    name: str,
+    overrides: Mapping[str, str] | None = None,
+) -> Path:
+    code = (
+        "import sys; "
+        f"sys.prefix = {str(installation.venv)!r}; "
+        f"sys.argv = [{str(installation.executable)!r}]; "
+        "from pipx.commands.environment import environment; "
+        f"raise SystemExit(environment({name!r}))"
+    )
+    env = os.environ.copy()
+    for env_name in ("PIPX_HOME", "PIPX_BIN_DIR", "PIPX_DEFAULT_PYTHON"):
+        env.pop(env_name, None)
+    if overrides is not None:
+        env.update(overrides)
+    result = subprocess.run([sys.executable, "-c", code], env=env, capture_output=True, text=True, check=True)
+    return Path(result.stdout.strip())
+
+
+@_SKIP_ON_WINDOWS
+@pytest.mark.parametrize(
+    ("name", "attribute"),
+    [
+        ("PIPX_HOME", "home"),
+        ("PIPX_BIN_DIR", "bin_dir"),
+        ("PIPX_DEFAULT_PYTHON", "source_interpreter"),
+    ],
+    ids=["home", "bin-dir", "default-python"],
+)
+def test_self_managed_value_is_discovered(
+    self_managed_installation: SelfManagedInstallation,
+    name: str,
+    attribute: str,
+) -> None:
+    assert _get_environment_value(self_managed_installation, name) == getattr(self_managed_installation, attribute)
+
+
+@_SKIP_ON_WINDOWS
+def test_self_managed_explicit_environment_wins(self_managed_installation: SelfManagedInstallation) -> None:
+    explicit_home = self_managed_installation.home.parent / "explicit"
+    assert (
+        _get_environment_value(
+            self_managed_installation,
+            "PIPX_HOME",
+            {"PIPX_HOME": str(explicit_home)},
+        )
+        == explicit_home
+    )
+
+
+@_SKIP_ON_WINDOWS
+@pytest.mark.parametrize(
+    ("name", "attribute"),
+    [("PIPX_HOME", "home"), ("PIPX_BIN_DIR", "bin_dir")],
+    ids=["home", "bin-dir"],
+)
+def test_self_managed_moved_value_is_discovered(
+    self_managed_installation: SelfManagedInstallation,
+    name: str,
+    attribute: str,
+) -> None:
+    moved_home = self_managed_installation.home.parent.parent / "moved"
+    self_managed_installation.home.rename(moved_home)
+    moved_installation = self_managed_installation._replace(
+        home=moved_home,
+        bin_dir=moved_home / "bin",
+        venv=moved_home / "venvs" / "pipx",
+        executable=moved_home / "bin" / "pipx",
+    )
+    assert _get_environment_value(moved_installation, name) == getattr(moved_installation, attribute)
+
+
+@_SKIP_ON_WINDOWS
+def test_self_managed_direct_venv_script_does_not_set_bin_dir(
+    self_managed_installation: SelfManagedInstallation,
+) -> None:
+    environment = discover_self_managed_environment(
+        prefix=self_managed_installation.venv,
+        executable=str(self_managed_installation.venv / "bin" / "pipx"),
+    )
+    assert "PIPX_BIN_DIR" not in environment
+
+
+@_SKIP_ON_WINDOWS
+def test_self_managed_executable_on_path_sets_bin_dir(
+    self_managed_installation: SelfManagedInstallation,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PATH", f"{self_managed_installation.bin_dir}{os.pathsep}{os.environ['PATH']}")
+    environment = discover_self_managed_environment(prefix=self_managed_installation.venv, executable="pipx")
+    assert environment["PIPX_BIN_DIR"] == str(self_managed_installation.bin_dir)
+
+
+@_SKIP_ON_WINDOWS
+def test_self_managed_missing_executable_does_not_set_bin_dir(
+    self_managed_installation: SelfManagedInstallation,
+) -> None:
+    environment = discover_self_managed_environment(
+        prefix=self_managed_installation.venv,
+        executable="pipx-command-that-does-not-exist",
+    )
+    assert "PIPX_BIN_DIR" not in environment
+
+
+def test_self_managed_windows_is_ignored(
+    self_managed_installation: SelfManagedInstallation,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(os, "name", "nt")
+    assert not discover_self_managed_environment(
+        prefix=self_managed_installation.venv,
+        executable=str(self_managed_installation.executable),
+    )
+
+
+@_SKIP_ON_WINDOWS
+def test_self_managed_missing_metadata_is_ignored(tmp_path: Path) -> None:
+    venv = tmp_path / "pipx" / "venvs" / "pipx"
+    venv.mkdir(parents=True)
+    assert not discover_self_managed_environment(prefix=venv, executable="pipx")
+
+
+@_SKIP_ON_WINDOWS
+@pytest.mark.parametrize(
+    "metadata",
+    [[], {"main_package": {"package": "black"}}],
+    ids=["non-object", "different-package"],
+)
+def test_self_managed_invalid_metadata_is_ignored(
+    self_managed_installation: SelfManagedInstallation,
+    metadata: object,
+) -> None:
+    (self_managed_installation.venv / "pipx_metadata.json").write_text(json.dumps(metadata), encoding="utf-8")
+    assert not discover_self_managed_environment(
+        prefix=self_managed_installation.venv,
+        executable=str(self_managed_installation.executable),
+    )


### PR DESCRIPTION
A pipx installation that manages itself loses custom `PIPX_HOME`, `PIPX_BIN_DIR`, and `PIPX_DEFAULT_PYTHON` settings in later shells because those values exist only in the bootstrap environment. The managed executable then reads platform defaults and operates on a different installation. Fixes #774.

On Unix, pipx identifies its managed venv from `pipx_metadata.json`, derives the home and launcher directory from the installation layout, and reuses the recorded source interpreter. Explicit environment variables take precedence; unrelated venvs and direct venv entry points do not supply a bin directory.
