### PR TITLE
🐛 fix(animate): join spinner thread

### DIFF
--- a/changelog.d/1856.bugfix.19.md
+++ b/changelog.d/1856.bugfix.19.md
@@ -1,0 +1,1 @@
+Wait for the animation thread to stop before clearing its final frame.

--- a/src/pipx/animate.py
+++ b/src/pipx/animate.py
@@ -1,23 +1,22 @@
 import logging
 import shutil
 import sys
-from collections.abc import Generator
+from collections.abc import Generator, Sequence
 from contextlib import contextmanager
 from threading import Event, Thread
+from typing import Final
 
 from pipx.constants import WINDOWS
 from pipx.emojis import EMOJI_SUPPORT
 
-logger = logging.getLogger(__name__)
+STDERR_IS_TTY: Final[bool] = bool(sys.stderr and sys.stderr.isatty())
 
-stderr_is_tty = bool(sys.stderr and sys.stderr.isatty())
-
-CLEAR_LINE = "\033[K"
-EMOJI_ANIMATION_FRAMES = ["⣷", "⣯", "⣟", "⡿", "⢿", "⣻", "⣽", "⣾"]
-NONEMOJI_ANIMATION_FRAMES = ["", ".", "..", "..."]
-EMOJI_FRAME_PERIOD = 0.1
-NONEMOJI_FRAME_PERIOD = 1
-MINIMUM_COLS_ALLOW_ANIMATION = 16
+CLEAR_LINE: Final[str] = "\033[K"
+EMOJI_ANIMATION_FRAMES: Final[tuple[str, ...]] = ("⣷", "⣯", "⣟", "⡿", "⢿", "⣻", "⣽", "⣾")
+NONEMOJI_ANIMATION_FRAMES: Final[tuple[str, ...]] = ("", ".", "..", "...")
+EMOJI_FRAME_PERIOD: Final[float] = 0.1
+NONEMOJI_FRAME_PERIOD: Final[float] = 1
+MINIMUM_COLS_ALLOW_ANIMATION: Final[int] = 16
 
 
 if WINDOWS:
@@ -29,7 +28,7 @@ if WINDOWS:
 
 def _env_supports_animation() -> bool:
     (term_cols, _) = shutil.get_terminal_size(fallback=(0, 0))
-    return stderr_is_tty and term_cols > MINIMUM_COLS_ALLOW_ANIMATION
+    return STDERR_IS_TTY and term_cols > MINIMUM_COLS_ALLOW_ANIMATION
 
 
 @contextmanager
@@ -56,22 +55,24 @@ def animate(message: str, do_animation: bool, *, delay: float = 0) -> Generator[
         symbols = NONEMOJI_ANIMATION_FRAMES
         period = NONEMOJI_FRAME_PERIOD
 
-    thread_kwargs = {
-        "message": message,
-        "event": event,
-        "symbols": symbols,
-        "delay": delay,
-        "period": period,
-        "animate_at_beginning_of_line": animate_at_beginning_of_line,
-    }
-
-    t = Thread(target=print_animation, kwargs=thread_kwargs)
-    t.start()
+    thread = Thread(
+        target=print_animation,
+        kwargs={
+            "message": message,
+            "event": event,
+            "symbols": symbols,
+            "delay": delay,
+            "period": period,
+            "animate_at_beginning_of_line": animate_at_beginning_of_line,
+        },
+    )
+    thread.start()
 
     try:
         yield
     finally:
         event.set()
+        thread.join()
         clear_line()
 
 
@@ -79,7 +80,7 @@ def print_animation(
     *,
     message: str,
     event: Event,
-    symbols: list[str],
+    symbols: Sequence[str],
     delay: float,
     period: float,
     animate_at_beginning_of_line: bool,
@@ -87,18 +88,18 @@ def print_animation(
     (term_cols, _) = shutil.get_terminal_size(fallback=(9999, 24))
     event.wait(delay)
     while not event.wait(0):
-        for s in symbols:
+        for symbol in symbols:
             if animate_at_beginning_of_line:
-                max_message_len = term_cols - len(f"{s} ... ")
-                cur_line = f"{s} {message:.{max_message_len}}"
+                max_message_len = term_cols - len(f"{symbol} ... ")
+                current_line = f"{symbol} {message:.{max_message_len}}"
                 if len(message) > max_message_len:
-                    cur_line += "..."
+                    current_line += "..."
             else:
                 max_message_len = term_cols - len("... ")
-                cur_line = f"{message:.{max_message_len}}{s}"
+                current_line = f"{message:.{max_message_len}}{symbol}"
 
             clear_line()
-            sys.stderr.write(cur_line)
+            sys.stderr.write(current_line)
             sys.stderr.flush()
             if event.wait(period):
                 break
@@ -117,7 +118,7 @@ def win_cursor(visible: bool) -> None:
 
 
 def hide_cursor() -> None:
-    if stderr_is_tty:
+    if STDERR_IS_TTY:
         if WINDOWS:
             win_cursor(visible=False)
         else:
@@ -126,7 +127,7 @@ def hide_cursor() -> None:
 
 
 def show_cursor() -> None:
-    if stderr_is_tty:
+    if STDERR_IS_TTY:
         if WINDOWS:
             win_cursor(visible=True)
         else:
@@ -135,6 +136,17 @@ def show_cursor() -> None:
 
 
 def clear_line() -> None:
-    """Clears current line and positions cursor at start of line"""
     sys.stderr.write(f"\r{CLEAR_LINE}")
     sys.stdout.write(f"\r{CLEAR_LINE}")
+
+
+__all__ = [
+    "CLEAR_LINE",
+    "EMOJI_ANIMATION_FRAMES",
+    "EMOJI_FRAME_PERIOD",
+    "NONEMOJI_ANIMATION_FRAMES",
+    "NONEMOJI_FRAME_PERIOD",
+    "animate",
+    "hide_cursor",
+    "show_cursor",
+]

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -1,86 +1,105 @@
+import threading
 import time
+from collections.abc import Callable
 from timeit import default_timer
+from typing import Final
 
 import pytest
+from pytest_mock import MockerFixture
 
 import pipx.animate
 from pipx.animate import (
     CLEAR_LINE,
     EMOJI_ANIMATION_FRAMES,
-    EMOJI_FRAME_PERIOD,
     NONEMOJI_ANIMATION_FRAMES,
-    NONEMOJI_FRAME_PERIOD,
+    hide_cursor,
+    show_cursor,
 )
 
-# 40-char test_string counts columns e.g.: "0204060810 ... 363840"
-TEST_STRING_40_CHAR = "".join([f"{x:02}" for x in range(2, 41, 2)])
+TEST_STRING_40_CHAR: Final[str] = "".join(f"{number:02}" for number in range(2, 41, 2))
 
 
 def check_animate_output(
-    capsys,
-    test_string,
-    frame_strings,
-    frame_period,
-    frames_to_test,
-    extra_animate_time=0.4,
-    extra_after_thread_time=0.1,
-):
-    """
-    Refactored to use polling instead of rigid sleeps.
-    """
+    capsys: pytest.CaptureFixture[str],
+    test_string: str,
+    frame_strings: list[str],
+    frames_to_test: int,
+) -> None:
     expected_string = "".join(frame_strings)
-
-    # FIX: Calculate exact length required. Removed the "+ 1" that caused flakes.
     chars_to_test = len("".join(frame_strings[:frames_to_test]))
-
     total_err = ""
-    # Generous timeout for slow CI environments (e.g. Windows/Mac runners)
-    timeout = 5.0
-    start_time = default_timer()
+    deadline = default_timer() + 5
 
     with pipx.animate.animate(test_string, do_animation=True):
-        # POLLING LOOP: Keep reading until we get the expected data
-        while default_timer() - start_time < timeout:
-            captured = capsys.readouterr()
-            total_err += captured.err
-
-            # If we have enough data, stop waiting immediately
-            if len(total_err) >= chars_to_test:
-                break
-
-            # Tiny sleep to avoid 100% CPU usage loop
+        while default_timer() < deadline and len(total_err) < chars_to_test:
+            total_err += capsys.readouterr().err
             time.sleep(0.01)
 
-    # Capture any final output after loop or context manager exit
-    captured = capsys.readouterr()
-    total_err += captured.err
-
-    print("check_animate_output() Test Debug Output:")
-    if len(total_err) < chars_to_test:
-        print("Not enough captured characters--Timed out waiting for output")
-
-    print(f"captured characters: {len(total_err)}")
-    print(f"chars_to_test: {chars_to_test}")
-
-    for i in range(0, chars_to_test, 40):
-        i_end = min(i + 40, chars_to_test)
-        print(f"expected_string[{i}:{i_end}]: {expected_string[i:i_end]!r}")
-        print(f"captured.err[{i}:{i_end}]    : {total_err[i:i_end]!r}")
-
+    total_err += capsys.readouterr().err
     assert total_err[:chars_to_test] == expected_string[:chars_to_test]
 
 
-def test_delay_suppresses_output(capsys, monkeypatch):
-    monkeypatch.setattr(pipx.animate, "stderr_is_tty", True)
+def test_delay_suppresses_output(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pipx.animate, "STDERR_IS_TTY", True)
     monkeypatch.setenv("COLUMNS", "80")
 
     test_string = "asdf"
 
-    # We keep sleep here because we are testing the ABSENCE of output during a delay.
+    # The delay boundary requires elapsed time before checking for an early frame.
     with pipx.animate.animate(test_string, do_animation=True, delay=0.9):
         time.sleep(0.5)
     captured = capsys.readouterr()
     assert test_string not in captured.err
+
+
+@pytest.mark.parametrize(
+    "cursor_control,escape_sequence",
+    [(hide_cursor, "\033[?25l"), (show_cursor, "\033[?25h")],
+    ids=["hide", "show"],
+)
+def test_cursor_control_uses_ansi(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    cursor_control: Callable[[], None],
+    escape_sequence: str,
+) -> None:
+    monkeypatch.setattr(pipx.animate, "STDERR_IS_TTY", True)
+    monkeypatch.setattr(pipx.animate, "WINDOWS", False)
+
+    cursor_control()
+
+    assert capsys.readouterr().err == escape_sequence
+
+
+def test_animate_clears_after_thread_stops(monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture) -> None:
+    animation_clear_started = threading.Event()
+    main_clear_started = threading.Event()
+    writes: list[str] = []
+    clear = f"\r{CLEAR_LINE}"
+
+    def record_write(text: str) -> int:
+        if text == clear:
+            if threading.current_thread() is threading.main_thread():
+                main_clear_started.set()
+            else:
+                animation_clear_started.set()
+                main_clear_started.wait(timeout=1)
+        writes.append(text)
+        return len(text)
+
+    stderr = mocker.MagicMock(write=mocker.Mock(side_effect=record_write))
+    mocker.patch.object(pipx.animate.sys, "stderr", stderr)
+    monkeypatch.setattr(pipx.animate, "STDERR_IS_TTY", True)
+    monkeypatch.setattr(pipx.animate, "EMOJI_SUPPORT", True)
+    monkeypatch.setenv("COLUMNS", "80")
+
+    with pipx.animate.animate("message", do_animation=True):
+        assert animation_clear_started.wait(timeout=1)
+
+    assert writes[-1] == clear
 
 
 @pytest.mark.parametrize(
@@ -90,16 +109,22 @@ def test_delay_suppresses_output(capsys, monkeypatch):
         (46, f"{TEST_STRING_40_CHAR}"),
         (47, f"{TEST_STRING_40_CHAR}"),
     ],
+    ids=["truncated", "exact", "spare-column"],
 )
-def test_line_lengths_emoji(capsys, monkeypatch, env_columns, expected_frame_message):
-    monkeypatch.setattr(pipx.animate, "stderr_is_tty", True)
+def test_line_lengths_emoji(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    env_columns: int,
+    expected_frame_message: str,
+) -> None:
+    monkeypatch.setattr(pipx.animate, "STDERR_IS_TTY", True)
     monkeypatch.setattr(pipx.animate, "EMOJI_SUPPORT", True)
 
     monkeypatch.setenv("COLUMNS", str(env_columns))
 
     frames_to_test = 4
     frame_strings = [f"\r{CLEAR_LINE}{x} {expected_frame_message}" for x in EMOJI_ANIMATION_FRAMES]
-    check_animate_output(capsys, TEST_STRING_40_CHAR, frame_strings, EMOJI_FRAME_PERIOD, frames_to_test)
+    check_animate_output(capsys, TEST_STRING_40_CHAR, frame_strings, frames_to_test)
 
 
 @pytest.mark.parametrize(
@@ -109,9 +134,15 @@ def test_line_lengths_emoji(capsys, monkeypatch, env_columns, expected_frame_mes
         (44, f"{TEST_STRING_40_CHAR}"),
         (45, f"{TEST_STRING_40_CHAR}"),
     ],
+    ids=["truncated", "exact", "spare-column"],
 )
-def test_line_lengths_no_emoji(capsys, monkeypatch, env_columns, expected_frame_message):
-    monkeypatch.setattr(pipx.animate, "stderr_is_tty", True)
+def test_line_lengths_no_emoji(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    env_columns: int,
+    expected_frame_message: str,
+) -> None:
+    monkeypatch.setattr(pipx.animate, "STDERR_IS_TTY", True)
     monkeypatch.setattr(pipx.animate, "EMOJI_SUPPORT", False)
 
     monkeypatch.setenv("COLUMNS", str(env_columns))
@@ -123,22 +154,28 @@ def test_line_lengths_no_emoji(capsys, monkeypatch, env_columns, expected_frame_
         capsys,
         TEST_STRING_40_CHAR,
         frame_strings,
-        NONEMOJI_FRAME_PERIOD,
         frames_to_test,
     )
 
 
-@pytest.mark.parametrize("env_columns,stderr_is_tty", [(0, True), (8, True), (16, True), (17, False)])
-def test_env_no_animate(capsys, monkeypatch, env_columns, stderr_is_tty):
-    monkeypatch.setattr(pipx.animate, "stderr_is_tty", stderr_is_tty)
+@pytest.mark.parametrize(
+    "env_columns,supports_tty",
+    [(0, True), (8, True), (16, True), (17, False)],
+    ids=["zero-columns", "narrow-terminal", "threshold", "not-tty"],
+)
+def test_env_no_animate(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    env_columns: int,
+    supports_tty: bool,
+) -> None:
+    monkeypatch.setattr(pipx.animate, "STDERR_IS_TTY", supports_tty)
     monkeypatch.setenv("COLUMNS", str(env_columns))
 
     expected_string = f"{TEST_STRING_40_CHAR}...\n"
 
-    # Replaced complex sleep math with a simple short wait.
-    # We just need the context manager to run and exit to verify the static output.
     with pipx.animate.animate(TEST_STRING_40_CHAR, do_animation=True):
-        time.sleep(0.1)
+        pass
 
     captured = capsys.readouterr()
 


### PR DESCRIPTION
`animate` signals its stop event and clears the line without waiting for the spinner thread. A frame already in progress can write after the context exits and replace the clear ([#1856](https://github.com/pypa/pipx/issues/1856)).

Join the thread before the final clear. The regression blocks a frame in progress and proves the clear remains the final stderr write. The same-module simp pass types immutable values and tests, exports public names from EOF, removes unused state, and tightens the polling helper.
