### PR TITLE
⚡ perf(cli): defer venv completion scan

### DIFF
--- a/changelog.d/1856.performance.5.md
+++ b/changelog.d/1856.performance.5.md
@@ -1,0 +1,1 @@
+List managed environments only when shell completion requests them.

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -15,7 +15,7 @@ import urllib.parse
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, NoReturn, cast
+from typing import Any, Final, NoReturn, cast
 
 import argcomplete
 import platformdirs
@@ -172,11 +172,16 @@ class LineWrapRawTextHelpFormatter(argparse.RawDescriptionHelpFormatter):
 
 class InstalledVenvsCompleter:
     def __init__(self, venv_container: VenvContainer) -> None:
-        self.packages = [str(p.name) for p in sorted(venv_container.iter_venv_dirs())]
+        self._venv_container: Final[VenvContainer] = venv_container
+        self._packages: list[str] | None = None
 
     def use(self, prefix: str, **kwargs: Any) -> list[str]:
+        if self._packages is None:
+            self._packages = [path.name for path in sorted(self._venv_container.iter_venv_dirs())]
         canonical_prefix = canonicalize_name(prefix)
-        return [f"{prefix}{x[len(canonical_prefix) :]}" for x in self.packages if x.startswith(canonical_prefix)]
+        return [
+            f"{prefix}{name[len(canonical_prefix) :]}" for name in self._packages if name.startswith(canonical_prefix)
+        ]
 
 
 def get_pip_args(parsed_args: dict[str, str]) -> list[str]:

--- a/tests/test_completions.py
+++ b/tests/test_completions.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+from pytest_mock import MockerFixture
 
 from helpers import run_pipx_cli
 from pipx import main
@@ -18,3 +19,13 @@ def test_installed_venvs_noncanonical_prefix(tmp_path: Path) -> None:
     completer = main.InstalledVenvsCompleter(VenvContainer(tmp_path))
 
     assert completer.use("my__p") == ["my__pkg"]
+
+
+def test_installed_venvs_defers_listing(tmp_path: Path, mocker: MockerFixture) -> None:
+    venv_container = VenvContainer(tmp_path)
+    iter_venv_dirs = mocker.spy(venv_container, "iter_venv_dirs")
+    completer = main.InstalledVenvsCompleter(venv_container)
+
+    iter_venv_dirs.assert_not_called()
+    assert (completer.use(""), completer.use("")) == ([], [])
+    iter_venv_dirs.assert_called_once_with()


### PR DESCRIPTION
Every command calls `get_command_parser()`, which constructs the installed-environment completer. Its constructor walks and sorts the environment directory even when shell completion requests no candidates ([#1856](https://github.com/pypa/pipx/issues/1856)).

Defer the scan. Parser setup stores the container, and the first completion call lists and caches its environments. A regression proves that construction performs no listing and repeated calls reuse the cache; existing normalized-prefix coverage remains. The production module keeps `__all__` at EOF with a trailing comma.
