### PR TITLE
🐛 fix(paths): ignore empty values

### DIFF
--- a/changelog.d/1856.bugfix.12.md
+++ b/changelog.d/1856.bugfix.12.md
@@ -1,0 +1,1 @@
+Treat empty values for pipx path environment variables as unset.

--- a/src/pipx/paths.py
+++ b/src/pipx/paths.py
@@ -39,9 +39,7 @@ logger = logging.getLogger(__name__)
 
 def get_expanded_environ(env_name: str) -> Path | None:
     val = get_environment_value(env_name)
-    if val is not None:
-        return Path(val).expanduser().resolve()
-    return val
+    return Path(val).expanduser().resolve() if val else None
 
 
 class _PathContext:
@@ -184,3 +182,22 @@ class _PathContext:
 
 ctx = _PathContext()
 ctx.log_warnings()
+
+
+__all__ = [
+    "DEFAULT_PIPX_BIN_DIR",
+    "DEFAULT_PIPX_GLOBAL_BIN_DIR",
+    "DEFAULT_PIPX_GLOBAL_HOME",
+    "DEFAULT_PIPX_GLOBAL_MAN_DIR",
+    "DEFAULT_PIPX_HOME",
+    "DEFAULT_PIPX_MAN_DIR",
+    "OVERRIDE_PIPX_BIN_DIR",
+    "OVERRIDE_PIPX_GLOBAL_BIN_DIR",
+    "OVERRIDE_PIPX_GLOBAL_HOME",
+    "OVERRIDE_PIPX_GLOBAL_MAN_DIR",
+    "OVERRIDE_PIPX_HOME",
+    "OVERRIDE_PIPX_MAN_DIR",
+    "OVERRIDE_PIPX_SHARED_LIBS",
+    "ctx",
+    "get_expanded_environ",
+]

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -56,6 +56,24 @@ def test_resolve_user_dir_in_env_paths(monkeypatch):
     assert env_dir is None
 
 
+@pytest.mark.parametrize(
+    "env_name",
+    [
+        "PIPX_HOME",
+        "PIPX_GLOBAL_HOME",
+        "PIPX_BIN_DIR",
+        "PIPX_GLOBAL_BIN_DIR",
+        "PIPX_MAN_DIR",
+        "PIPX_GLOBAL_MAN_DIR",
+        "PIPX_SHARED_LIBS",
+    ],
+)
+def test_resolve_empty_env_paths(monkeypatch: pytest.MonkeyPatch, env_name: str) -> None:
+    monkeypatch.setenv(env_name, "")
+
+    assert get_expanded_environ(env_name) is None
+
+
 def test_allow_space_in_pipx_home(
     monkeypatch,
     capsys,


### PR DESCRIPTION
Empty pipx path environment variables pass through `Path("").resolve()` and become the current working directory ([#1856](https://github.com/pypa/pipx/issues/1856)). Pipx can then create managed directories inside a project checkout.

We treat empty path values as unset so pipx uses its configured defaults. The regression covers the reported local variables and the three global path variables that use the same parser.
