### PR TITLE
⚡ Cache resolved context paths

### DIFF
--- a/changelog.d/1856.performance.10.md
+++ b/changelog.d/1856.performance.10.md
@@ -1,0 +1,1 @@
+Cache resolved pipx context paths.

--- a/src/pipx/paths.py
+++ b/src/pipx/paths.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from functools import cached_property
 from pathlib import Path
 from typing import Final
 
@@ -83,15 +84,15 @@ class _PathContext:
             return self.home / ".cache"
         return self._default_cache
 
-    @property
+    @cached_property
     def bin_dir(self) -> Path:
         return (self._base_bin or self._default_bin).resolve()
 
-    @property
+    @cached_property
     def man_dir(self) -> Path:
         return (self._base_man or self._default_man).resolve()
 
-    @property
+    @cached_property
     def home(self) -> Path:
         if self._base_home:
             home = self._base_home
@@ -101,9 +102,13 @@ class _PathContext:
             home = self._default_home
         return home.resolve()
 
-    @property
+    @cached_property
     def shared_libs(self) -> Path:
         return (self._base_shared_libs or self.home / "shared").resolve()
+
+    def _clear_cached_paths(self) -> None:
+        for attribute in ("bin_dir", "home", "man_dir", "shared_libs"):
+            self.__dict__.pop(attribute, None)
 
     def make_local(self) -> None:
         self._base_home = OVERRIDE_PIPX_HOME or get_expanded_environ("PIPX_HOME")  # type: ignore[redundant-expr]
@@ -118,6 +123,7 @@ class _PathContext:
         self._default_trash = self._default_home / "trash"
         self._fallback_home = next((fallback for fallback in FALLBACK_PIPX_HOMES if fallback.exists()), None)
         self._home_exists = self._base_home is not None or any(fallback.exists() for fallback in FALLBACK_PIPX_HOMES)
+        self._clear_cached_paths()
 
     def make_global(self) -> None:
         self._base_home = OVERRIDE_PIPX_GLOBAL_HOME or get_expanded_environ("PIPX_GLOBAL_HOME")  # type: ignore[redundant-expr]
@@ -132,6 +138,7 @@ class _PathContext:
         self._base_shared_libs = None
         self._fallback_home = None
         self._home_exists = self._base_home is not None
+        self._clear_cached_paths()
 
     @property
     def standalone_python_cachedir(self) -> Path:

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+import pytest
+from pytest_mock import MockerFixture
+
+from pipx import paths
+
+
+@pytest.mark.parametrize(
+    ("attribute", "override_name"),
+    [
+        pytest.param("home", "OVERRIDE_PIPX_HOME", id="home"),
+        pytest.param("bin_dir", "OVERRIDE_PIPX_BIN_DIR", id="bin"),
+        pytest.param("man_dir", "OVERRIDE_PIPX_MAN_DIR", id="man"),
+        pytest.param("shared_libs", "OVERRIDE_PIPX_SHARED_LIBS", id="shared"),
+    ],
+)
+def test_context_resolves_base_path_once(
+    pipx_temp_env: None,
+    mocker: MockerFixture,
+    attribute: str,
+    override_name: str,
+) -> None:
+    resolve = mocker.spy(Path, "resolve")
+    paths.ctx.make_local()
+    expected = getattr(paths, override_name)
+    assert expected is not None
+
+    assert (getattr(paths.ctx, attribute), getattr(paths.ctx, attribute)) == (expected, expected)
+    assert sum(call.args[0] == expected for call in resolve.call_args_list) == 1


### PR DESCRIPTION
The exported path context calls `Path.resolve()` on every base-path property access. Those values cannot change between `make_local()` and `make_global()` calls.

Cache each resolved base with `cached_property`, then clear the entries after either context switch. Derived paths remain regular properties because they perform no filesystem resolution.

Add a parameterized regression covering every resolved base. Eight reads now make four `Path.resolve()` calls instead of eight. Preserve the explicit export list at the end of the module.

Refs #1856
