### PR TITLE
🐛 fix(standalone): support early Python 3.10

### DIFF
--- a/changelog.d/1856.bugfix.24.md
+++ b/changelog.d/1856.bugfix.24.md
@@ -1,0 +1,1 @@
+Preserve standalone archive extraction on Python 3.10 releases without the tar filter API.

--- a/src/pipx/standalone_python.py
+++ b/src/pipx/standalone_python.py
@@ -123,7 +123,10 @@ def _unpack(full_version, download_link, archive: Path, download_dir: Path, expe
 
         try:
             with tarfile.open(archive, mode="r:gz") as tar:
-                tar.extractall(download_dir, filter="data")
+                if hasattr(tarfile, "data_filter"):
+                    tar.extractall(download_dir, filter="data")
+                else:
+                    tar.extractall(download_dir)
         except tarfile.TarError as error:
             raise PipxError(f"Unable to unpack python {full_version} build.") from error
 

--- a/tests/test_standalone_interpreter.py
+++ b/tests/test_standalone_interpreter.py
@@ -21,6 +21,8 @@ from package_info import PKG
 from pipx import standalone_python
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from pytest_mock import MockerFixture
 
 MAJOR_PYTHON_VERSION = sys.version_info.major
@@ -71,6 +73,33 @@ def test_download_standalone_python_sets_tar_filter(
 
     assert Path(python_path).is_file()
     assert not [warning for warning in caught_warnings if "filter extracted tar archives" in str(warning.message)]
+
+
+def test_download_standalone_python_supports_early_python_310(
+    pipx_temp_env: None,
+    mocked_github_api: None,
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+) -> None:
+    original_extractall = tarfile.TarFile.extractall
+
+    def legacy_extractall(
+        archive: tarfile.TarFile,
+        path: str | Path = ".",
+        members: Iterable[tarfile.TarInfo] | None = None,
+        *,
+        numeric_owner: bool = False,
+    ) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            original_extractall(archive, path, members, numeric_owner=numeric_owner)
+
+    monkeypatch.delattr(tarfile, "data_filter")
+    mocker.patch.object(tarfile.TarFile, "extractall", legacy_extractall)
+
+    python_path = standalone_python.download_python_build_standalone(TARGET_PYTHON_VERSION)
+
+    assert Path(python_path).is_file()
 
 
 def test_download_standalone_python_rejects_unsafe_archive(


### PR DESCRIPTION
Python added `TarFile.extractall(filter=...)` in 3.10.12, but pipx supports Python 3.10.0 and later. [#1887](https://github.com/pypa/pipx/pull/1887) passed `filter="data"` on every supported runtime, so Python 3.10.0 through 3.10.11 raise `TypeError` during standalone interpreter extraction ([Python 3.10 tarfile documentation](https://docs.python.org/3.10/library/tarfile.html)).

Feature-detect `tarfile.data_filter` as the Python documentation recommends. Use the data filter when present and the legacy extraction signature on earlier 3.10 patch releases. The regression removes `data_filter`, substitutes the old `extractall` signature, and verifies a real standalone interpreter extraction in tox's Python 3.10 environment.
