### PR TITLE
🐛 fix(run): preserve Windows console encoding

### DIFF
--- a/changelog.d/1423.bugfix.md
+++ b/changelog.d/1423.bugfix.md
@@ -1,0 +1,1 @@
+Preserve the terminal encoding for applications started by `pipx run`.

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -139,7 +139,7 @@ def get_site_packages(python: Path) -> Path:
     return path
 
 
-def _fix_subprocess_env(env: dict[str, str]) -> dict[str, str]:
+def _fix_subprocess_env(env: dict[str, str], *, force_utf8: bool = True) -> dict[str, str]:
     # Remove PYTHONPATH because some platforms (macOS with Homebrew) add pipx
     #   directories to it, and can make it appear to venvs as though pipx
     #   dependencies are in the venv path (#233)
@@ -150,9 +150,9 @@ def _fix_subprocess_env(env: dict[str, str]) -> dict[str, str]:
         env.pop(env_to_remove, None)
 
     env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
-    # Make sure that Python writes output in UTF-8
-    env["PYTHONIOENCODING"] = "utf-8"
-    env["PYTHONLEGACYWINDOWSSTDIO"] = "utf-8"
+    if force_utf8:
+        env["PYTHONIOENCODING"] = "utf-8"
+        env["PYTHONLEGACYWINDOWSSTDIO"] = "utf-8"
     # Make sure we install packages to venv, not to userbase or a custom target dir
     env["PIP_USER"] = "0"
     env.pop("PIP_TARGET", None)
@@ -389,7 +389,7 @@ def exec_app(
 
     if env is None:
         env = dict(os.environ)
-    env = _fix_subprocess_env(env)
+    env = _fix_subprocess_env(env, force_utf8=False)
 
     if extra_python_paths is not None:
         env["PYTHONPATH"] = os.path.pathsep.join(
@@ -402,17 +402,7 @@ def exec_app(
     _LOGGER.info(f"exec_app: {' '.join(str(c) for c in cmd)}")
 
     if WINDOWS:
-        sys.exit(
-            subprocess.run(
-                cmd,
-                env=env,
-                stdout=None,
-                stderr=None,
-                encoding="utf-8",
-                text=True,
-                check=False,
-            ).returncode
-        )
+        sys.exit(subprocess.run(cmd, env=env, check=False).returncode)
     else:
         os.execvpe(str(cmd[0]), [str(x) for x in cmd], env)
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -239,6 +239,43 @@ def test_run_without_requirements(caplog, pipx_temp_env, tmp_path):
     assert out.read_text() == test_str
 
 
+@pytest.mark.skipif(sys.platform != "win32", reason="requires Windows code pages")
+@pytest.mark.parametrize(
+    ("encoding", "script_text"),
+    [
+        pytest.param("cp850", 'print("äöü")', id="cp850-text"),
+        pytest.param(
+            "cp437",
+            'import sys; print("┏━┓" if sys.stdout.encoding == "utf-8" else "+-+")',
+            id="cp437-terminal-fallback",
+        ),
+    ],
+)
+def test_run_preserves_windows_console_encoding(tmp_path: Path, encoding: str, script_text: str) -> None:
+    script = tmp_path / "console_output.py"
+    script.write_text(script_text, encoding="utf-8")
+    env = os.environ | {
+        "PIPX_DEFAULT_BACKEND": "pip",
+        "PIPX_HOME": str(tmp_path / "pipx"),
+        "PYTHONIOENCODING": encoding,
+    }
+
+    direct_output = subprocess.run(
+        [sys.executable, script],
+        env=env,
+        stdout=subprocess.PIPE,
+        check=True,
+    ).stdout
+    pipx_output = subprocess.run(
+        [sys.executable, "-m", "pipx", "run", script],
+        env=env,
+        stdout=subprocess.PIPE,
+        check=True,
+    ).stdout
+
+    assert pipx_output == direct_output
+
+
 @mock.patch("os.execvpe", new=execvpe_mock)
 @pytest.mark.parametrize(
     "script_text, expected_output",

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -239,7 +239,6 @@ def test_run_without_requirements(caplog, pipx_temp_env, tmp_path):
     assert out.read_text() == test_str
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="requires Windows code pages")
 @pytest.mark.parametrize(
     ("encoding", "script_text"),
     [
@@ -251,7 +250,7 @@ def test_run_without_requirements(caplog, pipx_temp_env, tmp_path):
         ),
     ],
 )
-def test_run_preserves_windows_console_encoding(tmp_path: Path, encoding: str, script_text: str) -> None:
+def test_run_preserves_console_encoding(tmp_path: Path, encoding: str, script_text: str) -> None:
     script = tmp_path / "console_output.py"
     script.write_text(script_text, encoding="utf-8")
     env = os.environ | {

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -8,10 +8,31 @@ from typing import TYPE_CHECKING
 import pytest
 
 from pipx import paths
-from pipx.util import rmdir, run_subprocess, safe_unlink
+from pipx.util import exec_app, rmdir, run_subprocess, safe_unlink
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
+
+
+@pytest.mark.parametrize("windows", [pytest.param(False, id="posix"), pytest.param(True, id="windows")])
+def test_exec_app_preserves_stream_encoding(
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    windows: bool,
+) -> None:
+    monkeypatch.setattr("pipx.util.WINDOWS", windows)
+    env = {"PYTHONIOENCODING": "cp850", "PYTHONLEGACYWINDOWSSTDIO": "cp850"}
+    if windows:
+        boundary = mocker.patch("pipx.util.subprocess.run", autospec=True, side_effect=RuntimeError)
+    else:
+        boundary = mocker.patch("pipx.util.os.execvpe", autospec=True, side_effect=RuntimeError)
+
+    with pytest.raises(RuntimeError):
+        exec_app(["python"], env)
+
+    child_env = boundary.call_args.kwargs["env"] if windows else boundary.call_args.args[2]
+    assert child_env["PYTHONIOENCODING"] == "cp850"
+    assert child_env["PYTHONLEGACYWINDOWSSTDIO"] == "cp850"
 
 
 def test_rmdir_without_safe_rm_is_non_fatal_for_locked_files(


### PR DESCRIPTION
Closes #1423.

Closes #1358.

`pipx run` forces UTF-8 on the spawned application even when the Windows console uses an OEM code page. A CP850 console then interprets UTF-8 bytes as CP850, while terminal libraries choose UTF-8 glyphs instead of a console-safe set.

`exec_app` now preserves the parent stream settings when handing control to an application. Captured internal commands retain pipx's UTF-8 environment and decoding contract.
