### PR TITLE
⚡ perf(venv): cache site-packages path

### DIFF
--- a/changelog.d/1856.performance.2.md
+++ b/changelog.d/1856.performance.2.md
@@ -1,0 +1,1 @@
+Cache each managed environment's site-packages path.

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -151,6 +151,7 @@ class Venv:
             env_backend=env_backend,
         )
         self._backend: Backend | None = None
+        self._site_packages: Path | None = None
         self._uses_shared_libs_cache: bool | None = None
 
     @property
@@ -256,6 +257,7 @@ class Venv:
             include_pip=override_shared,
             verbose=self.verbose,
         )
+        self._site_packages = None
 
         self.pipx_metadata.venv_args = venv_args
         # Persist the chosen backend on disk only when actually creating the venv.
@@ -469,10 +471,16 @@ class Venv:
             not_required=not_required,
         )
 
+    @property
+    def site_packages(self) -> Path:
+        if self._site_packages is None:
+            self._site_packages = get_site_packages(self.python_path)
+        return self._site_packages
+
     def _find_entry_point(self, app: str) -> EntryPoint | None:
         if not self.python_path.exists():
             return None
-        dists = Distribution.discover(name=self.main_package_name, path=[str(get_site_packages(self.python_path))])
+        dists = Distribution.discover(name=self.main_package_name, path=[str(self.site_packages)])
         for dist in dists:
             for ep in dist.entry_points:
                 if ep.group == "pipx.run":
@@ -503,7 +511,7 @@ class Venv:
         return (self.bin_path / filename).is_file()
 
     def has_package(self, package_name: str) -> bool:
-        return bool(list(Distribution.discover(name=package_name, path=[str(get_site_packages(self.python_path))])))
+        return bool(list(Distribution.discover(name=package_name, path=[str(self.site_packages)])))
 
     def upgrade_package_no_metadata(self, package_name: str, pip_args: list[str]) -> None:
         _LOGGER.info("Upgrading %s", package_descr := full_package_description(package_name, package_name))

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -1,0 +1,25 @@
+import subprocess
+from pathlib import Path
+
+from pytest_mock import MockerFixture
+
+from pipx.venv import Venv
+
+
+def test_has_app_caches_site_packages(tmp_path: Path, mocker: MockerFixture) -> None:
+    venv = Venv(tmp_path / "demo")
+    venv.python_path.parent.mkdir(parents=True)
+    venv.python_path.touch()
+    site_packages = tmp_path / "site-packages"
+    dist_info = site_packages / "demo-1.0.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text("Name: demo\nVersion: 1.0\n")
+    (dist_info / "entry_points.txt").write_text("[pipx.run]\ndemo = demo:main\n")
+    run_subprocess = mocker.patch(
+        "pipx.util.run_subprocess",
+        autospec=True,
+        return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout=f"{site_packages}\n", stderr=""),
+    )
+
+    assert (venv.has_app("demo", "demo"), venv.has_app("demo", "demo")) == (True, True)
+    run_subprocess.assert_called_once()


### PR DESCRIPTION
Cached `pipx run` checks `Venv.has_app()` before `Venv.run_app()`. Both discover the entry point through `get_site_packages()`, which starts an interpreter for the same `sysconfig` path ([#1856](https://github.com/pypa/pipx/issues/1856)).

Memoize that path per `Venv` and clear it after environment creation. The regression creates real distribution metadata and proves that two app checks start one interpreter subprocess. The full run-command tests preserve cached and local entry-point behavior. The production module keeps `__all__` at EOF with a trailing comma.
