### PR TITLE
🐛 fix(uninject): handle locked Windows apps

### DIFF
--- a/changelog.d/1856.bugfix.27.md
+++ b/changelog.d/1856.bugfix.27.md
@@ -1,0 +1,1 @@
+Keep Windows uninject working while an exposed app runs.

--- a/src/pipx/commands/uninject.py
+++ b/src/pipx/commands/uninject.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from importlib import metadata
 from pathlib import Path
 
@@ -18,7 +17,7 @@ from pipx.constants import (
     ExitCode,
 )
 from pipx.emojis import stars
-from pipx.util import PipxError, pipx_wrap
+from pipx.util import PipxError, pipx_wrap, safe_unlink
 from pipx.venv import Venv
 from pipx.venv_inspect import fetch_info_in_venv, get_distributions_by_name, get_required_dependency_names
 
@@ -123,7 +122,7 @@ def uninject_dep(
     if need_app_uninstall:
         for path in new_resource_paths:
             try:
-                os.unlink(path)
+                safe_unlink(path)
             except FileNotFoundError:
                 logger.info(f"tried to remove but couldn't find {path}")
             else:

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -83,7 +83,7 @@ def safe_unlink(file: Path) -> None:
     # But it does let us rename/move it. To get around this issue, we can move
     # the file to a temporary folder (to be deleted at a later time)
 
-    if not file.is_file():
+    if not file.is_file() and not file.is_symlink():
         return
     try:
         file.unlink()

--- a/tests/test_uninject.py
+++ b/tests/test_uninject.py
@@ -1,8 +1,12 @@
+import subprocess
 from pathlib import Path
+
+import pytest
 
 from helpers import app_name, run_pipx_cli, skip_if_windows
 from package_info import PKG
 from pipx import paths
+from pipx.constants import WINDOWS
 
 
 def file_or_symlink(filepath: Path) -> bool:
@@ -37,6 +41,27 @@ def test_uninject_with_include_apps(pipx_temp_env, capsys, caplog):
     assert not run_pipx_cli(["inject", "pycowsay", PKG["black"]["spec"], "--include-deps", "--include-apps"])
     assert not run_pipx_cli(["uninject", "pycowsay", "black", "--verbose"])
     assert "removed file" in caplog.text
+
+
+@pytest.mark.skipif(not WINDOWS, reason="Windows-specific test")
+def test_uninject_running_app(pipx_temp_env: None) -> None:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    assert not run_pipx_cli(["inject", "pycowsay", PKG["black"]["spec"], "--include-apps"])
+    app = paths.ctx.bin_dir / app_name("black")
+
+    process = subprocess.Popen(
+        [app, "-"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        assert process.poll() is None
+        assert not run_pipx_cli(["uninject", "pycowsay", "black"])
+        assert not app.exists()
+    finally:
+        process.terminate()
+        process.wait(timeout=10)
 
 
 def test_uninject_with_suffix_removes_apps(pipx_temp_env: None, root: Path) -> None:


### PR DESCRIPTION
Uninjecting an included application on Windows can raise `PermissionError` when its executable is running, after pipx has removed the package from the managed environment. [Issue #1856](https://github.com/pypa/pipx/issues/1856) tracks the exposed-file failure.

`uninject` now routes copied executables through pipx's locked-file removal path, which moves an active executable to the trash. The same helper accepts symlinks so POSIX cleanup still removes an exposed link after its target disappears.
