### PR TITLE
✨ feat(shared): allow skipping maintenance

### DIFF
--- a/changelog.d/1278.feature.md
+++ b/changelog.d/1278.feature.md
@@ -1,0 +1,1 @@
+Allow commands to skip shared-library maintenance.

--- a/docs/how-to/configure-paths.md
+++ b/docs/how-to/configure-paths.md
@@ -25,8 +25,9 @@ sudo PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin PIPX_MAN_DIR=/usr/local/sha
 sudo pipx install --global <PACKAGE>
 ```
 
-> [!NOTE] After version 1.2.0, the default pipx paths have been moved from `~/.local/pipx` to specific user data
-> directories on each platform using [platformdirs](https://pypi.org/project/platformdirs/) library
+> [!NOTE]
+> After version 1.2.0, the default pipx paths have been moved from `~/.local/pipx` to specific user data directories on
+> each platform using [platformdirs](https://pypi.org/project/platformdirs/) library
 >
 > | Old Path               | New Path                                   |
 > | ---------------------- | ------------------------------------------ |

--- a/docs/how-to/configure-paths.md
+++ b/docs/how-to/configure-paths.md
@@ -25,9 +25,8 @@ sudo PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin PIPX_MAN_DIR=/usr/local/sha
 sudo pipx install --global <PACKAGE>
 ```
 
-> [!NOTE]
-> After version 1.2.0, the default pipx paths have been moved from `~/.local/pipx` to specific user data directories on
-> each platform using [platformdirs](https://pypi.org/project/platformdirs/) library
+> [!NOTE] After version 1.2.0, the default pipx paths have been moved from `~/.local/pipx` to specific user data
+> directories on each platform using [platformdirs](https://pypi.org/project/platformdirs/) library
 >
 > | Old Path               | New Path                                   |
 > | ---------------------- | ------------------------------------------ |
@@ -99,6 +98,16 @@ in your shell profile or in pip's own config file (`pip.conf` / `pip.ini`). See 
 
 Set `PIPX_DISABLE_SHARED_LIBS_AUTO_UPGRADE=1` to skip automatic shared library upgrades during commands such as
 `pipx install` and `pipx upgrade`. The explicit `pipx upgrade-shared` command still upgrades the shared libraries.
+
+Use `--skip-maintenance` to apply the same policy to one command.
+
+```
+pipx install --skip-maintenance my-package
+```
+
+When pipx must create the shared environment, this policy keeps the pip version bundled with Python instead of
+downloading a replacement. It is not a general offline mode; pass pip options such as `--no-index` and `--find-links` to
+control where application packages come from.
 
 Per-command pip options can be passed with `--pip-args`:
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -48,6 +48,7 @@ from pipx.interpreter import (
 )
 from pipx.package_specifier import valid_pypi_name
 from pipx.result import OperationResult, render_result
+from pipx.shared_libs import skip_shared_libs_maintenance
 from pipx.util import PipxError, mkdir, pipx_wrap, rmdir
 from pipx.venv import VenvContainer
 from pipx.version import version as __version__
@@ -304,10 +305,11 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:
         backend=cli_backend,
         env_backend=env_backend,
     )
-    result = args.func(args, ctx)
-    if isinstance(result, OperationResult):
-        return render_result(result, json_output=getattr(args, "json", False), quiet=getattr(args, "quiet", 0))
-    return result
+    with skip_shared_libs_maintenance(getattr(args, "skip_maintenance", False)):
+        result = args.func(args, ctx)
+        if isinstance(result, OperationResult):
+            return render_result(result, json_output=getattr(args, "json", False), quiet=getattr(args, "quiet", 0))
+        return result
 
 
 def _validate_backend_available(cli_backend: str | None, env_backend: str | None) -> None:
@@ -916,7 +918,6 @@ def _add_list(subparsers: argparse._SubParsersAction, shared_parser: argparse.Ar
         action="store_true",
         help="List pinned packages only. Pass --include-injected at the same time to list injected packages that were pinned.",
     )
-    g.add_argument("--skip-maintenance", action="store_true", help="(deprecated) No-op")
     p.set_defaults(func=_cmd_list)
 
 
@@ -1212,6 +1213,12 @@ def get_command_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Ar
             "Give more output. May be used multiple times corresponding to the"
             " INFO, DEBUG and NOTSET logging levels. The count maxes out at 3."
         ),
+    )
+
+    shared_parser.add_argument(
+        "--skip-maintenance",
+        action="store_true",
+        help="Do not upgrade shared libraries; use bundled pip when creating them.",
     )
 
     if not constants.WINDOWS:

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -2,7 +2,10 @@ import datetime
 import logging
 import os
 import time
+from collections.abc import Generator
 from configparser import ConfigParser
+from contextlib import contextmanager
+from contextvars import ContextVar
 from pathlib import Path
 from typing import Final
 
@@ -25,10 +28,20 @@ logger = logging.getLogger(__name__)
 
 SHARED_LIBS_MAX_AGE_SEC: Final[float] = datetime.timedelta(days=30).total_seconds()
 DISABLE_SHARED_LIBS_AUTO_UPGRADE: Final[str] = "PIPX_DISABLE_SHARED_LIBS_AUTO_UPGRADE"
+_SKIP_MAINTENANCE: Final[ContextVar[bool]] = ContextVar("skip_maintenance", default=False)
 
 
 def shared_libs_auto_upgrade_disabled() -> bool:
-    return strtobool(os.getenv(DISABLE_SHARED_LIBS_AUTO_UPGRADE, "0"))
+    return _SKIP_MAINTENANCE.get() or strtobool(os.getenv(DISABLE_SHARED_LIBS_AUTO_UPGRADE, "0"))
+
+
+@contextmanager
+def skip_shared_libs_maintenance(enabled: bool) -> Generator[None, None, None]:
+    token = _SKIP_MAINTENANCE.set(enabled)
+    try:
+        yield
+    finally:
+        _SKIP_MAINTENANCE.reset(token)
 
 
 def _venv_python_is_valid(python_path: Path) -> bool:
@@ -102,15 +115,15 @@ class _SharedLibs:
 
         return self._site_packages[self.python_path]
 
-    def create(self, pip_args: list[str], verbose: bool = False) -> None:
+    def create(self, pip_args: list[str], verbose: bool = False, *, reinstall_pip: bool | None = None) -> None:
         with self._maintenance_lock():
-            self._create(pip_args, verbose)
+            self._create(pip_args, verbose, reinstall_pip)
 
     def _maintenance_lock(self) -> BaseFileLock:
         self.root.parent.mkdir(parents=True, exist_ok=True)
         return FileLock(self.root.with_name(f".{self.root.name}.lock"))
 
-    def _create(self, pip_args: list[str], verbose: bool) -> None:
+    def _create(self, pip_args: list[str], verbose: bool, reinstall_pip: bool | None = None) -> None:
         if not self.is_valid:
             with animate("creating shared libraries", not verbose):
                 create_process = run_subprocess(
@@ -119,8 +132,12 @@ class _SharedLibs:
             subprocess_post_check(create_process)
             self._is_valid = None
 
-            # Reinstall pip so OS-vendor patches cannot enter the shared environment.
-            self._upgrade(pip_args=[*pip_args, "--force-reinstall"], verbose=verbose, raises=True)
+            should_reinstall_pip = not shared_libs_auto_upgrade_disabled() if reinstall_pip is None else reinstall_pip
+            if should_reinstall_pip:
+                # Reinstall pip so OS-vendor patches cannot enter the shared environment.
+                self._upgrade(pip_args=[*pip_args, "--force-reinstall"], verbose=verbose, raises=True)
+            else:
+                logger.info("Skipping the shared pip reinstall because maintenance is disabled")
 
             # Remove setuptools before the .pth file exposes shared libraries to apps. Python <3.12 venvs bundle a
             # copy that fails under 3.12+ because the standard library no longer includes distutils.
@@ -170,7 +187,7 @@ class _SharedLibs:
 
     def _upgrade(self, *, pip_args: list[str], verbose: bool, raises: bool) -> None:
         if not self.is_valid:
-            self._create(verbose=verbose, pip_args=pip_args)
+            self._create(verbose=verbose, pip_args=pip_args, reinstall_pip=True)
             return
 
         if self.has_been_updated_this_run:
@@ -217,4 +234,5 @@ __all__ = [
     "SHARED_LIBS_MAX_AGE_SEC",
     "shared_libs",
     "shared_libs_auto_upgrade_disabled",
+    "skip_shared_libs_maintenance",
 ]

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,5 +1,6 @@
 import os
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -647,3 +648,28 @@ def test_install_quiet_flag(pipx_temp_env, capsys):
     assert "These apps are now" not in captured.out
     assert "done!" not in captured.out
     assert "done!" not in captured.err
+
+
+def test_install_skip_maintenance_without_index(
+    pipx_ultra_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    root: Path,
+    tmp_path: Path,
+) -> None:
+    wheelhouse = tmp_path / "wheelhouse"
+    wheelhouse.mkdir()
+    wheel = shutil.copy2(
+        next(
+            (root / ".pipx_tests" / "package_cache" / f"{sys.version_info.major}.{sys.version_info.minor}").glob(
+                "pycowsay-*.whl"
+            )
+        ),
+        wheelhouse,
+    )
+
+    assert not run_pipx_cli(
+        ["install", "--skip-maintenance", str(wheel), f"--pip-args=--no-index --find-links={wheelhouse}"]
+    )
+
+    assert "installed package pycowsay" in capsys.readouterr().out
+    assert not shared_libs.shared_libs_auto_upgrade_disabled()

--- a/tests/test_shared_libs.py
+++ b/tests/test_shared_libs.py
@@ -93,6 +93,16 @@ def test_shared_libs_create_preserves_pip_args(pipx_ultra_temp_env: None) -> Non
     assert (pip_args, shared_libs.shared_libs.is_valid) == (["--disable-pip-version-check"], True)
 
 
+def test_shared_libs_create_without_index_when_auto_upgrade_disabled(
+    pipx_ultra_temp_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(shared_libs.DISABLE_SHARED_LIBS_AUTO_UPGRADE, "1")
+
+    shared_libs.shared_libs.create(pip_args=["--no-index"])
+
+    assert shared_libs.shared_libs.is_valid
+
+
 def test_shared_libs_validity_check_is_cached(pipx_ultra_temp_env: None, mocker: MockerFixture) -> None:
     shared_libs.shared_libs.python_path.parent.mkdir(parents=True)
     shared_libs.shared_libs.python_path.touch()


### PR DESCRIPTION
[Issue #1278](https://github.com/pypa/pipx/issues/1278) reports that installing local wheels in a fresh pipx home still contacts an index. pipx force-reinstalls `pip>=23.1` while creating its shared environment. Before this change, `PIPX_DISABLE_SHARED_LIBS_AUTO_UPGRADE` covered an existing environment but not initialization.

The maintenance policy now keeps Python's bundled pip during shared-environment creation. A common `--skip-maintenance` option applies that policy to one command, with scoped state that resets after dispatch. An explicit `pipx upgrade-shared` still installs the managed pip version.

This option does not claim to disable every network path. Package source control remains with pip arguments such as `--no-index` and `--find-links`, as documented in the updated configuration guide.
