### PR TITLE
🐛 fix(shared): enforce pip floor

### DIFF
--- a/changelog.d/1856.bugfix.21.md
+++ b/changelog.d/1856.bugfix.21.md
@@ -1,0 +1,1 @@
+Enforce pip's minimum supported version when shared-library upgrades include a user pin.

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -3,12 +3,8 @@ import logging
 import os
 import time
 from configparser import ConfigParser
-from contextlib import suppress
 from pathlib import Path
 from typing import Final
-
-from packaging.requirements import InvalidRequirement, Requirement
-from packaging.specifiers import SpecifierSet
 
 from pipx import paths
 from pipx.animate import animate
@@ -171,19 +167,6 @@ class _SharedLibs:
         if not verbose:
             filtered_pip_args.append("-q")
 
-        user_pip_requirement = None
-        for arg in filtered_pip_args:
-            with suppress(InvalidRequirement):
-                if (requirement := Requirement(arg)).name == "pip":
-                    user_pip_requirement = requirement
-                    break
-
-        install_args = (
-            [*filtered_pip_args, "pip >= 23.1"]
-            if not user_pip_requirement or not (user_pip_requirement.specifier & SpecifierSet(">=23.1"))
-            else filtered_pip_args
-        )
-
         try:
             with animate("upgrading shared libraries", not verbose):
                 upgrade_process = run_subprocess(
@@ -195,7 +178,8 @@ class _SharedLibs:
                         "--disable-pip-version-check",
                         "install",
                         "--upgrade",
-                        *install_args,
+                        *filtered_pip_args,
+                        "pip >= 23.1",
                     ]
                 )
             subprocess_post_check(upgrade_process)

--- a/tests/test_shared_libs.py
+++ b/tests/test_shared_libs.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from pytest_mock import MockerFixture
 
 from pipx import shared_libs
 from pipx.constants import PIPX_SHARED_PTH, WINDOWS
@@ -87,6 +88,27 @@ def test_shared_libs_create_preserves_pip_args(pipx_ultra_temp_env: None) -> Non
     pip_args = ["--disable-pip-version-check"]
     shared_libs.shared_libs.create(pip_args=pip_args)
     assert (pip_args, shared_libs.shared_libs.is_valid) == (["--disable-pip-version-check"], True)
+
+
+def test_shared_libs_upgrade_enforces_pip_floor(
+    pipx_ultra_temp_env: None,
+    mocker: MockerFixture,
+) -> None:
+    shared_libs.shared_libs.create(verbose=True, pip_args=[])
+    shared_libs.shared_libs.has_been_updated_this_run = False
+    run_subprocess = mocker.patch(
+        "pipx.shared_libs.run_subprocess",
+        side_effect=[
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="ModuleSpec", stderr=""),
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+        ],
+    )
+
+    shared_libs.shared_libs.upgrade(pip_args=["pip==20"], verbose=True, raises=True)
+
+    install_command = run_subprocess.call_args_list[1].args[0]
+    assert "pip==20" in install_command
+    assert "pip >= 23.1" in install_command
 
 
 def test_venv_python_is_valid_non_windows() -> None:


### PR DESCRIPTION
`_SharedLibs.upgrade` uses the truthiness of a specifier intersection to decide whether a user pip requirement enforces `>=23.1`. The intersection of `pip==20` and `>=23.1` retains both specifiers and remains truthy, so the command omits the floor ([#1856](https://github.com/pypa/pipx/issues/1856)).

Append the floor to every shared pip upgrade. Pip intersects compatible user pins and reports a conflict for incompatible pins instead of installing an unsupported version. The regression creates a real shared environment, captures the subprocess boundary, and verifies that the command includes both the user pin and floor.
