### PR TITLE
🐛 fix(standalone): bound network requests

### DIFF
--- a/changelog.d/1856.bugfix.25.md
+++ b/changelog.d/1856.bugfix.25.md
@@ -1,0 +1,1 @@
+Apply a 30-second timeout to standalone Python index and archive network requests.

--- a/src/pipx/standalone_python.py
+++ b/src/pipx/standalone_python.py
@@ -45,6 +45,7 @@ MACHINE_SUFFIX: Final[dict[str, dict[str, Any]]] = {
 
 GITHUB_API_URL: Final[str] = "https://api.github.com/repos/astral-sh/python-build-standalone/releases/latest"
 PYTHON_VERSION_REGEX: Final[re.Pattern[str]] = re.compile(r"cpython-(\d+\.\d+\.\d+)")
+_URL_OPEN_TIMEOUT: Final[float] = 30
 
 
 def download_python_build_standalone(python_version: str, override: bool = False):
@@ -97,7 +98,7 @@ def _download(full_version: str, download_link: str, archive: Path):
         try:
             # python standalone builds are typically ~32MB in size. to avoid
             # ballooning memory usage, we read the file in chunks
-            with urlopen(download_link) as response, open(archive, "wb") as file_handle:
+            with urlopen(download_link, timeout=_URL_OPEN_TIMEOUT) as response, open(archive, "wb") as file_handle:
                 for data in iter(partial(response.read, 32768), b""):
                     file_handle.write(data)
         except urllib.error.URLError as e:
@@ -172,7 +173,7 @@ def get_or_update_index(use_cache: bool = True):
 def get_latest_python_releases() -> list[tuple[str, str]]:
     """Returns the list of python download links from the latest github release."""
     try:
-        with urlopen(GITHUB_API_URL) as response:
+        with urlopen(GITHUB_API_URL, timeout=_URL_OPEN_TIMEOUT) as response:
             release_data = json.load(response)
 
     except urllib.error.URLError as e:

--- a/tests/test_standalone_interpreter.py
+++ b/tests/test_standalone_interpreter.py
@@ -102,6 +102,47 @@ def test_download_standalone_python_supports_early_python_310(
     assert Path(python_path).is_file()
 
 
+def test_get_latest_python_releases_sets_request_timeout(mocker: MockerFixture) -> None:
+    urlopen = mocker.patch.object(
+        standalone_python,
+        "urlopen",
+        return_value=io.StringIO(json.dumps({"assets": []})),
+    )
+
+    assert standalone_python.get_latest_python_releases() == []
+    urlopen.assert_called_once_with(standalone_python.GITHUB_API_URL, timeout=30)
+
+
+def test_download_standalone_python_sets_request_timeout(
+    pipx_temp_env: None,
+    mocker: MockerFixture,
+) -> None:
+    archive = io.BytesIO()
+    with tarfile.open(fileobj=archive, mode="w:gz") as python_tar:
+        for name in ("python/bin/python3", "python/python.exe"):
+            python_tar.addfile(tarfile.TarInfo(name), io.BytesIO())
+    archive_bytes = archive.getvalue()
+    link = "https://example.invalid/cpython-3.99.0-aarch64-apple-darwin-install_only.tar.gz"
+    cache_dir = standalone_python.paths.ctx.standalone_python_cachedir
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "index.json").write_text(
+        json.dumps(
+            {
+                "fetched": datetime.datetime.now().timestamp(),
+                "releases": [[link, f"sha256:{hashlib.sha256(archive_bytes).hexdigest()}"]],
+            }
+        )
+    )
+    mocker.patch.object(standalone_python.platform, "system", return_value="Darwin")
+    mocker.patch.object(standalone_python.platform, "machine", return_value="arm64")
+    urlopen = mocker.patch.object(standalone_python, "urlopen", return_value=io.BytesIO(archive_bytes))
+
+    python_path = standalone_python.download_python_build_standalone("3.99")
+
+    assert Path(python_path).is_file()
+    urlopen.assert_called_once_with(link, timeout=30)
+
+
 def test_download_standalone_python_rejects_unsafe_archive(
     pipx_temp_env: None,
     mocker: MockerFixture,


### PR DESCRIPTION
Standalone Python release-index lookup and archive download call `urlopen` without a timeout. A stalled GitHub request can leave interpreter resolution blocked ([#1856](https://github.com/pypa/pipx/issues/1856)).

Apply a shared 30-second timeout to both requests. The regressions mock the network boundary while checking parsed release data and the extracted executable. Public module exports remain at EOF with a trailing comma.
