### PR TITLE
⚡ perf(shared): cache validity checks

### DIFF
--- a/changelog.d/1856.performance.md
+++ b/changelog.d/1856.performance.md
@@ -1,0 +1,1 @@
+Cache shared-library validity checks within each pipx process.

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -66,6 +66,7 @@ def _venv_python_is_valid(python_path: Path) -> bool:
 class _SharedLibs:
     def __init__(self) -> None:
         self._site_packages: dict[Path, Path] = {}
+        self._is_valid: bool | None = None
         self.has_been_updated_this_run = False
         self.has_been_logged_this_run = False
 
@@ -106,6 +107,7 @@ class _SharedLibs:
                     [DEFAULT_PYTHON, "-m", "venv", "--clear", self.root], run_dir=str(self.root)
                 )
             subprocess_post_check(create_process)
+            self._is_valid = None
 
             # Reinstall pip so OS-vendor patches cannot enter the shared environment.
             self.upgrade(pip_args=[*pip_args, "--force-reinstall"], verbose=verbose, raises=True)
@@ -119,20 +121,20 @@ class _SharedLibs:
 
     @property
     def is_valid(self) -> bool:
-        if self.python_path.is_file():
-            # On Windows, check that the venv's underlying Python still exists
-            if not _venv_python_is_valid(self.python_path):
-                return False
+        if self._is_valid is None:
+            self._is_valid = (
+                self.python_path.is_file()
+                and _venv_python_is_valid(self.python_path)
+                and self.pip_path.is_file()
+                and run_subprocess(
+                    [self.python_path, "-c", "import importlib.util; print(importlib.util.find_spec('pip'))"],
+                    capture_stderr=False,
+                    log_cmd_str="<checking pip's availability>",
+                ).stdout.strip()
+                != "None"
+            )
 
-            check_pip = "import importlib.util; print(importlib.util.find_spec('pip'))"
-            out = run_subprocess(
-                [self.python_path, "-c", check_pip],
-                capture_stderr=False,
-                log_cmd_str="<checking pip's availability>",
-            ).stdout.strip()
-
-            return self.pip_path.is_file() and out != "None"
-        return False
+        return self._is_valid
 
     @property
     def needs_upgrade(self) -> bool:

--- a/tests/test_shared_libs.py
+++ b/tests/test_shared_libs.py
@@ -90,6 +90,20 @@ def test_shared_libs_create_preserves_pip_args(pipx_ultra_temp_env: None) -> Non
     assert (pip_args, shared_libs.shared_libs.is_valid) == (["--disable-pip-version-check"], True)
 
 
+def test_shared_libs_validity_check_is_cached(pipx_ultra_temp_env: None, mocker: MockerFixture) -> None:
+    shared_libs.shared_libs.python_path.parent.mkdir(parents=True)
+    shared_libs.shared_libs.python_path.touch()
+    shared_libs.shared_libs.pip_path.touch()
+    run_subprocess = mocker.patch(
+        "pipx.shared_libs.run_subprocess",
+        autospec=True,
+        return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="ModuleSpec", stderr=""),
+    )
+
+    assert (shared_libs.shared_libs.is_valid, shared_libs.shared_libs.is_valid) == (True, True)
+    run_subprocess.assert_called_once()
+
+
 def test_shared_libs_upgrade_enforces_pip_floor(
     pipx_ultra_temp_env: None,
     mocker: MockerFixture,
@@ -98,15 +112,13 @@ def test_shared_libs_upgrade_enforces_pip_floor(
     shared_libs.shared_libs.has_been_updated_this_run = False
     run_subprocess = mocker.patch(
         "pipx.shared_libs.run_subprocess",
-        side_effect=[
-            subprocess.CompletedProcess(args=[], returncode=0, stdout="ModuleSpec", stderr=""),
-            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
-        ],
+        return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
     )
 
     shared_libs.shared_libs.upgrade(pip_args=["pip==20"], verbose=True, raises=True)
 
-    install_command = run_subprocess.call_args_list[1].args[0]
+    install_command = run_subprocess.call_args.args[0]
+    run_subprocess.assert_called_once()
     assert "pip==20" in install_command
     assert "pip >= 23.1" in install_command
 


### PR DESCRIPTION
`Venv.check_upgrade_shared_libs()` can read `shared_libs.is_valid` more than once per command. Each read launches Python to locate pip, so one command can repeat the same subprocess ([#1856](https://github.com/pypa/pipx/issues/1856)).

Cache the result for the lifetime of the pipx process. Shared-environment creation resets it after changing the filesystem. The regression proves that two reads start one subprocess, and existing creation coverage verifies the reset. The production module keeps `__all__` at EOF with a trailing comma.
