### PR TITLE
🐛 fix(emojis): handle missing stderr

### DIFF
--- a/changelog.d/1856.bugfix.11.md
+++ b/changelog.d/1856.bugfix.11.md
@@ -1,0 +1,1 @@
+Avoid import crashes when stderr or its encoding is unavailable.

--- a/src/pipx/emojis.py
+++ b/src/pipx/emojis.py
@@ -3,27 +3,21 @@ import sys
 
 
 def strtobool(val: str) -> bool:
-    val = val.lower()
-    if val in ("y", "yes", "t", "true", "on", "1"):
-        return True
-    elif val in ("n", "no", "f", "false", "off", "0"):
-        return False
-    else:
-        return False
+    return val.lower() in ("y", "yes", "t", "true", "on", "1")
 
 
 def use_emojis() -> bool:
-    # All emojis that pipx might possibly use
-    emoji_test_str = "✨🌟⚠️😴⣷⣯⣟⡿⢿⣻⣽⣾"
+    if (use_emoji := os.getenv("PIPX_USE_EMOJI")) is not None:
+        return strtobool(use_emoji)
+    if (use_emoji := os.getenv("USE_EMOJI")) is not None:
+        return strtobool(use_emoji)
+    if (encoding := getattr(sys.stderr, "encoding", None)) is None:
+        return False
     try:
-        emoji_test_str.encode(sys.stderr.encoding)
-        platform_emoji_support = True
+        "✨🌟⚠️😴⣷⣯⣟⡿⢿⣻⣽⣾".encode(encoding)
     except UnicodeEncodeError:
-        platform_emoji_support = False
-    use_emoji = os.getenv("PIPX_USE_EMOJI")
-    if use_emoji is None:
-        use_emoji = str(os.getenv("USE_EMOJI", platform_emoji_support))
-    return strtobool(use_emoji)
+        return False
+    return True
 
 
 EMOJI_SUPPORT = use_emojis()
@@ -38,3 +32,14 @@ else:
     hazard = ""
     error = ""
     sleep = ""
+
+
+__all__ = [
+    "EMOJI_SUPPORT",
+    "error",
+    "hazard",
+    "sleep",
+    "stars",
+    "strtobool",
+    "use_emojis",
+]

--- a/tests/test_emojis.py
+++ b/tests/test_emojis.py
@@ -1,14 +1,49 @@
+import subprocess
 import sys
 from io import BytesIO, TextIOWrapper
-from unittest import mock
 
 import pytest
+from pytest_mock import MockerFixture
 
 from pipx.emojis import use_emojis
 
 
 @pytest.mark.parametrize(
-    "PIPX_USE_EMOJI, encoding, expected",
+    "stderr_expression",
+    [
+        pytest.param("None", id="missing-stream"),
+        pytest.param("io.StringIO()", id="missing-encoding"),
+    ],
+)
+def test_import_without_stderr_encoding(stderr_expression: str) -> None:
+    process = subprocess.run(
+        [sys.executable, "-c", f"import io, sys; sys.stderr = {stderr_expression}; import pipx.emojis"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert process.returncode == 0, process.stderr
+
+
+def test_use_emojis_without_stderr(monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture) -> None:
+    mocker.patch.object(sys, "stderr", None)
+    monkeypatch.delenv("PIPX_USE_EMOJI", raising=False)
+    monkeypatch.delenv("USE_EMOJI", raising=False)
+
+    assert use_emojis() is False
+
+
+def test_use_emojis_legacy_override_without_stderr(monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture) -> None:
+    mocker.patch.object(sys, "stderr", None)
+    monkeypatch.delenv("PIPX_USE_EMOJI", raising=False)
+    monkeypatch.setenv("USE_EMOJI", "1")
+
+    assert use_emojis() is True
+
+
+@pytest.mark.parametrize(
+    ("env_value", "encoding", "expected"),
     [
         # utf-8
         (None, "utf-8", True),
@@ -39,8 +74,18 @@ from pipx.emojis import use_emojis
         ("false", "cp1252", False),
     ],
 )
-def test_use_emojis(monkeypatch, PIPX_USE_EMOJI, encoding, expected):
-    with mock.patch.object(sys, "stderr", TextIOWrapper(BytesIO(), encoding=encoding)):
-        if PIPX_USE_EMOJI is not None:
-            monkeypatch.setenv("PIPX_USE_EMOJI", PIPX_USE_EMOJI)
-        assert use_emojis() is expected
+def test_use_emojis(
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+    env_value: str | None,
+    encoding: str,
+    expected: bool,
+) -> None:
+    mocker.patch.object(sys, "stderr", TextIOWrapper(BytesIO(), encoding=encoding))
+    monkeypatch.delenv("USE_EMOJI", raising=False)
+    if env_value is None:
+        monkeypatch.delenv("PIPX_USE_EMOJI", raising=False)
+    else:
+        monkeypatch.setenv("PIPX_USE_EMOJI", env_value)
+
+    assert use_emojis() is expected


### PR DESCRIPTION
`pipx.emojis` reads `sys.stderr.encoding` during import and crashes before CLI startup when `sys.stderr` is missing or has no encoding ([#1856](https://github.com/pypa/pipx/issues/1856)).

We evaluate explicit emoji overrides before probing stderr and disable automatic emoji support when no encoding exists. The regression imports the module in subprocesses that cover both stream states.
