### PR TITLE
⚡ perf(run): reuse PATH lookup

### DIFF
--- a/changelog.d/1856.performance.4.md
+++ b/changelog.d/1856.performance.4.md
@@ -1,0 +1,1 @@
+Reuse the `pipx run` PATH lookup when warning about an existing app.

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -183,12 +183,12 @@ def run_package(
     resolved_backend: str | None = None,
     no_path_check: bool = False,
 ) -> NoReturn:
-    if not no_path_check and which(app):
+    if not no_path_check and (app_path := which(app)):
         _LOGGER.warning(
             pipx_wrap(
                 f"""
                 {hazard}  {app} is already on your PATH and installed at
-                {which(app)}. Downloading and running anyway.
+                {app_path}. Downloading and running anyway.
                 """,
                 subsequent_indent=" " * 4,
             )

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -65,18 +65,18 @@ def test_cache(pipx_temp_env, monkeypatch, capsys, caplog):
 
 
 @mock.patch("os.execvpe", new=execvpe_mock)
-def test_no_path_check(pipx_temp_env, monkeypatch, capsys, caplog):
-    def fake_which(_app):
-        return "/fake/bin/pycowsay"
-
+def test_no_path_check(pipx_temp_env: None, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    which = mock.Mock(return_value="/fake/bin/pycowsay")
     for module_name in ("pipx.commands.run", "pipx.commands.run_uv"):
-        monkeypatch.setattr(importlib.import_module(module_name), "which", fake_which)
+        monkeypatch.setattr(importlib.import_module(module_name), "which", which)
 
     run_pipx_cli_exit(["run", "pycowsay", "cowsay", "args"])
+    which.assert_called_once_with("pycowsay")
     assert "is already on your PATH" in caplog.text
 
     caplog.clear()
     run_pipx_cli_exit(["run", "--no-path-check", "pycowsay", "cowsay", "args"])
+    which.assert_called_once_with("pycowsay")
     assert "is already on your PATH" not in caplog.text
 
 


### PR DESCRIPTION
`run_package()` calls `shutil.which()` in the warning condition and again while formatting the warning. One `pipx run` therefore scans PATH twice with the same app name ([#1856](https://github.com/pypa/pipx/issues/1856)).

Reuse the first result. The public CLI regression verifies one warning-path lookup while confirming that `--no-path-check` performs none. The production module keeps `__all__` at EOF with a trailing comma.
