### PR TITLE
fix(run): infer app name for VCS URLs

### DIFF
--- a/changelog.d/854.feature.md
+++ b/changelog.d/854.feature.md
@@ -1,0 +1,1 @@
+Infer the app name when running packages from VCS URLs.

--- a/docs/how-to/run-scripts.md
+++ b/docs/how-to/run-scripts.md
@@ -22,13 +22,18 @@ pipx run --with requests --with rich my-script.py
 
 ## Running from source control
 
-`pipx run` accepts git URLs through `--spec`. Using `black` as an example:
+`pipx run` accepts source-control URLs directly. Using `black` as an example:
 
 ```
-pipx run --spec git+https://github.com/psf/black.git black
-pipx run --spec git+ssh://git@github.com/psf/black black
-pipx run --spec git+https://github.com/psf/black.git@branch black
-pipx run --spec git+https://github.com/psf/black.git@ce14fa8b497bae2b50ec48b3bd7022573a59cdb1 black
+pipx run git+https://github.com/psf/black.git
+pipx run git+ssh://git@github.com/psf/black
+pipx run git+https://github.com/psf/black.git@branch
+pipx run git+https://github.com/psf/black.git@ce14fa8b497bae2b50ec48b3bd7022573a59cdb1
+```
+
+Use `--spec` when the executable name differs from the package name or when installing from an archive URL:
+
+```
 pipx run --spec https://github.com/psf/black/archive/18.9b0.zip black
 ```
 

--- a/docs/reference/examples.md
+++ b/docs/reference/examples.md
@@ -33,18 +33,18 @@ pipx run BINARY  # latest version of binary is run with python3
 pipx run --spec PACKAGE==2.0.0 BINARY  # specific version of package is run
 pipx run --python python3.10 BINARY  # Installed and invoked with specific Python version
 pipx run --python python3.10 --spec PACKAGE=1.7.3 BINARY
-pipx run --spec git+https://url.git BINARY  # latest version on default branch is run
-pipx run --spec git+https://url.git@branch BINARY
-pipx run --spec git+https://url.git@hash BINARY
+pipx run git+https://url.git  # latest version on default branch is run
+pipx run git+https://url.git@branch
+pipx run git+https://url.git@hash
 pipx run pycowsay moo
 pipx --version  # prints pipx version
 pipx run pycowsay --version  # prints pycowsay version
 pipx run --python pythonX pycowsay
 pipx run pycowsay==2.0 --version
 pipx run pycowsay[dev] --version
-pipx run --spec git+https://github.com/psf/black.git black
-pipx run --spec git+https://github.com/psf/black.git@branch-name black
-pipx run --spec git+https://github.com/psf/black.git@git-hash black
+pipx run git+https://github.com/psf/black.git
+pipx run git+https://github.com/psf/black.git@branch-name
+pipx run git+https://github.com/psf/black.git@git-hash
 pipx run --spec https://github.com/psf/black/archive/18.9b0.zip black --help
 pipx run https://gist.githubusercontent.com/cs01/fa721a17a326e551ede048c5088f9e0f/raw/6bdfbb6e9c1132b1c38fdd2f195d4a24c540c324/pipx-demo.py
 ```

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -37,6 +37,7 @@ else:
 _LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
 _VENV_EXPIRED_FILENAME: Final[str] = "pipx_expired_venv"
+_VCS_SCHEMES: Final[frozenset[str]] = frozenset({"bzr", "git", "hg", "svn"})
 
 _APP_NOT_FOUND_ERROR_MESSAGE: Final[str] = """\
 '{app}' executable script not found in package '{package_name}'.
@@ -61,11 +62,14 @@ def maybe_script_content(app: str, is_path: bool) -> str | Path | None:
 
     # Check for a URL
     if urllib.parse.urlparse(app).scheme:
+        if _is_vcs_url(app):
+            return None
         if not app.endswith(".py"):
             raise PipxError(
                 """
                 pipx will only execute apps from the internet directly if they
-                end with '.py'. To run from an SVN, try pipx --spec URL BINARY
+                end with '.py'. To run a package from another URL, use
+                'pipx run --spec URL BINARY'.
                 """
             )
         _LOGGER.info("Detected url. Downloading and executing as a Python file.")
@@ -178,6 +182,7 @@ def run_package(
     verbose: bool,
     use_cache: bool,
     *,
+    infer_app_name: bool = False,
     backend: str | None = None,
     env_backend: str | None = None,
     resolved_backend: str | None = None,
@@ -216,6 +221,9 @@ def run_package(
     venv_dir = _get_temporary_venv_path([package_or_url], python, pip_args, venv_args, resolved_backend or "pip")
 
     venv = Venv(venv_dir, backend=backend, env_backend=env_backend)
+    if infer_app_name and venv.pipx_metadata.main_package.package is not None:
+        app = venv.pipx_metadata.main_package.package
+        app_filename = f"{app}.exe" if WINDOWS else app
     bin_path = venv.bin_path / app_filename
     _prepare_venv_cache(venv, bin_path, use_cache)
 
@@ -233,6 +241,7 @@ def run_package(
             venv_args,
             use_cache,
             verbose,
+            infer_app_name=infer_app_name,
             backend=backend,
             env_backend=env_backend,
         )
@@ -301,6 +310,7 @@ def run(
             script_source=Path(app) if isinstance(content, Path) else None,
             dependencies=dependencies,
         )
+
     elif use_uvx:
         run_via_uv_tool_run(
             app=app,
@@ -327,6 +337,7 @@ def run(
             pypackages,
             verbose,
             use_cache,
+            infer_app_name=spec is None and _is_vcs_url(app),
             backend=backend,
             env_backend=env_backend,
             resolved_backend=resolved_backend,
@@ -345,6 +356,7 @@ def _prepare_venv(
     use_cache: bool,
     verbose: bool,
     *,
+    infer_app_name: bool = False,
     backend: str | None = None,
     env_backend: str | None = None,
 ) -> tuple[Venv, str, str]:
@@ -355,6 +367,10 @@ def _prepare_venv(
         package_name = venv.pipx_metadata.main_package.package
     else:
         package_name = package_name_from_spec(package_or_url, python, pip_args=pip_args, verbose=verbose)
+
+    if infer_app_name:
+        app = package_name
+        app_filename = f"{app}.exe" if WINDOWS else app
 
     override_shared = package_name == "pip"
 
@@ -396,6 +412,12 @@ def _prepare_venv(
         (venv_dir / _VENV_EXPIRED_FILENAME).touch()
 
     return venv, app, app_filename
+
+
+def _is_vcs_url(value: str) -> bool:
+    scheme = urllib.parse.urlparse(value).scheme
+    vcs, separator, _ = scheme.partition("+")
+    return bool(separator) and vcs in _VCS_SCHEMES
 
 
 def _get_temporary_venv_path(

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -2,6 +2,7 @@ import datetime
 import importlib
 import logging
 import os
+import shutil
 import subprocess
 import sys
 import textwrap
@@ -584,6 +585,38 @@ def test_run_local_path_entry_point(pipx_temp_env, caplog, root):
     run_pipx_cli_exit(["run", empty_project_path])
 
     assert "Using discovered entry point for 'pipx run'" in caplog.text
+
+
+@mock.patch("os.execvpe", new=execvpe_mock)
+def test_run_vcs_url_infers_app_name(pipx_temp_env, root, tmp_path, caplog):
+    project = tmp_path / "empty-project-vcs"
+    shutil.copytree(root / "testdata" / "empty_project", project)
+    pyproject = project / "pyproject.toml"
+    pyproject.write_text(pyproject.read_text().replace("empty_project.main:cli", "empty_project.main:main"))
+    subprocess.run(["git", "init", "--quiet"], cwd=project, check=True)
+    subprocess.run(["git", "add", "."], cwd=project, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=pipx tests",
+            "-c",
+            "user.email=pipx@example.invalid",
+            "commit",
+            "--quiet",
+            "-m",
+            "test fixture",
+        ],
+        cwd=project,
+        check=True,
+    )
+
+    command = ["run", "--backend", "pip", f"git+{project.as_uri()}"]
+    run_pipx_cli_exit(command, assert_exit=0)
+    run_pipx_cli_exit(command, assert_exit=0)
+
+    assert caplog.text.count("Determined package name: empty-project") == 1
+    assert "Reusing cached venv" in caplog.text
 
 
 @mock.patch("os.execvpe", new=execvpe_mock)


### PR DESCRIPTION
## Summary

- route VCS URLs through package installation and use the discovered package name as the app name
- reuse cached package metadata on later runs
- update the VCS examples and URL error guidance

## Why

Closes #854. VCS URLs currently enter the remote-script path and fail the `.py` check before pipx can inspect the package metadata.

## Validation

- `.venv/bin/pytest tests/test_run.py tests/test_run_uv.py -q` - 56 passed, 1 skipped
- `.venv/bin/pre-commit run --all-files` - passed
- `env NO_MKDOCS_2_WARNING=true .venv/bin/mkdocs build --strict --site-dir /tmp/pipx854-docs` - passed

- [x] ran the linter to address style issues (`pre-commit run --all-files`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `changelog.d/` folder
- [x] updated/extended the documentation