### PR TITLE
🐛 fix(upgrade): preserve injected pip args

### DIFF
--- a/changelog.d/1856.bugfix.8.md
+++ b/changelog.d/1856.bugfix.8.md
@@ -1,0 +1,1 @@
+Preserve stored pip arguments for injected packages during `pipx upgrade --include-injected`.

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -167,10 +167,9 @@ def _upgrade_venv(
 
     if venv is None:
         venv = Venv(venv_dir, verbose=verbose, backend=backend, env_backend=env_backend)
-    if not pip_args:
-        pip_args = venv.pipx_metadata.main_package.pip_args
+    main_pip_args = pip_args or venv.pipx_metadata.main_package.pip_args
     if not shared_libs_already_checked:
-        venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
+        venv.check_upgrade_shared_libs(pip_args=main_pip_args, verbose=verbose)
 
     if not venv.python_path.is_file():
         raise PipxError(
@@ -188,8 +187,7 @@ def _upgrade_venv(
             wrap_message=False,
         )
 
-    # Upgrade shared libraries (pip, setuptools and wheel)
-    venv.upgrade_packaging_libraries(pip_args)
+    venv.upgrade_packaging_libraries(main_pip_args)
 
     versions_updated = 0
 
@@ -197,7 +195,7 @@ def _upgrade_venv(
     versions_updated += _upgrade_package(
         venv,
         package_name,
-        pip_args,
+        main_pip_args,
         is_main_package=True,
         force=force,
         upgrading_all=upgrading_all,

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from helpers import (
@@ -192,16 +194,14 @@ def test_upgrade_pip_args(
         assert arg not in metadata.main_package.pip_args
 
 
-def test_upgrade_injected_preserves_stored_pip_args(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
-    assert not run_pipx_cli(["install", PKG["pylint"]["spec"]])
-    assert not run_pipx_cli(["inject", "pylint", PKG["black"]["spec"], "--pip-args=--no-cache-dir"])
+def test_upgrade_injected_uses_stored_pip_args(pipx_temp_env: None, root: Path) -> None:
+    assert not run_pipx_cli(["install", PKG["pycowsay"]["spec"], "--pip-args=--no-cache-dir"])
+    assert not run_pipx_cli(["inject", "pycowsay", str(root / "testdata" / "empty_project"), "--pip-args=--no-compile"])
 
-    pipx_venvs_dir = paths.ctx.home / "venvs"
-    metadata = PipxMetadata(pipx_venvs_dir / "pylint")
-    assert "--no-cache-dir" in metadata.injected_packages["black"].pip_args
+    assert not run_pipx_cli(["upgrade", "--include-injected", "pycowsay"])
 
-    assert not run_pipx_cli(["upgrade", "--include-injected", "pylint"])
-    capsys.readouterr()
-
-    metadata = PipxMetadata(pipx_venvs_dir / "pylint")
-    assert "--no-cache-dir" in metadata.injected_packages["black"].pip_args
+    metadata = PipxMetadata(paths.ctx.home / "venvs" / "pycowsay")
+    assert (metadata.main_package.pip_args, metadata.injected_packages["empty-project"].pip_args) == (
+        ["--no-cache-dir"],
+        ["--no-compile"],
+    )


### PR DESCRIPTION
`pipx upgrade --include-injected` replaces pip arguments stored for an injected package with the main package arguments when the command receives no override ([#1856](https://github.com/pypa/pipx/issues/1856)). Users then lose private-index or build options recorded for the injection.

We now keep command arguments separate from resolved main-package arguments. An injection uses its recorded values when no command override exists; an explicit `--pip-args` value applies to the main package and its injections.
