### PR TITLE
🐛 fix(cleanup): guard trash moves

### DIFF
--- a/changelog.d/1856.bugfix.13.md
+++ b/changelog.d/1856.bugfix.13.md
@@ -1,0 +1,1 @@
+Keep trash cleanup non-fatal during directory races and failed moves.

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -40,7 +40,7 @@ class RelevantSearch:
 
 def _get_trash_file(path: Path) -> Path:
     if not paths.ctx.trash.is_dir():
-        paths.ctx.trash.mkdir()
+        paths.ctx.trash.mkdir(exist_ok=True)
     prefix = "".join(random.choices(string.ascii_lowercase, k=8))
     return paths.ctx.trash / f"{prefix}.{path.name}"
 
@@ -63,7 +63,10 @@ def rmdir(path: Path, safe_rm: bool = True) -> None:
         if safe_rm:
             _LOGGER.warning(f"Failed to delete {path}. Will move it to a temp folder to delete later.")
 
-            path.rename(_get_trash_file(path))
+            try:
+                path.rename(_get_trash_file(path))
+            except OSError as error:
+                _LOGGER.warning("Failed to move %s to the trash; remove it by hand (%s).", path, error)
         else:
             _LOGGER.warning(f"Failed to delete {path}. You may need to delete it manually.")
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,14 +2,16 @@ from __future__ import annotations
 
 import logging
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
 
-from pipx.util import rmdir, run_subprocess
+from pipx import paths
+from pipx.util import rmdir, run_subprocess, safe_unlink
 
 if TYPE_CHECKING:
-    from pathlib import Path
+    from pytest_mock import MockerFixture
 
 
 def test_rmdir_without_safe_rm_is_non_fatal_for_locked_files(
@@ -33,6 +35,49 @@ def test_rmdir_without_safe_rm_is_non_fatal_for_locked_files(
 
     assert trash_dir.is_dir()
     assert f"Failed to delete {trash_dir}. You may need to delete it manually." in caplog.text
+
+
+def test_rmdir_with_safe_rm_is_non_fatal_when_move_fails(
+    caplog: pytest.LogCaptureFixture,
+    mocker: MockerFixture,
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "locked"
+    path.mkdir()
+    mocker.patch("pipx.util.shutil.rmtree")
+    mocker.patch.object(Path, "rename", side_effect=PermissionError("locked directory"))
+    mocker.patch.object(type(paths.ctx), "trash", mocker.PropertyMock(return_value=tmp_path / "trash"))
+
+    with caplog.at_level(logging.WARNING, logger="pipx.util"):
+        rmdir(path)
+
+    assert path.is_dir()
+    assert f"Failed to move {path} to the trash" in caplog.text
+
+
+def test_safe_unlink_handles_existing_trash_directory(mocker: MockerFixture, tmp_path: Path) -> None:
+    file = tmp_path / "locked"
+    file.write_text("content")
+    trash_dir = tmp_path / "trash"
+    trash_dir.mkdir()
+    is_dir = Path.is_dir
+    stale = True
+
+    def stale_is_dir(path: Path) -> bool:
+        nonlocal stale
+        if path == trash_dir and stale:
+            stale = False
+            return False
+        return is_dir(path)
+
+    mocker.patch.object(type(paths.ctx), "trash", mocker.PropertyMock(return_value=trash_dir))
+    mocker.patch.object(Path, "is_dir", stale_is_dir)
+    mocker.patch.object(Path, "unlink", side_effect=PermissionError("locked file"))
+
+    safe_unlink(file)
+
+    assert not file.exists()
+    assert [path.read_text() for path in trash_dir.iterdir()] == ["content"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`rmdir` can raise `OSError` when its deferred trash move fails. `_get_trash_file` can raise `FileExistsError` when two processes create the trash directory together ([#1856](https://github.com/pypa/pipx/issues/1856)).

We allow concurrent trash-directory creation and log failed deferred moves so cleanup returns without aborting startup. Public cleanup regressions simulate both filesystem failures.
