### PR TITLE
🐛 fix(standalone): support Windows ARM64

### DIFF
--- a/changelog.d/1856.bugfix.29.md
+++ b/changelog.d/1856.bugfix.29.md
@@ -1,0 +1,1 @@
+Support standalone Python downloads on Windows ARM64.

--- a/src/pipx/standalone_python.py
+++ b/src/pipx/standalone_python.py
@@ -40,7 +40,10 @@ MACHINE_SUFFIX: Final[dict[str, dict[str, Any]]] = {
             "musl": ["x86_64_v3-unknown-linux-musl-install_only.tar.gz"],
         },
     },
-    "Windows": {"AMD64": ["x86_64-pc-windows-msvc-install_only.tar.gz"]},
+    "Windows": {
+        "AMD64": ["x86_64-pc-windows-msvc-install_only.tar.gz"],
+        "ARM64": ["aarch64-pc-windows-msvc-install_only.tar.gz"],
+    },
 }
 
 GITHUB_API_URL: Final[str] = "https://api.github.com/repos/astral-sh/python-build-standalone/releases/latest"

--- a/tests/test_standalone_interpreter.py
+++ b/tests/test_standalone_interpreter.py
@@ -174,11 +174,11 @@ def test_download_standalone_python_rejects_unsafe_archive(
         standalone_python.download_python_build_standalone("3.99")
 
 
-@pytest.mark.skipif(not constants.WINDOWS, reason="Windows-specific test")
 def test_list_pythons_windows_arm64(
     mocked_github_api: None,
     mocker: MockerFixture,
 ) -> None:
+    mocker.patch.object(standalone_python.platform, "system", return_value="Windows")
     mocker.patch.object(standalone_python.platform, "machine", return_value="ARM64")
 
     assert standalone_python.list_pythons()["3.13.7"][0].endswith("aarch64-pc-windows-msvc-install_only.tar.gz")

--- a/tests/test_standalone_interpreter.py
+++ b/tests/test_standalone_interpreter.py
@@ -174,6 +174,16 @@ def test_download_standalone_python_rejects_unsafe_archive(
         standalone_python.download_python_build_standalone("3.99")
 
 
+@pytest.mark.skipif(not constants.WINDOWS, reason="Windows-specific test")
+def test_list_pythons_windows_arm64(
+    mocked_github_api: None,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch.object(standalone_python.platform, "machine", return_value="ARM64")
+
+    assert standalone_python.list_pythons()["3.13.7"][0].endswith("aarch64-pc-windows-msvc-install_only.tar.gz")
+
+
 def test_list_no_standalone_interpreters(pipx_temp_env, monkeypatch, capsys):
     assert not run_pipx_cli(["interpreter", "list"])
 


### PR DESCRIPTION
Python-build-standalone publishes Windows ARM64 archives for Python 3.11 and newer, but pipx maps Windows AMD64 alone. `pipx interpreter` and fetch-on-missing flows therefore report no available build on an ARM64 Windows host. [Issue #1856](https://github.com/pypa/pipx/issues/1856) tracks the missing platform mapping, and [upstream issue #386](https://github.com/astral-sh/python-build-standalone/issues/386) records the available releases.

pipx now maps Windows `ARM64` to upstream `aarch64-pc-windows-msvc` archives. Interpreter discovery still returns only published versions, so Python 3.10 retains the existing unavailable-build result.
