### PR TITLE
🐛 fix(cli): reject Windows alternate paths

### DIFF
--- a/changelog.d/1856.bugfix.28.md
+++ b/changelog.d/1856.bugfix.28.md
@@ -1,0 +1,1 @@
+Reject both Windows path separators in package names.

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -235,8 +235,8 @@ def package_is_url(package: str, raise_error: bool = True) -> bool:
     return False
 
 
-def package_is_path(package: str):
-    if os.path.sep in package:
+def package_is_path(package: str) -> None:
+    if any(separator in package for separator in (os.path.sep, os.path.altsep) if separator):
         raise PipxError(
             pipx_wrap(
                 f"""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -97,6 +97,14 @@ def test_package_is_path_ignores_existing_directory(tmp_path, monkeypatch):
     main.package_is_path("commit-check")
 
 
+def test_package_is_path_rejects_forward_slash(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert run_pipx_cli(["uninstall", "namespace/package"])
+    assert "'namespace/package' looks like a path" in capsys.readouterr().err
+
+
 @pytest.mark.parametrize(
     ("missing_raw", "python_raw", "expected_option", "expected_invalid"),
     [


### PR DESCRIPTION
Windows accepts `/` as an alternate path separator, while pipx checks package arguments for `\` alone. A command such as `pipx uninstall namespace/package` treats the path as a managed package name instead of returning the existing path diagnostic. [Issue #1856](https://github.com/pypa/pipx/issues/1856) tracks this Windows branch.

Package validation now checks both the native and alternate path separators. Plain package names retain their existing handling.
