### PR TITLE
🐛 fix(venv): parse metadata versions

### DIFF
--- a/changelog.d/1856.bugfix.14.md
+++ b/changelog.d/1856.bugfix.14.md
@@ -1,0 +1,1 @@
+Compare metadata versions by parsed release components when selecting shared libraries.

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -2,18 +2,15 @@ import logging
 import shutil
 import time
 from collections.abc import Generator
+from importlib.metadata import Distribution, EntryPoint
 from pathlib import Path
 from typing import TYPE_CHECKING, Final, NoReturn
 
 if TYPE_CHECKING:
     from subprocess import CompletedProcess
 
-try:
-    from importlib.metadata import Distribution, EntryPoint
-except ImportError:
-    from importlib_metadata import Distribution, EntryPoint  # type: ignore[import-not-found,no-redef]
-
 from packaging.utils import canonicalize_name
+from packaging.version import Version
 
 from pipx.animate import animate
 from pipx.backends import Backend, assert_not_pip_under_uv, env_default_backend, get_backend, resolve_backend_name
@@ -46,6 +43,7 @@ from pipx.util import (
 from pipx.venv_inspect import VenvMetadata, inspect_venv
 
 _LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
+_BACKEND_METADATA_VERSION: Final[Version] = Version("0.6")
 
 # Keyed on full path so global vs user-local venvs with the same name don't
 # collide; deduped per-session because ``upgrade-all --backend uv`` against
@@ -220,7 +218,7 @@ class Venv:
         # (or missing file) fall back to the .pth probe so legacy venvs still
         # report correctly.
         recorded_version = self.pipx_metadata.read_metadata_version
-        if recorded_version is not None and recorded_version >= "0.6":
+        if recorded_version is not None and Version(recorded_version) >= _BACKEND_METADATA_VERSION:
             answer = self.pipx_metadata.backend == "pip"
         else:
             answer = next(self.root.glob(f"**/{PIPX_SHARED_PTH}"), None) is not None

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -18,6 +18,7 @@ from pipx.backends import (
 )
 from pipx.backends.uv import UvBackend
 from pipx.commands.run_uv import translate_pip_args_for_uv
+from pipx.constants import PIPX_SHARED_PTH
 from pipx.main import _validate_backend_available
 from pipx.util import PipxError
 from pipx.venv import Venv, reset_backend_override_warnings
@@ -353,6 +354,18 @@ def test_metadata_round_trip_includes_backend(tmp_path: Path) -> None:
 
     reread = pipx_metadata_file.PipxMetadata(venv_dir)
     assert reread.backend == "uv"
+
+
+def test_metadata_version_order_for_shared_libs(tmp_path: Path) -> None:
+    venv_dir = tmp_path / "venv"
+    site_packages = venv_dir / "lib/python/site-packages"
+    site_packages.mkdir(parents=True)
+    (site_packages / PIPX_SHARED_PTH).touch()
+    venv = Venv(venv_dir)
+    venv.pipx_metadata.read_metadata_version = "0.10"
+    venv.pipx_metadata.backend = UV
+
+    assert venv.uses_shared_libs is False
 
 
 def test_legacy_metadata_defaults_to_pip(tmp_path: Path) -> None:


### PR DESCRIPTION
`Venv.uses_shared_libs` compares recorded metadata versions as strings, so `0.10` sorts below `0.6` and takes the legacy `.pth` probe ([#1856](https://github.com/pypa/pipx/issues/1856)). The probe reports a `uv` venv with a stale marker as using shared libraries.

We parse recorded versions with `packaging.version.Version` before applying the backend threshold. We remove the unreachable `importlib_metadata` fallback because pipx requires Python 3.10 or newer.
