### PR TITLE
🐛 fix(standalone): filter tar extraction

### DIFF
--- a/changelog.d/1856.bugfix.23.md
+++ b/changelog.d/1856.bugfix.23.md
@@ -1,0 +1,1 @@
+Use tar's data filter when extracting standalone Python archives for consistent safety.

--- a/src/pipx/standalone_python.py
+++ b/src/pipx/standalone_python.py
@@ -121,8 +121,11 @@ def _unpack(full_version, download_link, archive: Path, download_dir: Path, expe
                 f"Checksum mismatch for python {full_version} build. Expected {expected_checksum}, got {checksum}."
             )
 
-        with tarfile.open(archive, mode="r:gz") as tar:
-            tar.extractall(download_dir)
+        try:
+            with tarfile.open(archive, mode="r:gz") as tar:
+                tar.extractall(download_dir, filter="data")
+        except tarfile.TarError as error:
+            raise PipxError(f"Unable to unpack python {full_version} build.") from error
 
 
 def _is_valid_python_index(index: Any) -> bool:
@@ -228,3 +231,12 @@ def resolve_python_version(requested_version: str):
             return full_version, download_link
 
     raise PipxError(f"Unable to acquire a standalone python build matching {requested_version}.")
+
+
+__all__ = [
+    "download_python_build_standalone",
+    "get_latest_python_releases",
+    "get_or_update_index",
+    "list_pythons",
+    "resolve_python_version",
+]

--- a/tests/test_standalone_interpreter.py
+++ b/tests/test_standalone_interpreter.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 import datetime
+import hashlib
+import io
 import json
 import shutil
 import subprocess
 import sys
+import tarfile
+import warnings
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
@@ -54,6 +59,48 @@ def test_legacy_standalone_python_index_is_refreshed(pipx_temp_env, monkeypatch)
 
     assert standalone_python.get_or_update_index()["releases"] == current_releases
     assert json.loads(index_file.read_text())["releases"] == [[legacy_link, digest]]
+
+
+def test_download_standalone_python_sets_tar_filter(
+    pipx_temp_env: None,
+    mocked_github_api: None,
+) -> None:
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
+        python_path = standalone_python.download_python_build_standalone(TARGET_PYTHON_VERSION)
+
+    assert Path(python_path).is_file()
+    assert not [warning for warning in caught_warnings if "filter extracted tar archives" in str(warning.message)]
+
+
+def test_download_standalone_python_rejects_unsafe_archive(
+    pipx_temp_env: None,
+    mocker: MockerFixture,
+) -> None:
+    archive = io.BytesIO()
+    with tarfile.open(fileobj=archive, mode="w:gz") as python_tar:
+        for name, content in (("python/bin/python3", b""), ("../outside", b"unsafe")):
+            member = tarfile.TarInfo(name)
+            member.size = len(content)
+            python_tar.addfile(member, io.BytesIO(content))
+    archive_bytes = archive.getvalue()
+    link = "https://example.invalid/cpython-3.99.0-aarch64-apple-darwin-install_only.tar.gz"
+    cache_dir = standalone_python.paths.ctx.standalone_python_cachedir
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "index.json").write_text(
+        json.dumps(
+            {
+                "fetched": datetime.datetime.now().timestamp(),
+                "releases": [[link, f"sha256:{hashlib.sha256(archive_bytes).hexdigest()}"]],
+            }
+        )
+    )
+    mocker.patch.object(standalone_python.platform, "system", return_value="Darwin")
+    mocker.patch.object(standalone_python.platform, "machine", return_value="arm64")
+    mocker.patch.object(standalone_python, "urlopen", return_value=io.BytesIO(archive_bytes))
+
+    with pytest.raises(standalone_python.PipxError, match="Unable to unpack"):
+        standalone_python.download_python_build_standalone("3.99")
 
 
 def test_list_no_standalone_interpreters(pipx_temp_env, monkeypatch, capsys):


### PR DESCRIPTION
`_unpack` calls `tar.extractall` without selecting a filter. Python 3.13 warns that 3.14 will change the default, leaving behavior dependent on the runtime ([#1856](https://github.com/pypa/pipx/issues/1856)). Selecting the safe filter also exposes raw `tarfile` exceptions for rejected archives.

Extract with the data filter and convert `tarfile` failures to `PipxError`. One public regression downloads and extracts a real standalone build without the deprecation warning; another supplies a path-traversal archive and verifies a normal pipx error. Public module exports remain at EOF with a trailing comma.

Compatibility follow-up [#1888](https://github.com/pypa/pipx/pull/1888) feature-detects the filter API because Python added it in 3.10.12.
