### PR TITLE
🐛 fix(unpin): list changed packages

### DIFF
--- a/changelog.d/1856.bugfix.17.md
+++ b/changelog.d/1856.bugfix.17.md
@@ -1,0 +1,1 @@
+List only packages whose pin state changed during `pipx unpin`.

--- a/src/pipx/commands/pin.py
+++ b/src/pipx/commands/pin.py
@@ -1,6 +1,7 @@
 import logging
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Final
 
 from pipx.colors import bold
 from pipx.constants import ExitCode
@@ -8,10 +9,10 @@ from pipx.emojis import sleep
 from pipx.util import PipxError
 from pipx.venv import Venv
 
-logger = logging.getLogger(__name__)
+_LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
 
-def _update_pin_info(venv: Venv, package_name: str, is_main_package: bool, unpin: bool) -> int:
+def _update_pin_info(venv: Venv, package_name: str, is_main_package: bool, unpin: bool) -> None:
     package_metadata = venv.package_metadata[package_name]
     venv.update_package_metadata(
         package_name=str(package_metadata.package),
@@ -23,7 +24,6 @@ def _update_pin_info(venv: Venv, package_name: str, is_main_package: bool, unpin
         suffix=package_metadata.suffix,
         pinned=not unpin,
     )
-    return 1
 
 
 def pin(
@@ -39,8 +39,7 @@ def pin(
         raise PipxError(f"Package {venv.name} is not installed") from e
 
     if injected_only or skip:
-        pinned_packages_count = 0
-        pinned_packages_list = []
+        pinned_packages_list: list[str] = []
         for package_name in venv.package_metadata:
             if package_name == venv.main_package_name or package_name in skip:
                 continue
@@ -49,15 +48,15 @@ def pin(
                 print(f"{package_name} was pinned. Not modifying.")
                 continue
 
-            pinned_packages_count += _update_pin_info(venv, package_name, is_main_package=False, unpin=False)
+            _update_pin_info(venv, package_name, is_main_package=False, unpin=False)
             pinned_packages_list.append(f"{package_name} {venv.package_metadata[package_name].package_version}")
 
-        if pinned_packages_count != 0:
-            print(bold(f"Pinned {pinned_packages_count} packages in venv {venv.name}"))
+        if pinned_packages_list:
+            print(bold(f"Pinned {len(pinned_packages_list)} packages in venv {venv.name}"))
             for package in pinned_packages_list:
                 print("  -", package)
     elif main_package_metadata.pinned:
-        logger.warning(f"Package {main_package_metadata.package} already pinned {sleep}")
+        _LOGGER.warning(f"Package {main_package_metadata.package} already pinned {sleep}")
     else:
         for package_name in venv.package_metadata:
             if package_name == venv.main_package_name:
@@ -75,21 +74,30 @@ def unpin(venv_dir: Path, verbose: bool) -> ExitCode:
     except KeyError as e:
         raise PipxError(f"Package {venv.name} is not installed") from e
 
-    unpinned_packages_count = 0
-    unpinned_packages_list = []
+    unpinned_packages_list: list[str] = []
 
     for package_name in venv.package_metadata:
-        if package_name == main_package_metadata.package and main_package_metadata.pinned:
-            unpinned_packages_count += _update_pin_info(venv, package_name, is_main_package=True, unpin=True)
-        elif venv.package_metadata[package_name].pinned:
-            unpinned_packages_count += _update_pin_info(venv, package_name, is_main_package=False, unpin=True)
+        if not venv.package_metadata[package_name].pinned:
+            continue
+        _update_pin_info(
+            venv,
+            package_name,
+            is_main_package=package_name == main_package_metadata.package,
+            unpin=True,
+        )
         unpinned_packages_list.append(package_name)
 
-    if unpinned_packages_count != 0:
-        print(bold(f"Unpinned {unpinned_packages_count} packages in venv {venv.name}"))
+    if unpinned_packages_list:
+        print(bold(f"Unpinned {len(unpinned_packages_list)} packages in venv {venv.name}"))
         for package in unpinned_packages_list:
             print("  -", package)
     else:
-        logger.warning(f"No packages to unpin in venv {venv.name}")
+        _LOGGER.warning(f"No packages to unpin in venv {venv.name}")
 
     return ExitCode(0)
+
+
+__all__ = [
+    "pin",
+    "unpin",
+]

--- a/tests/test_unpin.py
+++ b/tests/test_unpin.py
@@ -1,3 +1,7 @@
+from pathlib import Path
+
+import pytest
+
 from helpers import run_pipx_cli
 from package_info import PKG
 
@@ -51,3 +55,20 @@ def test_unpin_injected_packages(capsys, pipx_temp_env):
 
     captured = capsys.readouterr()
     assert "Unpinned 3 packages in venv black" in captured.out
+
+
+def test_unpin_reports_only_changed_packages(
+    pipx_temp_env: None,
+    root: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    assert not run_pipx_cli(["inject", "pycowsay", str(root / "testdata/empty_project")])
+    assert not run_pipx_cli(["pin", "pycowsay", "--injected-only"])
+    capsys.readouterr()
+
+    assert not run_pipx_cli(["unpin", "pycowsay"])
+    output = capsys.readouterr().out
+    assert "Unpinned 1 packages in venv pycowsay" in output
+    assert "  - empty-project" in output
+    assert "  - pycowsay" not in output


### PR DESCRIPTION
`pipx unpin` counts only packages whose pin state changes, but lists every package in the environment. Pin only an injected package and it reports one change while listing the unchanged main package ([#1856](https://github.com/pypa/pipx/issues/1856)).

Build the itemized report from packages updated during the command so its count and entries agree.
