### PR TITLE
🧪 test(metadata): cover encoder fallback

### DIFF
--- a/changelog.d/1856.bugfix.1.md
+++ b/changelog.d/1856.bugfix.1.md
@@ -1,1 +1,1 @@
-Treat corrupt venv metadata as missing instead of crashing list and bulk commands.
+Report corrupt venv metadata as missing without aborting list and bulk commands.

--- a/src/pipx/pipx_metadata_file.py
+++ b/src/pipx/pipx_metadata_file.py
@@ -11,7 +11,7 @@ from pipx.util import PipxError, pipx_wrap
 _LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
 
-PIPX_INFO_FILENAME = "pipx_metadata.json"
+PIPX_INFO_FILENAME: Final[str] = "pipx_metadata.json"
 
 
 class _RawPackageInfo(TypedDict, total=False):

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -19,7 +19,7 @@ from helpers import (
 )
 from package_info import PKG
 from pipx import constants, paths, shared_libs, venv
-from pipx.pipx_metadata_file import PackageInfo, _json_decoder_object_hook
+from pipx.pipx_metadata_file import PIPX_INFO_FILENAME, PackageInfo, _json_decoder_object_hook
 from pipx.util import PipxError
 
 
@@ -81,16 +81,18 @@ def test_list_legacy_venv(pipx_temp_env, monkeypatch, capsys, metadata_version):
 @pytest.mark.parametrize(
     "metadata",
     [
-        "{",
-        "{}",
-        '{"pipx_metadata_version":"0.6","main_package":{"unexpected":true}}',
+        pytest.param("{", id="invalid-json"),
+        pytest.param("{}", id="missing-version"),
+        pytest.param(
+            '{"pipx_metadata_version":"0.6","main_package":{"unexpected":true}}',
+            id="unexpected-package-field",
+        ),
     ],
-    ids=["invalid-json", "missing-version", "unexpected-package-field"],
 )
-def test_list_corrupt_metadata_does_not_crash(pipx_temp_env: None, metadata: str) -> None:
+def test_list_returns_problem_for_corrupt_metadata(pipx_temp_env: None, metadata: str) -> None:
     venv_dir = paths.ctx.venvs / "broken"
     venv_dir.mkdir(parents=True)
-    (venv_dir / "pipx_metadata.json").write_text(metadata, encoding="utf-8")
+    (venv_dir / PIPX_INFO_FILENAME).write_text(metadata, encoding="utf-8")
     assert run_pipx_cli(["list"]) == constants.EXIT_CODE_LIST_PROBLEM
 
 
@@ -217,8 +219,6 @@ def test_list_does_not_trigger_maintenance(pipx_temp_env, caplog):
     assert not shared_libs.shared_libs.has_been_updated_this_run
     assert shared_libs.shared_libs.needs_upgrade
 
-    # same test with --skip-maintenance, which is a no-op
-    # we expect the same result, along with a warning
     os.utime(
         shared_libs.shared_libs.pip_path,
         (access_time, -shared_libs.SHARED_LIBS_MAX_AGE_SEC - 5 * 60 + now),

--- a/tests/test_pipx_metadata_file.py
+++ b/tests/test_pipx_metadata_file.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from dataclasses import replace
 from pathlib import Path
@@ -7,7 +8,7 @@ import pytest
 from helpers import assert_package_metadata, create_package_info_ref, run_pipx_cli
 from package_info import PKG
 from pipx import paths
-from pipx.pipx_metadata_file import PackageInfo, PipxMetadata
+from pipx.pipx_metadata_file import JsonEncoderHandlesPath, PackageInfo, PipxMetadata
 from pipx.util import PipxError
 
 TEST_PACKAGE1 = PackageInfo(
@@ -40,6 +41,11 @@ TEST_PACKAGE2 = PackageInfo(
     man_paths_of_dependencies={"dep2": [Path("man1/dep2.1")]},
     package_version="6.7.8",
 )
+
+
+def test_json_encoder_rejects_unsupported_value() -> None:
+    with pytest.raises(TypeError, match=r"complex.*not JSON serializable"):
+        json.dumps(1j, cls=JsonEncoderHandlesPath)
 
 
 def test_pipx_metadata_file_create(tmp_path):


### PR DESCRIPTION
`JsonEncoderHandlesPath.default()` delegates unsupported values to the standard JSON encoder. #1863 changed that line, and the merged branch lacks a regression for the fallback. The corrupt-metadata table also used a filename literal and a detached `ids=` list.

Add a complex-number regression for the encoder fallback, use `PIPX_INFO_FILENAME` in the list test, attach readable IDs to each `pytest.param` row, and type the filename constant as `Final`.
