### PR TITLE
🐛 fix(run): translate uv pip options

### DIFF
--- a/changelog.d/1856.bugfix.2.md
+++ b/changelog.d/1856.bugfix.2.md
@@ -1,0 +1,1 @@
+Translate pip binary and trusted-host options to valid uv run arguments, and reject `--no-deps` before invoking uv.

--- a/src/pipx/commands/run_uv.py
+++ b/src/pipx/commands/run_uv.py
@@ -12,21 +12,47 @@ from pipx.emojis import hazard
 from pipx.util import PipxError, exec_app, pipx_wrap
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
 _LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
-# Pip flags translatable to ``uv tool run`` / ``uv run``; anything else errors.
-_UV_TRANSLATABLE_VALUE_FLAGS: Final[frozenset[str]] = frozenset(
-    {"--index-url", "-i", "--extra-index-url", "--find-links", "-f", "--no-binary", "--only-binary", "--trusted-host"}
-)
+_UV_VALUE_FLAG_MAP: Final[dict[str, str]] = {
+    "--index-url": "--index-url",
+    "-i": "-i",
+    "--extra-index-url": "--extra-index-url",
+    "--find-links": "--find-links",
+    "-f": "-f",
+    "--trusted-host": "--allow-insecure-host",
+}
+_UV_FORMAT_CONTROL_FLAG_MAP: Final[dict[str, tuple[str, str]]] = {
+    "--no-binary": ("--no-binary", "--no-binary-package"),
+    "--only-binary": ("--no-build", "--no-build-package"),
+}
 _UV_TRANSLATABLE_BOOL_FLAGS: Final[dict[str, str]] = {
     "--pre": "--prerelease=allow",
-    "--no-deps": "--no-deps",
     "--no-cache-dir": "--no-cache",
     "--upgrade": "--upgrade",
     "-U": "--upgrade",
 }
+
+
+def _next_pip_arg(flag: str, iterator: Iterator[str]) -> str:
+    try:
+        return next(iterator)
+    except StopIteration as exc:
+        raise PipxError(f"Missing value for {flag!r} in --pip-args.") from exc
+
+
+def _translate_format_control(flag: str, value: str) -> list[str]:
+    all_flag, package_flag = _UV_FORMAT_CONTROL_FLAG_MAP[flag]
+    if value == ":all:":
+        return [all_flag]
+    if value == ":none:":
+        return []
+    if not all(packages := value.split(",")):
+        raise PipxError(f"Invalid value for {flag!r} in --pip-args: {value!r}.")
+    return [item for package in packages for item in (package_flag, package)]
 
 
 def _reject_venv_args(venv_args: list[str]) -> None:
@@ -128,16 +154,17 @@ def translate_pip_args_for_uv(pip_args: list[str]) -> list[str]:
         if (translated_bool := _UV_TRANSLATABLE_BOOL_FLAGS.get(arg)) is not None:
             translated.append(translated_bool)
             continue
-        if arg in _UV_TRANSLATABLE_VALUE_FLAGS:
-            try:
-                value = next(iterator)
-            except StopIteration as exc:
-                raise PipxError(f"Missing value for {arg!r} in --pip-args.") from exc
-            translated.extend([arg, value])
+        flag, separator, attached_value = arg.partition("=")
+        if flag in _UV_FORMAT_CONTROL_FLAG_MAP:
+            translated.extend(
+                _translate_format_control(flag, attached_value if separator else _next_pip_arg(flag, iterator))
+            )
             continue
-        # Bool flags must not accept ``=value`` (caught ``--pre=foo`` slipping through).
-        if "=" in arg and arg.split("=", 1)[0] in _UV_TRANSLATABLE_VALUE_FLAGS:
-            translated.append(arg)
+        if (translated_flag := _UV_VALUE_FLAG_MAP.get(flag)) is not None:
+            if separator:
+                translated.append(f"{translated_flag}={attached_value}")
+            else:
+                translated.extend([translated_flag, _next_pip_arg(flag, iterator)])
             continue
         raise PipxError(
             f"--pip-args contains {arg!r}, which has no `uv tool run` equivalent.\n"

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -217,6 +217,29 @@ def test_find_uv_binary_is_cached(mocker: MockerFixture) -> None:
         ),
         pytest.param(["--pre"], ["--prerelease=allow"], id="pre-to-prerelease"),
         pytest.param(["--index-url=https://example.com"], ["--index-url=https://example.com"], id="equals-form"),
+        pytest.param(["--no-binary", ":all:"], ["--no-binary"], id="no-binary-all"),
+        pytest.param(
+            ["--no-binary", "one,two"],
+            ["--no-binary-package", "one", "--no-binary-package", "two"],
+            id="no-binary-packages",
+        ),
+        pytest.param(["--no-binary=:none:"], [], id="no-binary-none"),
+        pytest.param(["--only-binary", ":all:"], ["--no-build"], id="only-binary-all"),
+        pytest.param(
+            ["--only-binary=one,two"],
+            ["--no-build-package", "one", "--no-build-package", "two"],
+            id="only-binary-packages",
+        ),
+        pytest.param(
+            ["--trusted-host", "packages.example"],
+            ["--allow-insecure-host", "packages.example"],
+            id="trusted-host",
+        ),
+        pytest.param(
+            ["--trusted-host=packages.example"],
+            ["--allow-insecure-host=packages.example"],
+            id="trusted-host-equals",
+        ),
     ],
 )
 def test_translate_pip_args_for_uv(pip_args: list[str], expected: list[str]) -> None:
@@ -229,6 +252,8 @@ def test_translate_pip_args_for_uv(pip_args: list[str], expected: list[str]) -> 
         pytest.param(["--editable"], id="editable"),
         pytest.param(["-e"], id="editable-short"),
         pytest.param(["--no-build-isolation"], id="unknown-flag"),
+        pytest.param(["--no-deps"], id="no-deps"),
+        pytest.param(["--no-binary="], id="empty-no-binary"),
         pytest.param(["--index-url"], id="missing-value"),
     ],
 )


### PR DESCRIPTION
pipx forwards the pip spellings `--no-binary`, `--only-binary`, `--trusted-host`, and `--no-deps` to `uv tool run`. uv 0.11.28 rejects those spellings with parser errors. Refs #1856.

Format-control values now map `:all:`, `:none:`, and package lists to the uv flags `--no-binary`, `--no-binary-package`, `--no-build`, and `--no-build-package`. `--trusted-host` maps to `--allow-insecure-host`; pipx rejects `--no-deps` before invoking uv.
