### PR TITLE
🐛 fix(install): skip no-op maintenance

### DIFF
--- a/changelog.d/1856.bugfix.26.md
+++ b/changelog.d/1856.bugfix.26.md
@@ -1,0 +1,1 @@
+Skip shared-library maintenance for no-op installs.

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -85,7 +85,6 @@ def install(
             backend=install_backend,
             env_backend=install_env_backend,
         )
-        venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
         if exists:
             if not reinstall and force and python_flag_passed:
                 print(
@@ -118,6 +117,7 @@ def install(
                 venv_dir = None
                 continue
 
+        venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
         try:
             override_shared = canonicalize_name(package_name) == "pip"
             venv.create_venv(venv_args, pip_args, override_shared)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -3,6 +3,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
@@ -13,6 +14,9 @@ from pipx import paths, shared_libs
 from pipx.pipx_metadata_file import PipxMetadata
 from pipx.util import PipxError
 from pipx.venv import Venv
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 TEST_DATA_PATH = "./testdata/test_package_specifier"
 
@@ -160,6 +164,24 @@ def test_install_same_package_twice_no_force(pipx_temp_env, capsys):
     assert "already seems to be installed" in captured.out
     assert "pipx upgrade" in captured.out
     assert "0.0.0.2" in captured.out
+
+
+def test_install_existing_package_skips_shared_lib_maintenance(pipx_temp_env: None, mocker: "MockerFixture") -> None:
+    assert run_pipx_cli(["install", PKG["pycowsay"]["spec"]]) == 0
+    mocker.patch.object(shared_libs.shared_libs, "has_been_updated_this_run", False)
+    mocker.patch(
+        "pipx.shared_libs.time.time",
+        return_value=shared_libs.shared_libs.pip_path.stat().st_mtime + shared_libs.SHARED_LIBS_MAX_AGE_SEC + 1,
+    )
+    run_subprocess = mocker.patch(
+        "pipx.shared_libs.run_subprocess",
+        autospec=True,
+        return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="ModuleSpec", stderr=""),
+    )
+
+    run_pipx_cli(["install", PKG["pycowsay"]["spec"]])
+
+    run_subprocess.assert_not_called()
 
 
 def test_include_deps(pipx_temp_env, capsys):


### PR DESCRIPTION
`pipx install` checks shared-library maintenance before returning for an installed package without `--force`. An aged shared environment can therefore run a pip upgrade even though the command reports that it changed nothing ([#1856](https://github.com/pypa/pipx/issues/1856)).

Move maintenance after the existing-package return. The regression ages the shared environment, mocks the clock and subprocess boundaries, and verifies that a repeated install starts no subprocess. The production module keeps `__all__` at EOF with a trailing comma.
