### PR TITLE
⚡ perf(uninstall): inspect legacy venv once

### DIFF
--- a/changelog.d/1856.performance.3.md
+++ b/changelog.d/1856.performance.3.md
@@ -1,0 +1,1 @@
+Inspect legacy environments once during uninstall and reinstall.

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -8,7 +8,7 @@ from packaging.utils import canonicalize_name
 from pipx.commands.common import add_suffix
 from pipx.commands.inject import inject_dep
 from pipx.commands.install import install
-from pipx.commands.uninstall import _get_venv_resource_paths
+from pipx.commands.uninstall import _get_venv_package_infos, _get_venv_resource_paths
 from pipx.constants import (
     EXIT_CODE_OK,
     EXIT_CODE_REINSTALL_INVALID_PYTHON,
@@ -34,9 +34,12 @@ def _restore_reinstall_backup(venv_dir: Path, restore_venv_dir: Path, backup_dir
 
 
 def _get_reinstall_resource_paths(venv: Venv, local_bin_dir: Path, local_man_dir: Path) -> set[Path]:
-    resource_paths = _get_venv_resource_paths("app", venv, venv.bin_path, local_bin_dir)
+    package_infos = _get_venv_package_infos(venv)
+    resource_paths = _get_venv_resource_paths("app", venv, venv.bin_path, local_bin_dir, package_infos)
     for man_section in MAN_SECTIONS:
-        resource_paths |= _get_venv_resource_paths("man", venv, venv.man_path / man_section, local_man_dir / man_section)
+        resource_paths |= _get_venv_resource_paths(
+            "man", venv, venv.man_path / man_section, local_man_dir / man_section, package_infos
+        )
     return resource_paths
 
 

--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -59,6 +59,15 @@ def _venv_metadata_to_package_info(
     )
 
 
+def _get_venv_package_infos(venv: Venv) -> tuple[PackageInfo, ...] | None:
+    if venv.pipx_metadata.main_package.package is not None:
+        return tuple(venv.package_metadata.values())
+    if not venv.python_path.is_file():
+        return None
+    venv_metadata = venv.get_venv_metadata_for_package(venv.root.name, set())
+    return (_venv_metadata_to_package_info(venv_metadata, venv.root.name),)
+
+
 def _get_package_bin_dir_app_paths(
     venv: Venv, package_info: PackageInfo, venv_bin_path: Path, local_bin_dir: Path
 ) -> set[Path]:
@@ -81,7 +90,11 @@ def _get_package_man_paths(venv: Venv, package_info: PackageInfo, venv_man_path:
 
 
 def _get_venv_resource_paths(
-    resource_type: str, venv: Venv, venv_resource_path: Path, local_resource_dir: Path
+    resource_type: str,
+    venv: Venv,
+    venv_resource_path: Path,
+    local_resource_dir: Path,
+    package_infos: tuple[PackageInfo, ...] | None,
 ) -> set[Path]:
     resource_paths = set()
     assert resource_type in ("app", "man"), "invalid resource type"
@@ -91,20 +104,9 @@ def _get_venv_resource_paths(
         "man": _get_package_man_paths,
     }[resource_type]
 
-    if venv.pipx_metadata.main_package.package is not None:
-        # Valid metadata for venv
-        for package_info in venv.package_metadata.values():
+    if package_infos is not None:
+        for package_info in package_infos:
             resource_paths |= get_package_resource_paths(venv, package_info, venv_resource_path, local_resource_dir)
-    elif venv.python_path.is_file():
-        # No metadata from pipx_metadata.json, but valid python interpreter.
-        # In pre-metadata-pipx venv.root.name is name of main package
-        # In pre-metadata-pipx there is no suffix
-        # We make the conservative assumptions: no injected packages,
-        # not include_dependencies.  Other PackageInfo fields are irrelevant
-        # here.
-        venv_metadata = venv.get_venv_metadata_for_package(venv.root.name, set())
-        main_package_info = _venv_metadata_to_package_info(venv_metadata, venv.root.name)
-        resource_paths = get_package_resource_paths(venv, main_package_info, venv_resource_path, local_resource_dir)
     else:
         # No metadata and no valid python interpreter.
         # We'll take our best guess on what to uninstall here based on symlink
@@ -135,11 +137,14 @@ def uninstall(venv_dir: Path, local_bin_dir: Path, local_man_dir: Path, verbose:
         return EXIT_CODE_UNINSTALL_VENV_NONEXISTENT
 
     venv = Venv(venv_dir, verbose=verbose)
+    package_infos = _get_venv_package_infos(venv)
 
-    bin_dir_app_paths = _get_venv_resource_paths("app", venv, venv.bin_path, local_bin_dir)
+    bin_dir_app_paths = _get_venv_resource_paths("app", venv, venv.bin_path, local_bin_dir, package_infos)
     man_dir_paths = set()
     for man_section in MAN_SECTIONS:
-        man_dir_paths |= _get_venv_resource_paths("man", venv, venv.man_path / man_section, local_man_dir / man_section)
+        man_dir_paths |= _get_venv_resource_paths(
+            "man", venv, venv.man_path / man_section, local_man_dir / man_section, package_infos
+        )
 
     for path in bin_dir_app_paths | man_dir_paths:
         try:
@@ -167,3 +172,13 @@ def uninstall_all(
         all_success &= return_val == 0
 
     return EXIT_CODE_OK if all_success else EXIT_CODE_UNINSTALL_ERROR
+
+
+__all__ = [
+    "_get_package_bin_dir_app_paths",
+    "_get_package_man_paths",
+    "_get_venv_package_infos",
+    "_get_venv_resource_paths",
+    "uninstall",
+    "uninstall_all",
+]

--- a/tests/test_reinstall.py
+++ b/tests/test_reinstall.py
@@ -2,9 +2,10 @@ import sys
 from dataclasses import replace
 
 import pytest
+from pytest_mock import MockerFixture
 
 from helpers import PIPX_METADATA_LEGACY_VERSIONS, app_name, mock_legacy_venv, run_pipx_cli, skip_if_windows
-from pipx import paths, util
+from pipx import paths, util, venv_inspect
 from pipx.pipx_metadata_file import PipxMetadata
 
 
@@ -30,6 +31,18 @@ def test_reinstall_legacy_venv(pipx_temp_env, capsys, metadata_version):
     mock_legacy_venv("pycowsay", metadata_version=metadata_version)
 
     assert not run_pipx_cli(["reinstall", "--python", sys.executable, "pycowsay"])
+
+
+def test_reinstall_legacy_venv_inspects_once_for_resources(pipx_temp_env: None, mocker: MockerFixture) -> None:
+    assert run_pipx_cli(["install", "pycowsay"]) == 0
+    executable_path = paths.ctx.bin_dir / app_name("pycowsay")
+    mock_legacy_venv("pycowsay")
+    run_subprocess = mocker.spy(venv_inspect, "run_subprocess")
+
+    assert run_pipx_cli(["reinstall", "--python", sys.executable, "pycowsay"]) == 0
+
+    assert executable_path.exists()
+    assert run_subprocess.call_count == 2
 
 
 def test_reinstall_suffix(pipx_temp_env, capsys):

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -1,6 +1,7 @@
 import sys
 
 import pytest
+from pytest_mock import MockerFixture
 
 from helpers import (
     PIPX_METADATA_LEGACY_VERSIONS,
@@ -11,7 +12,7 @@ from helpers import (
     skip_if_windows,
 )
 from package_info import PKG
-from pipx import paths
+from pipx import paths, venv_inspect
 
 
 def file_or_symlink(filepath):
@@ -51,6 +52,19 @@ def test_uninstall_legacy_venv(pipx_temp_env, metadata_version):
     mock_legacy_venv("pycowsay", metadata_version=metadata_version)
     assert not run_pipx_cli(["uninstall", "pycowsay"])
     assert not file_or_symlink(executable_path)
+
+
+def test_uninstall_legacy_venv_inspects_once(pipx_temp_env: None, mocker: MockerFixture) -> None:
+    assert run_pipx_cli(["install", "pycowsay"]) == 0
+    executable_path = paths.ctx.bin_dir / app_name("pycowsay")
+    assert executable_path.exists()
+    mock_legacy_venv("pycowsay")
+    run_subprocess = mocker.spy(venv_inspect, "run_subprocess")
+
+    assert run_pipx_cli(["uninstall", "pycowsay"]) == 0
+
+    assert not file_or_symlink(executable_path)
+    assert run_subprocess.call_count == 1
 
 
 def test_uninstall_suffix(pipx_temp_env):


### PR DESCRIPTION
Pre-metadata uninstall calls `_get_venv_resource_paths()` for apps, then again for every man section. The helper inspects the environment each time. A real CLI run therefore starts ten identical interpreter subprocesses; reinstall follows the same path ([#1856](https://github.com/pypa/pipx/issues/1856)).

Resolve package information once. Every resource lookup reuses it, reducing uninstall from ten inspections to one. Reinstall performs two instead of eleven because it still needs a post-install inspection for fresh metadata. The helper exports now have an explicit `__all__` at EOF with a trailing comma.
