### PR TITLE
🐛 fix(uninject): remove suffixed apps

### DIFF
--- a/changelog.d/1856.bugfix.9.md
+++ b/changelog.d/1856.bugfix.9.md
@@ -1,0 +1,1 @@
+Remove exposed apps that use a venv suffix when uninjecting packages.

--- a/src/pipx/commands/uninject.py
+++ b/src/pipx/commands/uninject.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from packaging.utils import canonicalize_name
 
 from pipx.colors import bold
+from pipx.commands.common import add_suffix
 from pipx.commands.uninstall import (
     _get_package_bin_dir_app_paths,
     _get_package_man_paths,
@@ -146,10 +147,10 @@ def get_include_resource_paths(package_name: str, venv: Venv, local_bin_dir: Pat
         )
 
     pkg_metadata = venv.package_metadata[package_name]
-    all_apps = set(pkg_metadata.apps)
+    all_apps = {add_suffix(app, pkg_metadata.suffix) for app in pkg_metadata.apps}
     all_man_pages = set(pkg_metadata.man_pages)
     if pkg_metadata.include_dependencies:
-        all_apps.update(pkg_metadata.apps_of_dependencies)
+        all_apps.update(add_suffix(app, pkg_metadata.suffix) for app in pkg_metadata.apps_of_dependencies)
         all_man_pages.update(pkg_metadata.man_pages_of_dependencies)
 
     need_to_remove = set()
@@ -196,3 +197,8 @@ def _collect_transitive_deps(
         for dep_name in get_required_dependency_names(dist, env):
             _collect_transitive_deps(dep_name, distributions, env, visited)
     return visited
+
+
+__all__ = [
+    "uninject",
+]

--- a/tests/test_uninject.py
+++ b/tests/test_uninject.py
@@ -1,10 +1,11 @@
-from helpers import run_pipx_cli, skip_if_windows
+from pathlib import Path
+
+from helpers import app_name, run_pipx_cli, skip_if_windows
 from package_info import PKG
 from pipx import paths
 
 
-def file_or_symlink(filepath):
-    # True for a regular file or a symlink (broken or not), False otherwise.
+def file_or_symlink(filepath: Path) -> bool:
     return filepath.exists() or filepath.is_symlink()
 
 
@@ -36,6 +37,24 @@ def test_uninject_with_include_apps(pipx_temp_env, capsys, caplog):
     assert not run_pipx_cli(["inject", "pycowsay", PKG["black"]["spec"], "--include-deps", "--include-apps"])
     assert not run_pipx_cli(["uninject", "pycowsay", "black", "--verbose"])
     assert "removed file" in caplog.text
+
+
+def test_uninject_with_suffix_removes_apps(pipx_temp_env: None, root: Path) -> None:
+    suffix = "@1"
+    assert not run_pipx_cli(["install", str(root / "testdata/empty_project"), f"--suffix={suffix}"])
+    assert not run_pipx_cli(
+        [
+            "inject",
+            f"empty-project{suffix}",
+            f"{root / 'testdata/test_package_specifier/local_extras'}[cow]",
+            "--include-deps",
+            "--with-suffix",
+        ]
+    )
+    app_paths = {paths.ctx.bin_dir / app_name(f"{app}{suffix}") for app in ("pycowsay", "repeatme")}
+    assert all(file_or_symlink(path) for path in app_paths)
+    assert not run_pipx_cli(["uninject", f"empty-project{suffix}", f"repeatme{suffix}"])
+    assert not any(file_or_symlink(path) for path in app_paths)
 
 
 def test_uninject_man_page(pipx_temp_env):


### PR DESCRIPTION
`pipx uninject` removes an injected distribution from a suffixed venv and leaves its exposed app paths behind because resource selection compares suffixed filenames with unsuffixed metadata ([#1856](https://github.com/pypa/pipx/issues/1856)).

We apply the recorded suffix to direct and dependency app names before selecting paths for removal. The regression uses local packages and covers both kinds of apps.
