### PR TITLE
🐛 fix(run): skip cache tag sweep

### DIFF
--- a/changelog.d/1856.bugfix.18.md
+++ b/changelog.d/1856.bugfix.18.md
@@ -1,0 +1,1 @@
+Skip cache tag files when removing expired `pipx run` environments.

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -274,12 +274,10 @@ def run(
     package
     """
 
-    # For any package, we need to just use the name
     try:
         package_name = Requirement(app).name
     except InvalidRequirement:
-        # Raw URLs to scripts are supported, too, so continue if
-        # we can't parse this as a package
+        # Raw script URLs are not valid package requirements.
         package_name = app
 
     # ``resolved_backend`` only decides ROUTING (uv tool run vs Venv); cli/env
@@ -440,7 +438,7 @@ def _prepare_venv_cache(venv: Venv, bin_path: Path | None, use_cache: bool) -> N
 
 def _remove_all_expired_venvs() -> None:
     for venv_dir in Path(paths.ctx.venv_cache).iterdir():
-        if _is_temporary_venv_expired(venv_dir):
+        if venv_dir.is_dir() and _is_temporary_venv_expired(venv_dir):
             _LOGGER.info(f"Removing expired venv {venv_dir!s}")
             rmdir(venv_dir)
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,3 +1,4 @@
+import datetime
 import importlib
 import logging
 import os
@@ -99,6 +100,34 @@ def test_cachedir_tag(pipx_ultra_temp_env, monkeypatch, capsys, caplog):
     # Verify the tag file starts with the required signature.
     with tag_path.open("r") as tag_file:
         assert tag_file.read().startswith("Signature: 8a477f597d28d172789f06886806bc55")
+
+
+@mock.patch("os.execvpe", new=execvpe_mock)
+def test_cache_sweep_ignores_tag(
+    pipx_ultra_temp_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    run_pipx_cli_exit(["run", "pycowsay", "cowsay", "args"])
+    tag_path = paths.ctx.venv_cache / "CACHEDIR.TAG"
+    expired_venv = paths.ctx.venv_cache / "expired"
+    expired_venv.mkdir()
+
+    class FutureDateTime(datetime.datetime):
+        @classmethod
+        def now(cls, tz: datetime.tzinfo | None = None) -> "FutureDateTime":
+            return cls.fromtimestamp((super().now(tz) + datetime.timedelta(days=15)).timestamp(), tz)
+
+    monkeypatch.setattr(datetime, "datetime", FutureDateTime)
+    caplog.set_level(logging.INFO)
+    caplog.clear()
+
+    run_pipx_cli_exit(["run", "pycowsay", "cowsay", "args"])
+
+    assert not expired_venv.exists()
+    assert tag_path.exists()
+    assert f"Removing expired venv {tag_path}" not in caplog.text
 
 
 @mock.patch("os.execvpe", new=execvpe_mock)


### PR DESCRIPTION
The expired `pipx run` environment sweep checks every cache entry, including `CACHEDIR.TAG`. Once the tag is older than 14 days, each run logs it as an expired environment although `rmdir` ignores files ([#1856](https://github.com/pypa/pipx/issues/1856)).

Filter sweep candidates to directories. The regression advances the clock past the expiration threshold, confirms cleanup removes an expired directory, and keeps the tag without the false removal log.
