### PR TITLE
🐛 fix(environment): return user values

### DIFF
--- a/changelog.d/1856.bugfix.10.md
+++ b/changelog.d/1856.bugfix.10.md
@@ -1,0 +1,1 @@
+Return user-set values for the advertised `pipx environment --value` choices.

--- a/src/pipx/commands/environment.py
+++ b/src/pipx/commands/environment.py
@@ -41,7 +41,7 @@ DERIVED_ENVIRONMENT_VARIABLES = [
 ENVIRONMENT_VALUE_CHOICES = ENVIRONMENT_VARIABLES + DERIVED_ENVIRONMENT_VARIABLES
 
 
-def environment(value: str) -> ExitCode:
+def environment(value: str | None) -> ExitCode:
     """Print a list of environment variables and paths used by pipx"""
     resolved_backend, backend_source = resolve_backend_name(env_value=env_default_backend())
     uv_binary, _uv_source = find_uv_binary()
@@ -65,7 +65,7 @@ def environment(value: str) -> ExitCode:
         "PIPX_HOME_ALLOW_SPACE": str(paths.ctx.allow_spaces_in_home_path).lower(),
     }
     if value is None:
-        print("Environment variables (set by user):")  # type: ignore[unreachable]
+        print("Environment variables (set by user):")
         print("")
         for env_variable in ENVIRONMENT_VARIABLES:
             env_value = os.getenv(env_variable, "")
@@ -77,7 +77,16 @@ def environment(value: str) -> ExitCode:
             print(f"{env_variable}={derived_value}")
     elif value in derived_values:
         print(derived_values[value])
+    elif value in ENVIRONMENT_VARIABLES:
+        print(os.getenv(value, ""))
     else:
         raise PipxError("Variable not found.")
 
     return EXIT_CODE_OK
+
+
+__all__ = [
+    "ENVIRONMENT_VALUE_CHOICES",
+    "ENVIRONMENT_VARIABLES",
+    "environment",
+]

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -46,6 +46,30 @@ def test_cli_with_args(monkeypatch, capsys):
     assert "invalid choice" in captured.err
 
 
+@pytest.mark.parametrize(
+    ("variable", "value"),
+    [
+        ("PIPX_GLOBAL_HOME", "global-home"),
+        ("PIPX_GLOBAL_BIN_DIR", "global-bin"),
+        ("PIPX_GLOBAL_MAN_DIR", "global-man"),
+        ("PIPX_DEFAULT_BACKEND", "pip"),
+        ("PIPX_FETCH_MISSING_PYTHON", "1"),
+        ("PIPX_FETCH_PYTHON", "missing"),
+    ],
+)
+def test_cli_with_user_environment_value(
+    pipx_temp_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    variable: str,
+    value: str,
+) -> None:
+    monkeypatch.setenv(variable, value)
+
+    assert not run_pipx_cli(["environment", "--value", variable])
+    assert capsys.readouterr().out == f"{value}\n"
+
+
 def test_resolve_user_dir_in_env_paths(monkeypatch):
     monkeypatch.setenv("TEST_DIR", "~/test")
     home = Path.home()


### PR DESCRIPTION
For six advertised user environment variables, `pipx environment --value` accepts the name and then raises `Variable not found.` because the command only queries derived values ([#1856](https://github.com/pypa/pipx/issues/1856)).

Known user environment names fall back to their raw values when no derived value exists. Argparse rejects unknown names.
