### PR TITLE
🐛 fix(interpreter): skip corrupt builds

### DIFF
--- a/changelog.d/1856.bugfix.16.md
+++ b/changelog.d/1856.bugfix.16.md
@@ -1,0 +1,1 @@
+Continue bulk interpreter upgrades after finding a corrupt standalone interpreter.

--- a/src/pipx/commands/interpreter.py
+++ b/src/pipx/commands/interpreter.py
@@ -1,6 +1,7 @@
 import logging
 import subprocess
 from pathlib import Path
+from typing import Final
 
 from packaging import version
 
@@ -10,7 +11,7 @@ from pipx.pipx_metadata_file import PipxMetadata
 from pipx.util import is_paths_relative, rmdir
 from pipx.venv import Venv, VenvContainer
 
-logger = logging.getLogger(__name__)
+_LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
 
 def get_installed_standalone_interpreters() -> list[Path]:
@@ -37,7 +38,7 @@ def get_interpreter_users(interpreter: Path, venvs: list[Venv]) -> list[PipxMeta
 
 def list_interpreters(
     venv_container: VenvContainer,
-):
+) -> constants.ExitCode:
     interpreters = get_installed_standalone_interpreters()
     venvs = get_venvs_using_standalone_interpreter(venv_container)
     output: list[str] = []
@@ -57,7 +58,7 @@ def list_interpreters(
 
 def prune_interpreters(
     venv_container: VenvContainer,
-):
+) -> constants.ExitCode:
     interpreters = get_installed_standalone_interpreters()
     venvs = get_venvs_using_standalone_interpreter(venv_container)
     removed = []
@@ -84,7 +85,7 @@ def get_latest_micro_version(
     return current_version
 
 
-def upgrade_interpreters(venv_container: VenvContainer, verbose: bool):
+def upgrade_interpreters(venv_container: VenvContainer, verbose: bool) -> constants.ExitCode:
     with animate("Getting the index of the latest standalone python builds", not verbose):
         latest_pythons = standalone_python.list_pythons(use_cache=False)
 
@@ -93,7 +94,7 @@ def upgrade_interpreters(venv_container: VenvContainer, verbose: bool):
         try:
             parsed_latest_python_versions.append(version.parse(latest_python_version))
         except version.InvalidVersion:
-            logger.info(f"Invalid version found in latest pythons: {latest_python_version}. Skipping.")
+            _LOGGER.info(f"Invalid version found in latest pythons: {latest_python_version}. Skipping.")
 
     upgraded = []
 
@@ -102,15 +103,15 @@ def upgrade_interpreters(venv_container: VenvContainer, verbose: bool):
             continue
 
         interpreter_python = interpreter_dir / "python.exe" if constants.WINDOWS else interpreter_dir / "bin" / "python3"
-        interpreter_full_version = (
-            subprocess.run([str(interpreter_python), "--version"], stdout=subprocess.PIPE, check=True, text=True)
-            .stdout.strip()
-            .split()[1]
-        )
         try:
+            interpreter_full_version = (
+                subprocess.run([str(interpreter_python), "--version"], stdout=subprocess.PIPE, check=True, text=True)
+                .stdout.removeprefix("Python ")
+                .strip()
+            )
             parsed_interpreter_full_version = version.parse(interpreter_full_version)
-        except version.InvalidVersion:
-            logger.info(f"Invalid version found in interpreter at {interpreter_dir}. Skipping.")
+        except (OSError, subprocess.CalledProcessError, version.InvalidVersion):
+            _LOGGER.info(f"Cannot read the interpreter version at {interpreter_dir}. Skipping.")
             continue
         latest_micro_version = get_latest_micro_version(parsed_interpreter_full_version, parsed_latest_python_versions)
         if latest_micro_version > parsed_interpreter_full_version:
@@ -145,3 +146,10 @@ def upgrade_interpreters(venv_container: VenvContainer, verbose: bool):
 
     # Any failure to upgrade will raise PipxError, otherwise success
     return constants.EXIT_CODE_OK
+
+
+__all__ = [
+    "list_interpreters",
+    "prune_interpreters",
+    "upgrade_interpreters",
+]

--- a/tests/test_standalone_interpreter.py
+++ b/tests/test_standalone_interpreter.py
@@ -1,13 +1,22 @@
+from __future__ import annotations
+
 import datetime
 import json
 import shutil
+import subprocess
 import sys
+from typing import TYPE_CHECKING
+
+import pytest
 
 from helpers import (
     run_pipx_cli,
 )
 from package_info import PKG
 from pipx import standalone_python
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 MAJOR_PYTHON_VERSION = sys.version_info.major
 MINOR_PYTHON_VERSION = sys.version_info.minor
@@ -163,3 +172,31 @@ def test_upgrade_standalone_interpreter_nothing_to_upgrade(pipx_temp_env, capsys
     assert not run_pipx_cli(["interpreter", "upgrade"])
     captured = capsys.readouterr()
     assert "Nothing to upgrade" in captured.out
+
+
+@pytest.mark.parametrize(
+    "corrupt_error",
+    [
+        pytest.param(FileNotFoundError("missing interpreter"), id="missing-executable"),
+        pytest.param(subprocess.CalledProcessError(1, ["python", "--version"]), id="nonzero-exit"),
+    ],
+)
+def test_upgrade_standalone_interpreter_skips_corrupt(
+    pipx_temp_env: None,
+    mocker: MockerFixture,
+    corrupt_error: OSError | subprocess.CalledProcessError,
+) -> None:
+    for name in ("corrupt", "valid"):
+        (standalone_python.paths.ctx.standalone_python_cachedir / name).mkdir(parents=True)
+
+    def read_version(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if "corrupt" in command[0]:
+            raise corrupt_error
+        return subprocess.CompletedProcess(command, 0, stdout="Python 3.12.0\n")
+
+    mocker.patch.object(standalone_python, "list_pythons", return_value=["not-a-version", "3.12.1"])
+    mocker.patch("pipx.commands.interpreter.subprocess.run", side_effect=read_version)
+    download = mocker.patch.object(standalone_python, "download_python_build_standalone")
+
+    assert not run_pipx_cli(["interpreter", "upgrade"])
+    download.assert_called_once_with("3.12", override=True)


### PR DESCRIPTION
`pipx interpreter upgrade` runs `--version` with `check=True` for each cached interpreter. A missing or broken executable aborts the sweep before pipx processes later valid interpreters ([#1856](https://github.com/pypa/pipx/issues/1856)).

We log and skip an interpreter whose version probe or output is invalid. The sweep continues with the remaining cache entries.
