### PR TITLE
⚡ perf(python): resolve default lazily

### DIFF
--- a/changelog.d/1856.performance.6.md
+++ b/changelog.d/1856.performance.6.md
@@ -1,0 +1,1 @@
+Resolve the default Python interpreter on first use instead of import.

--- a/src/pipx/commands/environment.py
+++ b/src/pipx/commands/environment.py
@@ -4,7 +4,7 @@ from pipx import paths
 from pipx.backends import env_default_backend, find_uv_binary, resolve_backend_name
 from pipx.constants import EXIT_CODE_OK, ExitCode
 from pipx.emojis import EMOJI_SUPPORT
-from pipx.interpreter import DEFAULT_PYTHON
+from pipx.interpreter import get_default_python
 from pipx.shared_libs import (
     DISABLE_SHARED_LIBS_AUTO_UPGRADE,
     shared_libs_auto_upgrade_disabled,
@@ -55,7 +55,7 @@ def environment(value: str | None) -> ExitCode:
         "PIPX_TRASH_DIR": paths.ctx.trash,
         "PIPX_VENV_CACHEDIR": paths.ctx.venv_cache,
         "PIPX_STANDALONE_PYTHON_CACHEDIR": paths.ctx.standalone_python_cachedir,
-        "PIPX_DEFAULT_PYTHON": DEFAULT_PYTHON,
+        "PIPX_DEFAULT_PYTHON": get_default_python(),
         "PIPX_RESOLVED_BACKEND": resolved_backend,
         "PIPX_BACKEND_SOURCE": backend_source,
         "PIPX_UV_BINARY": str(uv_binary) if uv_binary else "",

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -14,7 +14,7 @@ from pipx.constants import (
     ExitCode,
 )
 from pipx.emojis import sleep
-from pipx.interpreter import DEFAULT_PYTHON
+from pipx.interpreter import get_default_python
 from pipx.pipx_metadata_file import PackageInfo, PipxMetadata, load_spec_file
 from pipx.util import PipxError, pipx_wrap
 from pipx.venv import Venv, VenvContainer
@@ -44,7 +44,7 @@ def install(
     # package_spec is anything pip-installable, including package_name, vcs spec,
     #   zip file, or tar.gz file.
 
-    python = python or DEFAULT_PYTHON
+    python = python or get_default_python()
 
     package_names = package_names or []
     if len(package_names) != len(package_specs):

--- a/src/pipx/interpreter.py
+++ b/src/pipx/interpreter.py
@@ -3,7 +3,9 @@ import os
 import shutil
 import subprocess
 import sys
+from functools import cache
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from packaging import version
 
@@ -13,6 +15,9 @@ from pipx.standalone_python import download_python_build_standalone
 from pipx.util import PipxError
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    DEFAULT_PYTHON: str
 
 
 def has_venv() -> bool:
@@ -197,9 +202,30 @@ def _resolve_python(python: str) -> str:
     raise InterpreterResolutionError(source="PIPX_DEFAULT_PYTHON", version=python)
 
 
-env_default_python = get_environment_value("PIPX_DEFAULT_PYTHON")
+def get_default_python_spec() -> str:
+    return get_environment_value("PIPX_DEFAULT_PYTHON") or sys.executable
 
-if not env_default_python:
-    DEFAULT_PYTHON = _get_sys_executable()
-else:
-    DEFAULT_PYTHON = _resolve_python(env_default_python)
+
+@cache
+def get_default_python() -> str:
+    if (python := get_environment_value("PIPX_DEFAULT_PYTHON")) is None:
+        return _get_sys_executable()
+    return _resolve_python(python)
+
+
+def __getattr__(name: str) -> object:
+    if name == "DEFAULT_PYTHON":
+        return get_default_python()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = [
+    "DEFAULT_PYTHON",
+    "InterpreterResolutionError",
+    "find_py_launcher_python",
+    "find_python_interpreter",
+    "find_unix_command_python",
+    "get_default_python",
+    "get_default_python_spec",
+    "has_venv",
+]

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -40,9 +40,10 @@ from pipx.constants import (
 )
 from pipx.emojis import hazard
 from pipx.interpreter import (
-    DEFAULT_PYTHON,
     InterpreterResolutionError,
     find_python_interpreter,
+    get_default_python,
+    get_default_python_spec,
 )
 from pipx.package_specifier import valid_pypi_name
 from pipx.util import PipxError, mkdir, pipx_wrap, rmdir
@@ -111,7 +112,7 @@ PIPX_DESCRIPTION += pipx_wrap(
     keep_newlines=True,
 )
 
-DOC_DEFAULT_PYTHON = os.getenv("PIPX__DOC_DEFAULT_PYTHON", DEFAULT_PYTHON)
+DOC_DEFAULT_PYTHON = os.getenv("PIPX__DOC_DEFAULT_PYTHON", get_default_python_spec())
 
 INSTALL_DESCRIPTION = textwrap.dedent(
     f"""
@@ -269,12 +270,12 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:
         if package_is_url(spec, raise_error=False) and "#egg=" not in spec:
             spec = f"{spec}#egg={args.package}"
 
-    python = DEFAULT_PYTHON
+    python = get_default_python()
     python_flag_passed = False
     if "python" in args:
         python_flag_passed = bool(args.python)
         try:
-            python = find_python_interpreter(args.python or DEFAULT_PYTHON, fetch_python=args.fetch_python)
+            python = find_python_interpreter(args.python or get_default_python(), fetch_python=args.fetch_python)
         except InterpreterResolutionError as e:
             logger.debug("Failed to resolve interpreter:", exc_info=True)
             print(pipx_wrap(f"{hazard} {e}", subsequent_indent=" " * 4))
@@ -1353,7 +1354,7 @@ def setup(args: argparse.Namespace) -> None:
     logger.debug(f"{time.strftime('%Y-%m-%d %H:%M:%S')}")
     logger.debug(f"{' '.join(sys.argv)}")
     logger.info(f"pipx version is {__version__}")
-    logger.info(f"Default python interpreter is '{DEFAULT_PYTHON}'")
+    logger.info(f"Default python interpreter is '{get_default_python()}'")
 
     mkdir(paths.ctx.venvs)
     mkdir(paths.ctx.bin_dir)

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -10,7 +10,7 @@ from pipx import paths
 from pipx.animate import animate
 from pipx.constants import WINDOWS
 from pipx.emojis import strtobool
-from pipx.interpreter import DEFAULT_PYTHON
+from pipx.interpreter import get_default_python
 from pipx.util import (
     get_site_packages,
     get_venv_paths,
@@ -104,7 +104,7 @@ class _SharedLibs:
         if not self.is_valid:
             with animate("creating shared libraries", not verbose):
                 create_process = run_subprocess(
-                    [DEFAULT_PYTHON, "-m", "venv", "--clear", self.root], run_dir=str(self.root)
+                    [get_default_python(), "-m", "venv", "--clear", self.root], run_dir=str(self.root)
                 )
             subprocess_post_check(create_process)
             self._is_valid = None

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -16,7 +16,7 @@ from pipx.animate import animate
 from pipx.backends import Backend, assert_not_pip_under_uv, env_default_backend, get_backend, resolve_backend_name
 from pipx.constants import PIPX_SHARED_PTH, ExitCode
 from pipx.emojis import hazard
-from pipx.interpreter import DEFAULT_PYTHON
+from pipx.interpreter import get_default_python
 from pipx.package_specifier import (
     fix_package_name,
     get_extras,
@@ -129,12 +129,12 @@ class Venv:
         path: Path,
         *,
         verbose: bool = False,
-        python: str = DEFAULT_PYTHON,
+        python: str | None = None,
         backend: str | None = None,
         env_backend: str | None = None,
     ) -> None:
         self.root = path
-        self.python = python
+        self.python = python or get_default_python()
         self.bin_path, self.python_path, self.man_path = get_venv_paths(self.root)
         self.pipx_metadata = PipxMetadata(venv_dir=path)
         self.verbose = verbose

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,10 +120,9 @@ def pipx_temp_env_helper(pipx_shared_dir, tmp_path, monkeypatch, request, utils_
     monkeypatch.setattr(_pip_backend_module, "shared_libs", shared_libs.shared_libs)
     monkeypatch.setattr(_upgrade_module, "shared_libs", shared_libs.shared_libs)
 
-    monkeypatch.setattr(interpreter, "DEFAULT_PYTHON", sys.executable)
-
     if "PIPX_DEFAULT_PYTHON" in os.environ:
         monkeypatch.delenv("PIPX_DEFAULT_PYTHON")
+    interpreter.get_default_python.cache_clear()
     # CI runners ship uv on PATH; pin every legacy test to pip so the auto-
     # detect doesn't silently flip them. Uv-backend tests opt in with --backend uv.
     monkeypatch.setenv("PIPX_DEFAULT_BACKEND", "pip")

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import subprocess
 import sys
@@ -20,6 +21,35 @@ from pipx.interpreter import (
 from pipx.util import PipxError
 
 original_which = shutil.which
+
+
+def test_import_defers_default_python_resolution() -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", "import pipx.interpreter; print('imported')"],
+        env={**os.environ, "PIPX_DEFAULT_PYTHON": "missing-pipx-python"},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert (result.returncode, result.stdout.strip()) == (0, "imported")
+
+
+def test_default_python_compatibility_attribute() -> None:
+    pipx.interpreter.get_default_python.cache_clear()
+    try:
+        assert pipx.interpreter.DEFAULT_PYTHON == pipx.interpreter.get_default_python()
+    finally:
+        pipx.interpreter.get_default_python.cache_clear()
+
+
+def test_get_default_python_resolves_configured_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    pipx.interpreter.get_default_python.cache_clear()
+    monkeypatch.setenv("PIPX_DEFAULT_PYTHON", sys.executable)
+    try:
+        assert pipx.interpreter.get_default_python() == str(Path(sys.executable).resolve())
+    finally:
+        pipx.interpreter.get_default_python.cache_clear()
 
 
 @pytest.mark.skipif(not sys.platform.startswith("win"), reason="Looks for Python.exe")


### PR DESCRIPTION
Importing `pipx.interpreter` resolves `PIPX_DEFAULT_PYTHON` at module load. An invalid setting prevents the module from importing, while Windows discovery can also invoke the Python launcher before a command needs an interpreter ([#1856](https://github.com/pypa/pipx/issues/1856)).

Replace the eager constant with a cached first-use resolver and update internal consumers. Documentation uses the unresolved configured value, and a compatibility module attribute preserves existing `DEFAULT_PYTHON` imports. A subprocess regression confirms that an invalid setting no longer breaks module import. The interpreter export list remains at EOF with a trailing comma.
