### PR TITLE
🐛 fix(metadata): tolerate corrupt files

### DIFF
--- a/changelog.d/1856.bugfix.1.md
+++ b/changelog.d/1856.bugfix.1.md
@@ -1,0 +1,1 @@
+Treat corrupt venv metadata as missing instead of crashing list and bulk commands.

--- a/src/pipx/pipx_metadata_file.py
+++ b/src/pipx/pipx_metadata_file.py
@@ -63,11 +63,10 @@ class _RawSpecFile(TypedDict, total=False):
 
 
 class JsonEncoderHandlesPath(json.JSONEncoder):
-    def default(self, obj: Any) -> Any:
-        # only handles what json.JSONEncoder doesn't understand by default
-        if isinstance(obj, Path):
-            return {"__type__": "Path", "__Path__": str(obj)}
-        return super().default(obj)
+    def default(self, o: Any) -> Any:
+        if isinstance(o, Path):
+            return {"__type__": "Path", "__Path__": str(o)}
+        return super().default(o)
 
 
 def _json_decoder_object_hook(json_dict: dict[str, Any]) -> dict[str, Any] | Path:
@@ -241,7 +240,7 @@ class PipxMetadata:
             with open(self.venv_dir / PIPX_INFO_FILENAME, "rb") as pipx_metadata_fh:
                 payload: _RawMetadata = json.load(pipx_metadata_fh, object_hook=_json_decoder_object_hook)
                 self.from_dict(payload)
-        except OSError:  # Reset self if problem reading
+        except (AttributeError, KeyError, OSError, PipxError, TypeError, ValueError):
             if verbose:
                 _LOGGER.warning(
                     pipx_wrap(

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -78,6 +78,22 @@ def test_list_legacy_venv(pipx_temp_env, monkeypatch, capsys, metadata_version):
         assert "package pycowsay 0.0.0.2," in captured.out
 
 
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        "{",
+        "{}",
+        '{"pipx_metadata_version":"0.6","main_package":{"unexpected":true}}',
+    ],
+    ids=["invalid-json", "missing-version", "unexpected-package-field"],
+)
+def test_list_corrupt_metadata_does_not_crash(pipx_temp_env: None, metadata: str) -> None:
+    venv_dir = paths.ctx.venvs / "broken"
+    venv_dir.mkdir(parents=True)
+    (venv_dir / "pipx_metadata.json").write_text(metadata, encoding="utf-8")
+    assert run_pipx_cli(["list"]) == constants.EXIT_CODE_LIST_PROBLEM
+
+
 @pytest.mark.parametrize("metadata_version", ["0.1"])
 def test_list_suffix_legacy_venv(pipx_temp_env, monkeypatch, capsys, metadata_version):
     suffix = "_x"


### PR DESCRIPTION
A malformed `pipx_metadata.json` raises `JSONDecodeError`, `KeyError`, or `TypeError` while pipx constructs a venv. `pipx list` and bulk commands stop at the first damaged record. Refs #1856.

pipx now treats malformed JSON, missing required fields, incompatible versions, and invalid package records as unreadable metadata. pipx reports the damaged environment and continues processing the remaining venvs.
