### PR TITLE
🐛 fix(install): keep force out of metadata

### DIFF
--- a/changelog.d/1856.bugfix.3.md
+++ b/changelog.d/1856.bugfix.3.md
@@ -1,0 +1,1 @@
+Prevent `install --force` from saving its internal `--force-reinstall` option in package metadata.

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -99,7 +99,6 @@ def install(
                 )
             if force:
                 print(f"Installing to existing venv {venv.name!r}")
-                pip_args = ["--force-reinstall"] + pip_args
             else:
                 installed_version = venv.pipx_metadata.main_package.package_version
                 version_info = f" ({installed_version})" if installed_version else ""
@@ -128,6 +127,7 @@ def install(
                 package_name=package_name,
                 package_or_url=package_spec,
                 pip_args=pip_args,
+                install_only_pip_args=["--force-reinstall"] if force and exists else None,
                 include_dependencies=include_dependencies,
                 include_apps=True,
                 is_main_package=True,

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -10,6 +10,7 @@ import pytest
 from helpers import app_name, run_pipx_cli, skip_if_windows, unwrap_log_text
 from package_info import PKG
 from pipx import paths, shared_libs
+from pipx.pipx_metadata_file import PipxMetadata
 from pipx.util import PipxError
 from pipx.venv import Venv
 
@@ -136,6 +137,13 @@ def test_force_install(pipx_temp_env, capsys):
     run_pipx_cli(["install", "pycowsay", "--force"])
     captured = capsys.readouterr()
     assert "Installing to existing venv" in captured.out
+
+
+def test_force_install_does_not_record_internal_pip_args(pipx_temp_env: None) -> None:
+    assert not run_pipx_cli(["install", PKG["pycowsay"]["spec"]])
+    assert not run_pipx_cli(["install", PKG["pycowsay"]["spec"], "--force"])
+    metadata = PipxMetadata(paths.ctx.venvs / "pycowsay")
+    assert metadata.main_package.pip_args == []
 
 
 def test_install_no_packages_found(pipx_temp_env, capsys):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -140,10 +140,11 @@ def test_force_install(pipx_temp_env, capsys):
 
 
 def test_force_install_does_not_record_internal_pip_args(pipx_temp_env: None) -> None:
-    assert not run_pipx_cli(["install", PKG["pycowsay"]["spec"]])
-    assert not run_pipx_cli(["install", PKG["pycowsay"]["spec"], "--force"])
-    metadata = PipxMetadata(paths.ctx.venvs / "pycowsay")
-    assert metadata.main_package.pip_args == []
+    assert run_pipx_cli(["install", PKG["pycowsay"]["spec"]]) == 0
+    assert (
+        run_pipx_cli(["install", PKG["pycowsay"]["spec"], "--force"]),
+        PipxMetadata(paths.ctx.venvs / "pycowsay").main_package.pip_args,
+    ) == (0, [])
 
 
 def test_install_no_packages_found(pipx_temp_env, capsys):


### PR DESCRIPTION
`pipx install PACKAGE --force` prepends `--force-reinstall` to the pip arguments for the package and saves the same list in `pipx_metadata.json`. Later upgrades and reinstalls carry the internal flag forward, and a multi-package command can stack duplicate copies. Refs #1856.

Forced replacement now passes `--force-reinstall` through the existing install-scoped argument channel. The backend receives the flag for that operation, while saved user arguments remain unchanged.
