### PR TITLE
🐛 fix(metadata): use atomic file replacement

### DIFF
--- a/changelog.d/1856.bugfix.5.md
+++ b/changelog.d/1856.bugfix.5.md
@@ -1,0 +1,1 @@
+Keep existing venv metadata when pipx cannot write its replacement.

--- a/src/pipx/pipx_metadata_file.py
+++ b/src/pipx/pipx_metadata_file.py
@@ -1,7 +1,9 @@
 import json
 import logging
+from contextlib import suppress
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 from typing import Any, Final, TypedDict
 
 from pipx.backends._base import KNOWN_BACKENDS
@@ -213,8 +215,17 @@ class PipxMetadata:
 
     def write(self) -> None:
         self._validate_before_write()
+        temporary_path: Path | None = None
         try:
-            with open(self.venv_dir / PIPX_INFO_FILENAME, "w", encoding="utf-8") as pipx_metadata_fh:
+            with NamedTemporaryFile(
+                "w",
+                encoding="utf-8",
+                dir=self.venv_dir,
+                prefix=f".{PIPX_INFO_FILENAME}.",
+                suffix=".tmp",
+                delete=False,
+            ) as pipx_metadata_fh:
+                temporary_path = Path(pipx_metadata_fh.name)
                 json.dump(
                     self.to_dict(),
                     pipx_metadata_fh,
@@ -222,6 +233,7 @@ class PipxMetadata:
                     sort_keys=True,
                     cls=JsonEncoderHandlesPath,
                 )
+            temporary_path.replace(self.venv_dir / PIPX_INFO_FILENAME)
         except OSError:
             _LOGGER.warning(
                 pipx_wrap(
@@ -234,6 +246,10 @@ class PipxMetadata:
                     subsequent_indent=" " * 4,
                 )
             )
+        finally:
+            if temporary_path is not None:
+                with suppress(OSError):
+                    temporary_path.unlink()
 
     def read(self, verbose: bool = False) -> None:
         try:

--- a/tests/test_pipx_metadata_file.py
+++ b/tests/test_pipx_metadata_file.py
@@ -4,11 +4,12 @@ from dataclasses import replace
 from pathlib import Path
 
 import pytest
+from pytest_mock import MockerFixture
 
 from helpers import assert_package_metadata, create_package_info_ref, run_pipx_cli
 from package_info import PKG
-from pipx import paths
-from pipx.pipx_metadata_file import JsonEncoderHandlesPath, PackageInfo, PipxMetadata
+from pipx import paths, pipx_metadata_file
+from pipx.pipx_metadata_file import PIPX_INFO_FILENAME, JsonEncoderHandlesPath, PackageInfo, PipxMetadata
 from pipx.util import PipxError
 
 TEST_PACKAGE1 = PackageInfo(
@@ -93,6 +94,29 @@ def test_pipx_metadata_file_validation(tmp_path, test_package):
 
     with pytest.raises(PipxError):
         pipx_metadata.write()
+
+
+def test_write_preserves_existing_metadata_after_os_error(
+    tmp_path: Path,
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    venv_dir = tmp_path / "venv"
+    venv_dir.mkdir()
+    metadata_path = venv_dir / PIPX_INFO_FILENAME
+    previous_metadata = '{"existing": true}'
+    metadata_path.write_text(previous_metadata, encoding="utf-8")
+    metadata = PipxMetadata(venv_dir, read=False)
+    metadata.main_package = TEST_PACKAGE1
+    mocker.patch.object(pipx_metadata_file.json, "dump", side_effect=OSError("disk full"))
+
+    metadata.write()
+
+    assert (
+        metadata_path.read_text(encoding="utf-8"),
+        sorted(path.name for path in venv_dir.iterdir()),
+        f"Unable to write {PIPX_INFO_FILENAME}" in caplog.text,
+    ) == (previous_metadata, [PIPX_INFO_FILENAME], True)
 
 
 def test_package_install(monkeypatch, tmp_path, pipx_temp_env):


### PR DESCRIPTION
`PipxMetadata.write()` opens `pipx_metadata.json` with `w` before serialization. An `OSError` during `json.dump()` truncates the previous metadata, and later commands treat the venv metadata as missing, as reported in [#1856](https://github.com/pypa/pipx/issues/1856).

`write()` serializes to a named temporary file in the venv directory and replaces the target after closing the file. It deletes the temporary file after success or failure; a failed write leaves the previous metadata intact and emits the existing warning.
