### PR TITLE
🐛 fix(install): resolve attached pip paths

### DIFF
--- a/changelog.d/1856.bugfix.7.md
+++ b/changelog.d/1856.bugfix.7.md
@@ -1,0 +1,1 @@
+Resolve relative paths in attached `-c` and `-f` pip arguments before invoking pip.

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 ARCHIVE_EXTENSIONS = (".whl", ".tar.gz", ".zip")
 _LOCAL_VCS_SCHEMES: Final[frozenset[str]] = frozenset({"git+file", "hg+file"})
 _PIP_PATH_OPTIONS: Final[frozenset[str]] = frozenset({"-c", "--constraint", "-f", "--find-links"})
+_PIP_ATTACHED_PATH_OPTIONS: Final[frozenset[str]] = frozenset({"-c", "-f"})
 
 
 @dataclass(frozen=True)
@@ -52,10 +53,7 @@ def _check_package_path(package_path: str) -> tuple[Path, bool]:
 
 def _parse_specifier(package_spec: str) -> ParsedPackage:
     """Parse package_spec as would be given to pipx"""
-    # If package_spec is valid pypi name, pip will always treat it as a
-    #       pypi package, not checking for local path.
-    #       We replicate pypi precedence here (only non-valid-pypi names
-    #       initiate check for local path, e.g. './package-name')
+    # Match pip's PyPI precedence by checking local paths only for names that PyPI rejects.
     valid_pep508 = None
     valid_url = None
     valid_local_path = None
@@ -86,8 +84,6 @@ def _parse_specifier(package_spec: str) -> ParsedPackage:
         ):
             valid_url = package_spec
 
-    # Treat the input as a local path if it does not look like a PEP 508
-    # specifier nor a URL. In this case we want to split out the extra part.
     if not valid_pep508 and not valid_url:
         (package_path_str, package_extras_str) = _split_path_extras(package_spec)
         (package_path, package_path_exists) = _check_package_path(package_path_str)
@@ -168,6 +164,12 @@ def parse_specifier_for_install(package_spec: str, pip_args: list[str]) -> tuple
         pip_args.remove("--editable")
 
     for index, option in enumerate(pip_args):
+        if len(option) > 2 and (option_name := option[:2]) in _PIP_ATTACHED_PATH_OPTIONS and option[2] != "=":
+            value = option[2:]
+            if not urllib.parse.urlsplit(value).scheme:
+                pip_args[index] = f"{option_name}{Path(value).expanduser().resolve()}"
+            continue
+
         option_name, separator, value = option.partition("=")
         if option_name not in _PIP_PATH_OPTIONS:
             continue
@@ -258,3 +260,13 @@ def fix_package_name(package_or_url: str, package_name: str) -> str:
     package_req.name = package_name
 
     return str(package_req)
+
+
+__all__ = [
+    "fix_package_name",
+    "get_extras",
+    "parse_specifier_for_install",
+    "parse_specifier_for_metadata",
+    "parse_specifier_for_upgrade",
+    "valid_pypi_name",
+]

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -338,6 +338,21 @@ def test_pip_args_with_constraint_relative_path(constraint_flag, pipx_temp_env, 
     assert subprocess_package_version_output != package_version
 
 
+def test_pip_args_with_attached_constraint_records_absolute_path(
+    pipx_temp_env: None,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    constraint_file = tmp_path / "constraints.txt"
+    constraint_file.write_text("pycowsay==0.0.0.2")
+    monkeypatch.chdir(tmp_path)
+
+    assert (
+        run_pipx_cli(["install", "--pip-args=-cconstraints.txt", PKG["pycowsay"]["spec"]]),
+        PipxMetadata(paths.ctx.venvs / "pycowsay").main_package.pip_args[:1],
+    ) == (0, [f"-c{constraint_file}"])
+
+
 @pytest.mark.parametrize("constraint_flag", ["-c ", "--constraint ", "--constraint="])
 def test_pip_args_with_wrong_constraint_fail(constraint_flag, pipx_ultra_temp_env, tmp_path, capsys):
     constraint_file_name = "constraints.txt"

--- a/tests/test_package_specifier.py
+++ b/tests/test_package_specifier.py
@@ -285,6 +285,10 @@ def test_parse_specifier_for_install(
             ["-c", "https://example.com/constraints.txt"],
         ),
         (
+            ["-chttps://example.com/constraints.txt"],
+            ["-chttps://example.com/constraints.txt"],
+        ),
+        (
             ["--constraint", "https://example.com/constraints.txt"],
             ["--constraint", "https://example.com/constraints.txt"],
         ),
@@ -297,9 +301,22 @@ def test_parse_specifier_for_install(
             ["-c", str(Path("constraints.txt").resolve())],
         ),
         (
+            ["-cconstraints.txt"],
+            [f"-c{Path('constraints.txt').resolve()}"],
+        ),
+        (
             ["--constraint=constraints.txt"],
             [f"--constraint={Path('constraints.txt').resolve()}"],
         ),
+    ],
+    ids=[
+        "short-separated-url",
+        "short-attached-url",
+        "long-separated-url",
+        "long-equals-url",
+        "short-separated-path",
+        "short-attached-path",
+        "long-equals-path",
     ],
 )
 def test_parse_specifier_for_install_constraint_args(
@@ -330,6 +347,10 @@ def test_parse_specifier_for_install_accepts_local_vcs_url(package_spec: str) ->
             ["-f", "https://example.com/wheels"],
         ),
         (
+            ["-fhttps://example.com/wheels"],
+            ["-fhttps://example.com/wheels"],
+        ),
+        (
             ["--find-links", "https://example.com/wheels"],
             ["--find-links", "https://example.com/wheels"],
         ),
@@ -342,9 +363,22 @@ def test_parse_specifier_for_install_accepts_local_vcs_url(package_spec: str) ->
             ["-f", str(Path("wheels").resolve())],
         ),
         (
+            ["-fwheels"],
+            [f"-f{Path('wheels').resolve()}"],
+        ),
+        (
             ["--find-links=wheels"],
             [f"--find-links={Path('wheels').resolve()}"],
         ),
+    ],
+    ids=[
+        "short-separated-url",
+        "short-attached-url",
+        "long-separated-url",
+        "long-equals-url",
+        "short-separated-path",
+        "short-attached-path",
+        "long-equals-path",
     ],
 )
 def test_parse_specifier_for_install_find_links_args(


### PR DESCRIPTION
`pipx install --pip-args=-cconstraints.txt pycowsay` fails even when `constraints.txt` exists in the command working directory, as reported in [#1856](https://github.com/pypa/pipx/issues/1856). pipx invokes pip from a managed environment and passes the attached relative path unchanged, so pip cannot open the file. Attached `-f` arguments follow the same parsing path.

`parse_specifier_for_install` resolves local paths in attached short options before invoking pip, matching the normalization for separated and long-option forms. URLs remain unchanged.
