### PR TITLE
🐛 fix(paths): defer path warnings

### DIFF
--- a/changelog.d/1856.bugfix.20.md
+++ b/changelog.d/1856.bugfix.20.md
@@ -1,0 +1,1 @@
+Emit path warnings after logging setup for the active local or global context.

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -1348,6 +1348,7 @@ def setup(args: argparse.Namespace) -> None:
     verbose = getattr(args, "verbose", 0) - getattr(args, "quiet", 0)
 
     setup_logging(verbose)
+    paths.ctx.log_warnings()
 
     logger.debug(f"{time.strftime('%Y-%m-%d %H:%M:%S')}")
     logger.debug(f"{' '.join(sys.argv)}")

--- a/src/pipx/paths.py
+++ b/src/pipx/paths.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from pathlib import Path
+from typing import Final
 
 from platformdirs import user_cache_path, user_data_path, user_log_path
 
@@ -19,11 +20,11 @@ else:
     DEFAULT_PIPX_HOME = Path.home() / ".local/pipx"
     FALLBACK_PIPX_HOMES = [Path(user_data_path("pipx"))]
 
-DEFAULT_PIPX_BIN_DIR = Path.home() / ".local/bin"
-DEFAULT_PIPX_MAN_DIR = Path.home() / ".local/share/man"
-DEFAULT_PIPX_GLOBAL_HOME = Path("/opt/pipx")
-DEFAULT_PIPX_GLOBAL_BIN_DIR = Path("/usr/local/bin")
-DEFAULT_PIPX_GLOBAL_MAN_DIR = Path("/usr/local/share/man")
+DEFAULT_PIPX_BIN_DIR: Final[Path] = Path.home() / ".local/bin"
+DEFAULT_PIPX_MAN_DIR: Final[Path] = Path.home() / ".local/share/man"
+DEFAULT_PIPX_GLOBAL_HOME: Final[Path] = Path("/opt/pipx")
+DEFAULT_PIPX_GLOBAL_BIN_DIR: Final[Path] = Path("/usr/local/bin")
+DEFAULT_PIPX_GLOBAL_MAN_DIR: Final[Path] = Path("/usr/local/share/man")
 
 # Overrides for testing
 OVERRIDE_PIPX_HOME = None
@@ -34,7 +35,7 @@ OVERRIDE_PIPX_GLOBAL_HOME = None
 OVERRIDE_PIPX_GLOBAL_BIN_DIR = None
 OVERRIDE_PIPX_GLOBAL_MAN_DIR = None
 
-logger = logging.getLogger(__name__)
+_LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
 
 def get_expanded_environ(env_name: str) -> Path | None:
@@ -57,7 +58,7 @@ class _PathContext:
     _home_exists: bool
     log_file: Path | None = None
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.make_local()
 
     @property
@@ -93,7 +94,7 @@ class _PathContext:
     @property
     def home(self) -> Path:
         if self._base_home:
-            home = Path(self._base_home)
+            home = self._base_home
         elif self._fallback_home:
             home = self._fallback_home
         else:
@@ -115,7 +116,7 @@ class _PathContext:
         self._default_log = Path(user_log_path("pipx"))
         self._default_cache = Path(user_cache_path("pipx"))
         self._default_trash = self._default_home / "trash"
-        self._fallback_home = next(iter([fallback for fallback in FALLBACK_PIPX_HOMES if fallback.exists()]), None)
+        self._fallback_home = next((fallback for fallback in FALLBACK_PIPX_HOMES if fallback.exists()), None)
         self._home_exists = self._base_home is not None or any(fallback.exists() for fallback in FALLBACK_PIPX_HOMES)
 
     def make_global(self) -> None:
@@ -140,9 +141,9 @@ class _PathContext:
     def allow_spaces_in_home_path(self) -> bool:
         return strtobool(os.getenv("PIPX_HOME_ALLOW_SPACE", "0"))
 
-    def log_warnings(self):
+    def log_warnings(self) -> None:
         if " " in str(self.home) and not self.allow_spaces_in_home_path:
-            logger.warning(
+            _LOGGER.warning(
                 pipx_wrap(
                     (
                         f"{hazard} Found a space in the pipx home path. We heavily discourage this, due to "
@@ -152,13 +153,13 @@ class _PathContext:
                     subsequent_indent=" " * 4,
                 )
             )
-            logger.warning(
+            _LOGGER.warning(
                 pipx_wrap(
                     (f"{hazard} To see your PIPX_HOME dir: pipx environment --value PIPX_HOME"),
                     subsequent_indent=" " * 4,
                 )
             )
-            logger.warning(
+            _LOGGER.warning(
                 pipx_wrap(
                     (f"{hazard} Most likely fix on macOS: mv ~/Library/Application\\ Support/pipx ~/.local/"),
                     subsequent_indent=" " * 4,
@@ -168,7 +169,7 @@ class _PathContext:
         fallback_home_exists = self._fallback_home is not None and self._fallback_home.exists()
         specific_home_exists = self.home != self._fallback_home
         if fallback_home_exists and specific_home_exists:
-            logger.info(
+            _LOGGER.info(
                 pipx_wrap(
                     (
                         f"Both a specific pipx home folder ({self.home}) and the fallback "
@@ -181,7 +182,6 @@ class _PathContext:
 
 
 ctx = _PathContext()
-ctx.log_warnings()
 
 
 __all__ = [

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -99,26 +99,65 @@ def test_resolve_empty_env_paths(monkeypatch: pytest.MonkeyPatch, env_name: str)
 
 
 def test_allow_space_in_pipx_home(
-    monkeypatch,
-    capsys,
-    tmp_path,
-):
-    home_dir = Path(tmp_path) / "path with space"
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    home_dir = tmp_path / "path with space"
     monkeypatch.setattr(paths.ctx, "_base_home", home_dir)
     assert not run_pipx_cli(["environment", "--value", "PIPX_HOME_ALLOW_SPACE"])
-    paths.ctx.log_warnings()
     captured = capsys.readouterr()
     assert "Found a space" in captured.err
     assert "false" in captured.out
 
     monkeypatch.setenv("PIPX_HOME_ALLOW_SPACE", "1")
     assert not run_pipx_cli(["environment", "--value", "PIPX_HOME_ALLOW_SPACE"])
-    paths.ctx.log_warnings()
     captured = capsys.readouterr()
     assert "Found a space" not in captured.err
     assert "true" in captured.out
 
     paths.ctx.make_local()
+
+
+def test_cli_space_warning_respects_quiet(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(paths.ctx, "_base_home", tmp_path / "path with space")
+
+    assert not run_pipx_cli(["environment", "--value", "PIPX_HOME_ALLOW_SPACE", "--quiet"])
+
+    assert "Found a space" not in capsys.readouterr().err
+
+
+def test_cli_logs_fallback_home(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    fallback_home = tmp_path / "fallback"
+    fallback_home.mkdir()
+    monkeypatch.setattr(paths.ctx, "_base_home", tmp_path / "specific")
+    monkeypatch.setattr(paths.ctx, "_fallback_home", fallback_home)
+
+    assert not run_pipx_cli(["environment", "--verbose"])
+
+    assert "Both a specific pipx home folder" in capsys.readouterr().err
+
+
+@skip_if_windows
+def test_cli_global_warns_for_active_home(
+    pipx_temp_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(paths, "OVERRIDE_PIPX_GLOBAL_HOME", tmp_path / "global home")
+
+    assert not run_pipx_cli(["environment", "--global"])
+
+    assert "Found a space" in capsys.readouterr().err
 
 
 @skip_if_windows


### PR DESCRIPTION
`paths` emits its warnings during module import, before logging setup and before `setup` selects the `--global` context. Active local paths set after import receive no warning, global commands evaluate the local path, and quiet mode cannot control an import-time message ([#1856](https://github.com/pypa/pipx/issues/1856)).

Log warnings after context selection and logging setup. The regressions cover active local and global homes, quiet-mode suppression, and the fallback-home migration notice. The same-module simp pass types constants and methods, removes a redundant `Path` conversion, and avoids an intermediate fallback list.
