### PR TITLE
🐛 fix(shared): serialize maintenance

### DIFF
--- a/changelog.d/1056.bugfix.md
+++ b/changelog.d/1056.bugfix.md
@@ -1,0 +1,1 @@
+Serialize shared-library maintenance across pipx processes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dynamic = [
 dependencies = [
   "argcomplete>=1.9.4",
   "colorama>=0.4.4; sys_platform=='win32'",
+  "filelock>=3.16",
   "packaging>=20",
   "platformdirs>=2.1",
   "tomli; python_version<'3.11'",

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -6,6 +6,8 @@ from configparser import ConfigParser
 from pathlib import Path
 from typing import Final
 
+from filelock import BaseFileLock, FileLock
+
 from pipx import paths
 from pipx.animate import animate
 from pipx.constants import WINDOWS
@@ -101,6 +103,14 @@ class _SharedLibs:
         return self._site_packages[self.python_path]
 
     def create(self, pip_args: list[str], verbose: bool = False) -> None:
+        with self._maintenance_lock():
+            self._create(pip_args, verbose)
+
+    def _maintenance_lock(self) -> BaseFileLock:
+        self.root.parent.mkdir(parents=True, exist_ok=True)
+        return FileLock(self.root.with_name(f".{self.root.name}.lock"))
+
+    def _create(self, pip_args: list[str], verbose: bool) -> None:
         if not self.is_valid:
             with animate("creating shared libraries", not verbose):
                 create_process = run_subprocess(
@@ -110,7 +120,7 @@ class _SharedLibs:
             self._is_valid = None
 
             # Reinstall pip so OS-vendor patches cannot enter the shared environment.
-            self.upgrade(pip_args=[*pip_args, "--force-reinstall"], verbose=verbose, raises=True)
+            self._upgrade(pip_args=[*pip_args, "--force-reinstall"], verbose=verbose, raises=True)
 
             # Remove setuptools before the .pth file exposes shared libraries to apps. Python <3.12 venvs bundle a
             # copy that fails under 3.12+ because the standard library no longer includes distutils.
@@ -155,8 +165,12 @@ class _SharedLibs:
         return time_since_last_update_sec > SHARED_LIBS_MAX_AGE_SEC
 
     def upgrade(self, *, pip_args: list[str], verbose: bool = False, raises: bool = False) -> None:
+        with self._maintenance_lock():
+            self._upgrade(pip_args=pip_args, verbose=verbose, raises=raises)
+
+    def _upgrade(self, *, pip_args: list[str], verbose: bool, raises: bool) -> None:
         if not self.is_valid:
-            self.create(verbose=verbose, pip_args=pip_args)
+            self._create(verbose=verbose, pip_args=pip_args)
             return
 
         if self.has_been_updated_this_run:

--- a/tests/test_shared_libs.py
+++ b/tests/test_shared_libs.py
@@ -2,7 +2,10 @@ import json
 import os
 import subprocess
 import time
+from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from threading import Event
 from unittest.mock import patch
 
 import pytest
@@ -121,6 +124,38 @@ def test_shared_libs_upgrade_enforces_pip_floor(
     run_subprocess.assert_called_once()
     assert "pip==20" in install_command
     assert "pip >= 23.1" in install_command
+
+
+def test_shared_libs_upgrade_serializes_concurrent_calls(
+    pipx_ultra_temp_env: None,
+    mocker: MockerFixture,
+) -> None:
+    shared_libs.shared_libs.create(verbose=True, pip_args=[])
+    shared_libs.shared_libs.has_been_updated_this_run = False
+    first_started = Event()
+    release_first = Event()
+    second_started = Event()
+
+    def run_upgrade(_command: Sequence[str | Path]) -> subprocess.CompletedProcess[str]:
+        if first_started.is_set():
+            second_started.set()
+        else:
+            first_started.set()
+            if not release_first.wait(5):
+                raise TimeoutError("concurrent shared library test did not release the first upgrade")
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+    mocker.patch("pipx.shared_libs.run_subprocess", autospec=True, side_effect=run_upgrade)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first_upgrade = executor.submit(shared_libs.shared_libs.upgrade, pip_args=[], verbose=True, raises=True)
+        assert first_started.wait(5)
+        second_upgrade = executor.submit(shared_libs.shared_libs.upgrade, pip_args=[], verbose=True, raises=True)
+        try:
+            assert not second_started.wait(0.5)
+        finally:
+            release_first.set()
+        first_upgrade.result(timeout=5)
+        second_upgrade.result(timeout=5)
 
 
 def test_venv_python_is_valid_non_windows() -> None:


### PR DESCRIPTION
[Issue #1056](https://github.com/pypa/pipx/issues/1056) reports concurrent pipx commands rebuilding or upgrading the shared pip environment together, which can make either command fail.

Shared-library creation and upgrade now acquire one cross-process file lock stored beside the shared environment. Keeping the lock outside the virtual environment allows `venv --clear` to rebuild that environment without deleting the lock, and the operating system releases the lock when the process exits.

This handles the shared-library race. Concurrent `list` during application installation remains tracked by #1056 and needs atomic environment publication.
