### PR TITLE
⚡ Index installed distributions during inspection

### DIFF
--- a/changelog.d/1856.performance.7.md
+++ b/changelog.d/1856.performance.7.md
@@ -1,0 +1,1 @@
+Index installed distributions during environment inspection.

--- a/src/pipx/commands/uninject.py
+++ b/src/pipx/commands/uninject.py
@@ -20,7 +20,7 @@ from pipx.constants import (
 from pipx.emojis import stars
 from pipx.util import PipxError, pipx_wrap
 from pipx.venv import Venv
-from pipx.venv_inspect import fetch_info_in_venv, get_dist, get_required_dependency_names
+from pipx.venv_inspect import fetch_info_in_venv, get_distributions_by_name, get_required_dependency_names
 
 logger = logging.getLogger(__name__)
 
@@ -167,7 +167,7 @@ def get_include_resource_paths(package_name: str, venv: Venv, local_bin_dir: Pat
 
 def _get_remaining_dependencies(venv: Venv, excluded_package: str) -> set[str]:
     venv_sys_path, venv_env, _ = fetch_info_in_venv(venv.python_path)
-    distributions = tuple(metadata.distributions(path=venv_sys_path))
+    distributions = get_distributions_by_name(venv_sys_path)
 
     remaining_deps: set[str] = set()
     remaining_packages: list[str] = [
@@ -183,7 +183,7 @@ def _get_remaining_dependencies(venv: Venv, excluded_package: str) -> set[str]:
 
 def _collect_transitive_deps(
     package_name: str,
-    distributions: tuple[metadata.Distribution, ...],
+    distributions: dict[str, metadata.Distribution],
     env: dict[str, str],
     visited: set[str] | None = None,
 ) -> set[str]:
@@ -193,7 +193,7 @@ def _collect_transitive_deps(
     if canonical in visited:
         return visited
     visited.add(canonical)
-    if dist := get_dist(package_name, distributions):
+    if dist := distributions.get(canonical):
         for dep_name in get_required_dependency_names(dist, env):
             _collect_transitive_deps(dep_name, distributions, env, visited)
     return visited

--- a/src/pipx/venv_inspect.py
+++ b/src/pipx/venv_inspect.py
@@ -4,7 +4,7 @@ import json
 import logging
 import shutil
 import textwrap
-from collections.abc import Collection, Iterable, Iterator
+from collections.abc import Iterable, Iterator, Mapping
 from pathlib import Path, PurePosixPath
 from typing import NamedTuple
 from urllib.parse import urlparse
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 class VenvInspectInformation(NamedTuple):
-    distributions: Collection[metadata.Distribution]
+    distributions: Mapping[str, metadata.Distribution]
     env: dict[str, str]
     bin_path: Path
     man_path: Path
@@ -49,12 +49,13 @@ class VenvMetadata(NamedTuple):
     python_version: str
 
 
-def get_dist(package: str, distributions: Collection[metadata.Distribution]) -> metadata.Distribution | None:
-    """Find matching distribution in the canonicalized sense."""
-    for dist in distributions:
-        if canonicalize_name(dist.metadata["name"]) == canonicalize_name(package):
-            return dist
-    return None
+def get_distributions_by_name(paths: list[str]) -> dict[str, metadata.Distribution]:
+    metadata.MetadataPathFinder().invalidate_caches()
+    return {
+        canonicalize_name(name): dist
+        for dist in metadata.distributions(path=paths)
+        if (name := dist.metadata.get("Name")) is not None
+    }
 
 
 def get_package_dependencies(dist: metadata.Distribution, extras: set[str], env: dict[str, str]) -> list[Requirement]:
@@ -327,7 +328,7 @@ def _dfs_package_resources(
             # avoid infinite recursion, avoid duplicates in info
             continue
 
-        dep_dist = get_dist(dep_req.name, venv_inspect_info.distributions)
+        dep_dist = venv_inspect_info.distributions.get(dep_name)
         if dep_dist is None:
             raise PipxError(f"Pipx Internal Error: cannot find package {dep_req.name!r} metadata.")
         app_names, man_names = get_resources(dep_dist, venv_inspect_info.bin_path, venv_inspect_info.man_path)
@@ -441,13 +442,7 @@ def inspect_venv(
 
     (venv_sys_path, venv_env, venv_python_version) = fetch_info_in_venv(venv_python_path)
 
-    # Collect the generator created from metadata.distributions()
-    # (see `itertools.chain.from_iterable`) into a tuple because we
-    # need to iterate over it multiple times in `_dfs_package_apps`.
-
-    # Tuple is chosen over a list because the program only iterate over
-    # the distributions and never modify it.
-    distributions = tuple(metadata.distributions(path=venv_sys_path))
+    distributions = get_distributions_by_name(venv_sys_path)
 
     venv_inspect_info = VenvInspectInformation(
         bin_path=venv_bin_path,
@@ -456,7 +451,7 @@ def inspect_venv(
         distributions=distributions,
     )
 
-    root_dist = get_dist(root_req.name, venv_inspect_info.distributions)
+    root_dist = venv_inspect_info.distributions.get(canonicalize_name(root_req.name))
     if root_dist is None:
         raise PipxError(f"Pipx Internal Error: cannot find package {root_req.name!r} metadata.")
     app_paths_of_dependencies, man_paths_of_dependencies = _dfs_package_resources(
@@ -494,3 +489,13 @@ def inspect_venv(
         package_version=root_dist.version,
         python_version=venv_python_version,
     )
+
+
+__all__ = [
+    "VenvMetadata",
+    "fetch_info_in_venv",
+    "get_distributions_by_name",
+    "get_required_dependency_names",
+    "inspect_venv",
+    "list_not_required_packages",
+]

--- a/tests/test_venv_inspect.py
+++ b/tests/test_venv_inspect.py
@@ -1,0 +1,73 @@
+import os
+from pathlib import Path
+
+from packaging.utils import canonicalize_name
+from pytest_mock import MockerFixture
+
+from pipx import venv_inspect
+
+
+def _write_dist_info(site_packages: Path, name: str, requirements: tuple[str, ...] = ()) -> None:
+    dist_info = site_packages / f"{canonicalize_name(name)}-1.0.dist-info"
+    dist_info.mkdir(parents=True)
+    metadata = [f"Name: {name}", "Version: 1.0"]
+    metadata.extend(f"Requires-Dist: {requirement}" for requirement in requirements)
+    (dist_info / "METADATA").write_text("\n".join(metadata), encoding="utf-8")
+
+
+def test_inspect_venv_indexes_distribution_names_once(tmp_path: Path, mocker: MockerFixture) -> None:
+    site_packages = tmp_path / "site-packages"
+    _write_dist_info(site_packages, "Root_Package", ("dependency-package",))
+    _write_dist_info(site_packages, "Dependency_Package")
+    nameless_dist_info = site_packages / "nameless-1.0.dist-info"
+    nameless_dist_info.mkdir()
+    (nameless_dist_info / "METADATA").write_text("Version: 1.0\n", encoding="utf-8")
+    mocker.patch.object(
+        venv_inspect,
+        "fetch_info_in_venv",
+        autospec=True,
+        return_value=([str(site_packages)], {}, "Python 3.10.0"),
+    )
+    canonicalize = mocker.spy(venv_inspect, "canonicalize_name")
+
+    result = venv_inspect.inspect_venv(
+        "root-package",
+        set(),
+        tmp_path / "bin",
+        tmp_path / "python",
+        tmp_path / "man",
+    )
+
+    assert result.package_version == "1.0"
+    assert [call.args[0] for call in canonicalize.call_args_list].count("Root_Package") == 1
+    assert [call.args[0] for call in canonicalize.call_args_list].count("Dependency_Package") == 1
+
+
+def test_inspect_venv_refreshes_distribution_paths(tmp_path: Path, mocker: MockerFixture) -> None:
+    site_packages = tmp_path / "site-packages"
+    _write_dist_info(site_packages, "root-package")
+    mocker.patch.object(
+        venv_inspect,
+        "fetch_info_in_venv",
+        autospec=True,
+        return_value=([str(site_packages)], {}, "Python 3.10.0"),
+    )
+    args: tuple[str, set[str], Path, Path, Path] = (
+        "root-package",
+        set(),
+        tmp_path / "bin",
+        tmp_path / "python",
+        tmp_path / "man",
+    )
+
+    assert venv_inspect.inspect_venv(*args).package_version == "1.0"
+
+    site_packages_stat = site_packages.stat()
+    _write_dist_info(site_packages, "dependency-package")
+    (site_packages / "root-package-1.0.dist-info" / "METADATA").write_text(
+        "Name: root-package\nVersion: 1.0\nRequires-Dist: dependency-package\n",
+        encoding="utf-8",
+    )
+    os.utime(site_packages, ns=(site_packages_stat.st_atime_ns, site_packages_stat.st_mtime_ns))
+
+    assert venv_inspect.inspect_venv(*args).package_version == "1.0"


### PR DESCRIPTION
Environment inspection scans installed distributions for the root package and again for each dependency. Build one canonical-name index per inspection, then reuse it for resource traversal and uninject dependency pruning.

Clear `importlib.metadata`'s path cache before discovery. Without that refresh, an install within the same directory timestamp interval can remain invisible to the next inspection.

Add regressions with real `.dist-info` metadata for repeated canonicalization, stale directory listings, and nameless metadata entries. Keep `venv_inspect` exports explicit at the end of the module.

Refs #1856
