### PR TITLE
feat(install): reconcile existing packages with specs

### DIFF
--- a/changelog.d/1572.feature.md
+++ b/changelog.d/1572.feature.md
@@ -1,0 +1,1 @@
+Add `pipx install --upgrade` to reconcile apps with package specs.

--- a/docs/reference/examples.md
+++ b/docs/reference/examples.md
@@ -6,6 +6,8 @@ pipx install --python python3.10 pycowsay
 pipx install --python 3.12 pycowsay
 pipx install --fetch-python=missing --python 3.12 pycowsay
 pipx install --fetch-python=always --python 3.13 pycowsay
+pipx install --upgrade 'black>=22,<23'
+pipx install --upgrade --upgrade-strategy eager 'black>=22,<23'
 pipx install git+https://github.com/psf/black
 pipx install git+https://github.com/psf/black.git@branch-name
 pipx install git+https://github.com/psf/black.git@git-hash

--- a/docs/tutorial/install-applications.md
+++ b/docs/tutorial/install-applications.md
@@ -41,6 +41,18 @@ apps are exposed on your $PATH at /home/user/.local/bin
 
 ```
 
+### Keeping an installation within a version range
+
+Use `--upgrade` when you want an installed app to match a package spec:
+
+```
+pipx install --upgrade "black>=22,<23"
+```
+
+pipx installs the app when it is missing, upgrades or downgrades it when the installed version is outside the requested
+range, and does not contact the package index when the installed version already satisfies the spec. Add
+`--upgrade-strategy eager` to also upgrade dependencies when the app itself needs to change.
+
 ### Picking a Python interpreter
 
 Pass `--python` to install with a specific Python version. When that Python isn't on your `PATH`, pipx can download a

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -7,7 +7,7 @@ from packaging.utils import canonicalize_name
 
 from pipx import commands, paths
 from pipx.backends import PIP
-from pipx.commands.common import package_name_from_spec, run_post_install_actions
+from pipx.commands.common import expose_resources_globally, package_name_from_spec, run_post_install_actions
 from pipx.constants import (
     EXIT_CODE_INSTALL_VENV_EXISTS,
     EXIT_CODE_OK,
@@ -15,9 +15,78 @@ from pipx.constants import (
 )
 from pipx.emojis import sleep
 from pipx.interpreter import get_default_python
+from pipx.package_specifier import package_spec_satisfied
 from pipx.pipx_metadata_file import PackageInfo, PipxMetadata, load_spec_file
 from pipx.util import PipxError, pipx_wrap
 from pipx.venv import Venv, VenvContainer
+
+
+def _upgrade_existing_venv(
+    venv: Venv,
+    package_name: str,
+    package_spec: str,
+    local_bin_dir: Path,
+    local_man_dir: Path,
+    pip_args: list[str],
+    verbose: bool,
+    upgrade_strategy: str | None,
+) -> None:
+    package_metadata = venv.pipx_metadata.main_package
+    installed_version = package_metadata.package_version
+    if package_spec_satisfied(
+        package_spec,
+        package_name,
+        installed_version,
+        package_metadata.package_or_url or package_name,
+    ):
+        print(f"{package_name} {installed_version} already satisfies {package_spec}")
+        return
+    if package_metadata.pinned:
+        print(f"Not upgrading pinned package {venv.name}. Run `pipx unpin {venv.name}` to unpin it.")
+        return
+
+    main_pip_args = pip_args or package_metadata.pip_args
+    venv.check_upgrade_shared_libs(pip_args=main_pip_args, verbose=verbose)
+    venv.upgrade_packaging_libraries(main_pip_args)
+    venv.upgrade_package(
+        package_name,
+        package_spec,
+        main_pip_args,
+        include_dependencies=package_metadata.include_dependencies,
+        include_apps=package_metadata.include_apps,
+        is_main_package=True,
+        suffix=package_metadata.suffix,
+        upgrade_only_pip_args=([f"--upgrade-strategy={upgrade_strategy}"] if upgrade_strategy is not None else None),
+    )
+    package_metadata = venv.pipx_metadata.main_package
+    if package_metadata.include_apps:
+        expose_resources_globally(
+            "app",
+            local_bin_dir,
+            package_metadata.app_paths,
+            force=False,
+            suffix=package_metadata.suffix,
+        )
+        expose_resources_globally("man", local_man_dir, package_metadata.man_paths, force=False)
+    if package_metadata.include_dependencies:
+        for app_paths in package_metadata.app_paths_of_dependencies.values():
+            expose_resources_globally(
+                "app",
+                local_bin_dir,
+                app_paths,
+                force=False,
+                suffix=package_metadata.suffix,
+            )
+        for man_paths in package_metadata.man_paths_of_dependencies.values():
+            expose_resources_globally("man", local_man_dir, man_paths, force=False)
+    print(
+        pipx_wrap(
+            f"""
+            upgraded package {venv.name} from {installed_version} to
+            {package_metadata.package_version} (location: {venv.root!s})
+            """
+        )
+    )
 
 
 def install(
@@ -39,10 +108,15 @@ def install(
     python_flag_passed: bool = False,
     backend: str | None = None,
     env_backend: str | None = None,
+    upgrade: bool = False,
+    upgrade_strategy: str | None = None,
 ) -> ExitCode:
     """Returns pipx exit code."""
     # package_spec is anything pip-installable, including package_name, vcs spec,
     #   zip file, or tar.gz file.
+
+    if upgrade_strategy is not None and not upgrade:
+        raise PipxError("--upgrade-strategy requires --upgrade")
 
     python = python or get_default_python()
 
@@ -98,6 +172,21 @@ def install(
                 )
             if force:
                 print(f"Installing to existing venv {venv.name!r}")
+            elif upgrade:
+                _upgrade_existing_venv(
+                    venv,
+                    package_name,
+                    package_spec,
+                    local_bin_dir,
+                    local_man_dir,
+                    pip_args,
+                    verbose,
+                    upgrade_strategy,
+                )
+                if len(package_specs) == 1:
+                    return EXIT_CODE_OK
+                venv_dir = None
+                continue
             else:
                 installed_version = venv.pipx_metadata.main_package.package_version
                 version_info = f" ({installed_version})" if installed_version else ""

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -447,6 +447,17 @@ def _add_install(subparsers: argparse._SubParsersAction, shared_parser: argparse
         help="Modify existing virtual environment and files in PIPX_BIN_DIR and PIPX_MAN_DIR",
     )
     p.add_argument(
+        "--upgrade",
+        "-U",
+        action="store_true",
+        help="Upgrade or downgrade an existing package when its version does not satisfy the supplied spec",
+    )
+    p.add_argument(
+        "--upgrade-strategy",
+        choices=["only-if-needed", "eager"],
+        help="How dependency upgrades are handled when --upgrade changes an existing package",
+    )
+    p.add_argument(
         "--suffix",
         default="",
         help="Optional suffix for virtual environment and executable names.",
@@ -477,6 +488,7 @@ def _cmd_install(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
         ctx.venv_args,
         ctx.verbose,
         force=args.force,
+        upgrade=args.upgrade,
         reinstall=False,
         include_dependencies=args.include_deps,
         preinstall_packages=args.preinstall,
@@ -484,6 +496,7 @@ def _cmd_install(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
         python_flag_passed=ctx.python_flag_passed,
         backend=ctx.backend,
         env_backend=ctx.env_backend,
+        upgrade_strategy=args.upgrade_strategy,
     )
 
 

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -16,6 +16,7 @@ from typing import Final
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.specifiers import SpecifierSet
 from packaging.utils import canonicalize_name
+from packaging.version import InvalidVersion
 
 from pipx.emojis import hazard
 from pipx.util import PipxError, pipx_wrap
@@ -237,6 +238,26 @@ def valid_pypi_name(package_spec: str) -> str | None:
     return canonicalize_name(package_req.name)
 
 
+def package_spec_satisfied(
+    package_spec: str,
+    package_name: str,
+    installed_version: str,
+    installed_spec: str,
+) -> bool:
+    """Return whether an installed package satisfies a named requirement."""
+    try:
+        requirement = Requirement(package_spec)
+        installed_requirement = Requirement(installed_spec)
+        return (
+            requirement.url is None
+            and canonicalize_name(requirement.name) == canonicalize_name(package_name)
+            and requirement.extras.issubset(installed_requirement.extras)
+            and requirement.specifier.contains(installed_version)
+        )
+    except (InvalidRequirement, InvalidVersion):
+        return False
+
+
 def fix_package_name(package_or_url: str, package_name: str) -> str:
     try:
         package_req = Requirement(package_or_url)
@@ -266,6 +287,7 @@ def fix_package_name(package_or_url: str, package_name: str) -> str:
 __all__ = [
     "fix_package_name",
     "get_extras",
+    "package_spec_satisfied",
     "parse_specifier_for_install",
     "parse_specifier_for_metadata",
     "parse_specifier_for_upgrade",

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -536,6 +536,7 @@ class Venv:
         include_apps: bool,
         is_main_package: bool,
         suffix: str = "",
+        upgrade_only_pip_args: list[str] | None = None,
     ) -> None:
         _LOGGER.info("Upgrading %s", package_descr := full_package_description(package_name, package_or_url))
         with animate(f"upgrading {package_descr}", self.do_animation):
@@ -543,7 +544,7 @@ class Venv:
                 venv_root=self.root,
                 venv_python=self.python_path,
                 requirements=[package_or_url],
-                pip_args=pip_args,
+                pip_args=[*(upgrade_only_pip_args or []), *pip_args],
                 upgrade=True,
                 log_pip_errors=False,
                 verbose=self.verbose,

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -166,6 +166,45 @@ def test_install_same_package_twice_no_force(pipx_temp_env, capsys):
     assert "0.0.0.2" in captured.out
 
 
+def test_install_upgrade_installs_missing_package(pipx_temp_env, capsys):
+    assert not run_pipx_cli(["install", "--upgrade", PKG["black"]["spec"]])
+    captured = capsys.readouterr()
+    assert "installed package black 22.8.0" in captured.out
+
+
+def test_install_upgrade_reconciles_package_spec(pipx_temp_env, capsys):
+    assert not run_pipx_cli(["install", PKG["black"]["spec"]])
+
+    assert not run_pipx_cli(["install", "--upgrade", "--upgrade-strategy=eager", "black==22.10.0"])
+    captured = capsys.readouterr()
+    assert "upgraded package black from 22.8.0 to 22.10.0" in captured.out
+    metadata = PipxMetadata(paths.ctx.venvs / "black").main_package
+    assert metadata.package_version == "22.10.0"
+    assert metadata.pip_args == []
+
+    assert not run_pipx_cli(["install", "--upgrade", "black<22.9"])
+    captured = capsys.readouterr()
+    assert "upgraded package black from 22.10.0 to 22.8.0" in captured.out
+    assert PipxMetadata(paths.ctx.venvs / "black").main_package.package_version == "22.8.0"
+
+
+def test_install_upgrade_satisfied_spec_is_offline(pipx_temp_env, capsys, mocker: "MockerFixture"):
+    assert not run_pipx_cli(["install", PKG["black"]["spec"]])
+    check_shared = mocker.patch.object(Venv, "check_upgrade_shared_libs", autospec=True)
+    upgrade_package = mocker.patch.object(Venv, "upgrade_package", autospec=True)
+
+    assert not run_pipx_cli(["install", "--upgrade", "black>=22,<23"])
+    captured = capsys.readouterr()
+    assert "black 22.8.0 already satisfies black>=22,<23" in captured.out
+    check_shared.assert_not_called()
+    upgrade_package.assert_not_called()
+
+
+def test_install_upgrade_strategy_requires_upgrade(pipx_temp_env, capsys):
+    assert run_pipx_cli(["install", "--upgrade-strategy=eager", PKG["black"]["spec"]])
+    assert "--upgrade-strategy requires --upgrade" in capsys.readouterr().err
+
+
 def test_install_existing_package_skips_shared_lib_maintenance(pipx_temp_env: None, mocker: "MockerFixture") -> None:
     assert run_pipx_cli(["install", PKG["pycowsay"]["spec"]]) == 0
     mocker.patch.object(shared_libs.shared_libs, "has_been_updated_this_run", False)

--- a/tests/test_package_specifier.py
+++ b/tests/test_package_specifier.py
@@ -4,6 +4,7 @@ import pytest
 
 from pipx.package_specifier import (
     fix_package_name,
+    package_spec_satisfied,
     parse_specifier_for_install,
     parse_specifier_for_metadata,
     parse_specifier_for_upgrade,
@@ -26,6 +27,22 @@ TEST_DATA_PATH = "./testdata/test_package_specifier"
 )
 def test_valid_pypi_name(package_spec_in, package_name_out):
     assert valid_pypi_name(package_spec_in) == package_name_out
+
+
+@pytest.mark.parametrize(
+    "package_spec,installed_spec,expected",
+    [
+        ("black>=22,<23", "black==22.8.0", True),
+        ("black<22", "black==22.8.0", False),
+        ("Black", "black==22.8.0", True),
+        ("black[colorama]", "black==22.8.0", False),
+        ("black[colorama]", "black[colorama]==22.8.0", True),
+        ("black @ https://example.com/black.whl", "black==22.8.0", False),
+        ("https://example.com/black.whl", "black==22.8.0", False),
+    ],
+)
+def test_package_spec_satisfied(package_spec, installed_spec, expected):
+    assert package_spec_satisfied(package_spec, "black", "22.8.0", installed_spec) is expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`pipx install --upgrade` now reconciles an app with the supplied package spec:

- installs the app when it is missing
- upgrades or downgrades when the installed version or extras do not satisfy the spec
- returns before maintenance or package-index work when the installed requirement already matches

`--upgrade-strategy` supports pip's `only-if-needed` and `eager` dependency behavior without persisting the one-shot option in pipx metadata.

Closes #1572.

- [x] ran the linter to address style issues (`pre-commit run --all-files`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `changelog.d/` folder (choose a type: `feature`, `bugfix`, `doc`, `removal`, or `misc`)
- [x] updated/extended the documentation