### PR TITLE
✨ feat(install): reconcile exact state

### DIFF
--- a/changelog.d/1538.feature.md
+++ b/changelog.d/1538.feature.md
@@ -1,0 +1,1 @@
+Add exact package and environment reconciliation.

--- a/docs/reference/examples.md
+++ b/docs/reference/examples.md
@@ -8,6 +8,7 @@ pipx install --fetch-python=missing --python 3.12 pycowsay
 pipx install --fetch-python=always --python 3.13 pycowsay
 pipx install --upgrade 'black>=22,<23'
 pipx install --upgrade --upgrade-strategy eager 'black>=22,<23'
+pipx install --exact --python /usr/local/bin/python3.12 'black==25.1.0'
 pipx install git+https://github.com/psf/black
 pipx install git+https://github.com/psf/black.git@branch-name
 pipx install git+https://github.com/psf/black.git@git-hash

--- a/docs/tutorial/install-applications.md
+++ b/docs/tutorial/install-applications.md
@@ -53,6 +53,22 @@ pipx installs the app when it is missing, upgrades or downgrades it when the ins
 range, and does not contact the package index when the installed version already satisfies the spec. Add
 `--upgrade-strategy eager` to also upgrade dependencies when the app itself needs to change.
 
+### Reconciling an installation for automation
+
+Use `--exact` when a script owns both the package request and its environment settings:
+
+```
+pipx install --exact --python /usr/local/bin/python3.12 "black==25.1.0"
+```
+
+pipx installs a missing package, checks mutable package specs for upgrades, and rebuilds the environment when settings
+differ from the request. If a rebuild fails, pipx restores the previous environment. Install options describe the
+desired state. Omitted options use defaults from the current pipx configuration and discard values an earlier install
+recorded. pipx retains injected packages as separate state.
+
+`--exact` does not accept `--preinstall` because pipx does not record preinstalled packages and cannot compare their
+requested state.
+
 ### Picking a Python interpreter
 
 Pass `--python` to install with a specific Python version. When that Python isn't on your `PATH`, pipx can download a

--- a/src/pipx/commands/__init__.py
+++ b/src/pipx/commands/__init__.py
@@ -5,6 +5,7 @@ from pipx.commands.install import install, install_all
 from pipx.commands.interpreter import list_interpreters, prune_interpreters, upgrade_interpreters
 from pipx.commands.list_packages import list_packages
 from pipx.commands.pin import pin, unpin
+from pipx.commands.reconcile import reconcile_install
 from pipx.commands.reinstall import reinstall, reinstall_all
 from pipx.commands.run import run
 from pipx.commands.run_pip import run_pip
@@ -22,6 +23,7 @@ __all__ = [
     "list_packages",
     "pin",
     "prune_interpreters",
+    "reconcile_install",
     "reinstall",
     "reinstall_all",
     "run",

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -30,10 +30,11 @@ def _upgrade_existing_venv(
     pip_args: list[str],
     verbose: bool,
     upgrade_strategy: str | None,
+    always_upgrade: bool,
 ) -> None:
     package_metadata = venv.pipx_metadata.main_package
     installed_version = package_metadata.package_version
-    if package_spec_satisfied(
+    if not always_upgrade and package_spec_satisfied(
         package_spec,
         package_name,
         installed_version,
@@ -110,6 +111,7 @@ def install(
     env_backend: str | None = None,
     upgrade: bool = False,
     upgrade_strategy: str | None = None,
+    always_upgrade: bool = False,
 ) -> ExitCode:
     """Returns pipx exit code."""
     # package_spec is anything pip-installable, including package_name, vcs spec,
@@ -182,6 +184,7 @@ def install(
                     pip_args,
                     verbose,
                     upgrade_strategy,
+                    always_upgrade,
                 )
                 if len(package_specs) == 1:
                     return EXIT_CODE_OK

--- a/src/pipx/commands/reconcile.py
+++ b/src/pipx/commands/reconcile.py
@@ -1,0 +1,142 @@
+from dataclasses import replace
+from pathlib import Path
+
+from packaging.utils import canonicalize_name
+
+from pipx import paths
+from pipx.backends import PIP, resolve_backend_name
+from pipx.commands.common import package_name_from_spec
+from pipx.commands.install import install
+from pipx.commands.reinstall import reinstall
+from pipx.constants import EXIT_CODE_OK, ExitCode
+from pipx.package_specifier import parse_specifier_for_install
+from pipx.reconcile import ReconcileAction, ToolRequest, ToolState, plan_tool_request
+from pipx.util import PipxError
+from pipx.venv import Venv, VenvContainer
+
+
+def reconcile_install(
+    package_specs: list[str],
+    local_bin_dir: Path,
+    local_man_dir: Path,
+    python: str,
+    pip_args: list[str],
+    venv_args: list[str],
+    verbose: bool,
+    *,
+    force: bool,
+    include_dependencies: bool,
+    preinstall_packages: list[str] | None,
+    suffix: str,
+    backend: str | None,
+    env_backend: str | None,
+    upgrade_strategy: str | None,
+) -> ExitCode:
+    if preinstall_packages:
+        raise PipxError("--exact does not support --preinstall because pipx does not record preinstalled packages")
+
+    venv_container = VenvContainer(paths.ctx.venvs)
+    for package_spec in package_specs:
+        package_name = package_name_from_spec(
+            package_spec,
+            python,
+            pip_args=pip_args,
+            verbose=verbose,
+            backend=backend,
+            env_backend=env_backend,
+        )
+        venv_dir = venv_container.get_venv_dir(f"{package_name}{suffix}")
+        normalized_package_spec, normalized_pip_args = parse_specifier_for_install(package_spec, pip_args)
+        requested_backend = (
+            PIP
+            if canonicalize_name(package_name) == PIP
+            else resolve_backend_name(cli_value=backend, env_value=env_backend)[0]
+        )
+        request = ToolRequest(
+            package_name=package_name,
+            package_spec=normalized_package_spec,
+            python=Path(python).resolve(),
+            backend=requested_backend,
+            pip_args=tuple(normalized_pip_args),
+            venv_args=tuple(venv_args),
+            include_dependencies=include_dependencies,
+        )
+        venv = Venv(venv_dir, verbose=verbose) if venv_dir.is_dir() and any(venv_dir.iterdir()) else None
+        state = _tool_state(venv) if venv is not None else None
+        plan = plan_tool_request(request, state)
+        if state is not None and state.pinned and plan.action is not ReconcileAction.NOOP:
+            raise PipxError(
+                f"pipx cannot reconcile pinned package {package_name}; run `pipx unpin {package_name}` first"
+            )
+        if plan.action is ReconcileAction.NOOP:
+            assert state is not None
+            assert venv is not None
+            if state.package_spec != normalized_package_spec:
+                venv.pipx_metadata.main_package = replace(
+                    venv.pipx_metadata.main_package,
+                    package_or_url=normalized_package_spec,
+                )
+                venv.pipx_metadata.write()
+            print(f"{package_name} {state.version} satisfies {package_spec}")
+        elif plan.action in (ReconcileAction.INSTALL, ReconcileAction.UPGRADE):
+            install(
+                venv_dir,
+                [package_name],
+                [package_spec],
+                local_bin_dir,
+                local_man_dir,
+                python,
+                pip_args,
+                venv_args,
+                verbose,
+                force=force if plan.action is ReconcileAction.INSTALL else False,
+                reinstall=False,
+                include_dependencies=include_dependencies,
+                preinstall_packages=None,
+                suffix=suffix,
+                python_flag_passed=True,
+                backend=requested_backend,
+                env_backend=None,
+                upgrade=plan.action is ReconcileAction.UPGRADE,
+                upgrade_strategy=upgrade_strategy if plan.action is ReconcileAction.UPGRADE else None,
+                always_upgrade=plan.action is ReconcileAction.UPGRADE,
+            )
+        else:
+            print(f"Reinstalling {package_name} to reconcile {', '.join(reason.value for reason in plan.reasons)}")
+            reinstall(
+                venv_dir=venv_dir,
+                local_bin_dir=local_bin_dir,
+                local_man_dir=local_man_dir,
+                python=python,
+                verbose=verbose,
+                python_flag_passed=True,
+                backend=requested_backend,
+                env_backend=None,
+                package_spec=package_spec,
+                pip_args=pip_args,
+                venv_args=venv_args,
+                include_dependencies=include_dependencies,
+            )
+    return EXIT_CODE_OK
+
+
+def _tool_state(venv: Venv) -> ToolState:
+    package = venv.pipx_metadata.main_package
+    if package.package is None:
+        raise PipxError(f"{venv.name} has no main package in its metadata")
+    return ToolState(
+        package_name=package.package,
+        package_spec=package.package_or_url or package.package,
+        version=package.package_version,
+        source_interpreter=venv.pipx_metadata.source_interpreter,
+        backend=venv.pipx_metadata.backend,
+        pip_args=tuple(package.pip_args),
+        venv_args=tuple(venv.pipx_metadata.venv_args),
+        include_dependencies=package.include_dependencies,
+        pinned=package.pinned,
+    )
+
+
+__all__ = [
+    "reconcile_install",
+]

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -82,6 +82,10 @@ def reinstall(
     python_flag_passed: bool = False,
     backend: str | None = None,
     env_backend: str | None = None,
+    package_spec: str | None = None,
+    pip_args: list[str] | None = None,
+    venv_args: list[str] | None = None,
+    include_dependencies: bool | None = None,
 ) -> ExitCode:
     """Returns pipx exit code."""
     if not venv_dir.exists():
@@ -104,10 +108,13 @@ def reinstall(
         pip_args=venv.pipx_metadata.main_package.pip_args, verbose=verbose, force_upgrade=force_reinstall_shared_libs
     )
 
-    if venv.pipx_metadata.main_package.package_or_url is not None:
-        package_or_url = venv.pipx_metadata.main_package.package_or_url
-    else:
-        package_or_url = venv.main_package_name
+    package_metadata = venv.pipx_metadata.main_package
+    package_or_url = package_spec or package_metadata.package_or_url or venv.main_package_name
+    install_pip_args = package_metadata.pip_args if pip_args is None else pip_args
+    install_venv_args = venv.pipx_metadata.venv_args if venv_args is None else venv_args
+    install_include_dependencies = (
+        package_metadata.include_dependencies if include_dependencies is None else include_dependencies
+    )
 
     if venv.pipx_metadata.main_package.pinned:
         raise PipxError(f"{error} Package {venv_dir} is pinned. Run `pipx unpin {venv_dir.name}` to unpin it first.")
@@ -129,12 +136,12 @@ def reinstall(
             local_bin_dir,
             local_man_dir,
             python,
-            venv.pipx_metadata.main_package.pip_args,
-            venv.pipx_metadata.venv_args,
+            install_pip_args,
+            install_venv_args,
             verbose,
             force=True,
             reinstall=True,
-            include_dependencies=venv.pipx_metadata.main_package.include_dependencies,
+            include_dependencies=install_include_dependencies,
             preinstall_packages=[],
             suffix=venv.pipx_metadata.main_package.suffix,
             python_flag_passed=python_flag_passed,

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -453,11 +453,17 @@ def _add_install(subparsers: argparse._SubParsersAction, shared_parser: argparse
         action="store_true",
         help="Modify existing virtual environment and files in PIPX_BIN_DIR and PIPX_MAN_DIR",
     )
-    p.add_argument(
+    reconcile_mode = p.add_mutually_exclusive_group()
+    reconcile_mode.add_argument(
         "--upgrade",
         "-U",
         action="store_true",
         help="Upgrade or downgrade an existing package when its version does not satisfy the supplied spec",
+    )
+    reconcile_mode.add_argument(
+        "--exact",
+        action="store_true",
+        help="Reconcile a package and environment with CLI options and pipx defaults",
     )
     p.add_argument(
         "--upgrade-strategy",
@@ -484,6 +490,25 @@ def _add_install(subparsers: argparse._SubParsersAction, shared_parser: argparse
 
 
 def _cmd_install(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
+    if args.upgrade_strategy is not None and not (args.upgrade or args.exact):
+        raise PipxError("--upgrade-strategy requires --upgrade or --exact")
+    if args.exact:
+        return commands.reconcile_install(
+            args.package_spec,
+            paths.ctx.bin_dir,
+            paths.ctx.man_dir,
+            ctx.python,
+            ctx.pip_args,
+            ctx.venv_args,
+            ctx.verbose,
+            force=args.force,
+            include_dependencies=args.include_deps,
+            preinstall_packages=args.preinstall,
+            suffix=args.suffix,
+            backend=ctx.backend,
+            env_backend=ctx.env_backend,
+            upgrade_strategy=args.upgrade_strategy,
+        )
     return commands.install(
         None,
         None,

--- a/src/pipx/reconcile.py
+++ b/src/pipx/reconcile.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
+
+from pipx.package_specifier import package_spec_satisfied
+from pipx.result import OperationData
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def plan_tool_request(request: ToolRequest, state: ToolState | None) -> ReconcilePlan:
+    if state is None:
+        return ReconcilePlan(ReconcileAction.INSTALL)
+
+    reasons: list[ReinstallReason] = []
+    if canonicalize_name(request.package_name) != canonicalize_name(state.package_name) or _package_shape_changed(
+        request, state
+    ):
+        reasons.append(ReinstallReason.PACKAGE_SPEC)
+    if state.source_interpreter is None or request.python.resolve() != state.source_interpreter.resolve():
+        reasons.append(ReinstallReason.PYTHON)
+    if request.backend != state.backend:
+        reasons.append(ReinstallReason.BACKEND)
+    if request.pip_args != state.pip_args:
+        reasons.append(ReinstallReason.PIP_ARGS)
+    if request.venv_args != state.venv_args:
+        reasons.append(ReinstallReason.VENV_ARGS)
+    if request.include_dependencies != state.include_dependencies:
+        reasons.append(ReinstallReason.INCLUDE_DEPENDENCIES)
+    if reasons:
+        return ReconcilePlan(ReconcileAction.REINSTALL, tuple(reasons))
+    if _fixed_version_satisfied(request, state):
+        return ReconcilePlan(ReconcileAction.NOOP)
+    return ReconcilePlan(ReconcileAction.UPGRADE)
+
+
+def _package_shape_changed(request: ToolRequest, state: ToolState) -> bool:
+    try:
+        requirement = Requirement(request.package_spec)
+        installed_requirement = Requirement(state.package_spec)
+    except InvalidRequirement:
+        return request.package_spec != state.package_spec
+    return (
+        canonicalize_name(requirement.name) != canonicalize_name(installed_requirement.name)
+        or requirement.extras != installed_requirement.extras
+        or requirement.url != installed_requirement.url
+    )
+
+
+def _fixed_version_satisfied(request: ToolRequest, state: ToolState) -> bool:
+    try:
+        requirement = Requirement(request.package_spec)
+    except InvalidRequirement:
+        return False
+    specifiers = list(requirement.specifier)
+    return (
+        len(specifiers) == 1
+        and specifiers[0].operator in ("==", "===")
+        and "*" not in specifiers[0].version
+        and package_spec_satisfied(
+            request.package_spec,
+            state.package_name,
+            state.version,
+            state.package_spec,
+        )
+    )
+
+
+class ReconcileAction(str, enum.Enum):
+    INSTALL = "install"
+    NOOP = "noop"
+    REINSTALL = "reinstall"
+    UPGRADE = "upgrade"
+
+
+class ReinstallReason(str, enum.Enum):
+    BACKEND = "backend"
+    INCLUDE_DEPENDENCIES = "include-dependencies"
+    PACKAGE_SPEC = "package-spec"
+    PIP_ARGS = "pip-args"
+    PYTHON = "python"
+    VENV_ARGS = "venv-args"
+
+
+@dataclass(frozen=True)
+class ToolRequest:
+    package_name: str
+    package_spec: str
+    python: Path
+    backend: str
+    pip_args: tuple[str, ...]
+    venv_args: tuple[str, ...]
+    include_dependencies: bool
+
+
+@dataclass(frozen=True)
+class ToolState:
+    package_name: str
+    package_spec: str
+    version: str
+    source_interpreter: Path | None
+    backend: str
+    pip_args: tuple[str, ...]
+    venv_args: tuple[str, ...]
+    include_dependencies: bool
+    pinned: bool
+
+
+@dataclass(frozen=True)
+class ReconcilePlan(OperationData):
+    action: ReconcileAction
+    reasons: tuple[ReinstallReason, ...] = ()
+
+
+__all__ = [
+    "ReconcileAction",
+    "ReconcilePlan",
+    "ReinstallReason",
+    "ToolRequest",
+    "ToolState",
+    "plan_tool_request",
+]

--- a/tests/test_backends_install.py
+++ b/tests/test_backends_install.py
@@ -7,6 +7,7 @@ import pytest
 
 from helpers import run_pipx_cli
 from pipx import paths
+from pipx.pipx_metadata_file import PipxMetadata
 
 
 def test_install_pip_with_uv_backend_errors(capsys: pytest.CaptureFixture[str]) -> None:
@@ -36,3 +37,12 @@ def test_uv_backend_install_uninstall_smoke(pipx_temp_env, capsys: pytest.Captur
     uninstall_rc = run_pipx_cli(["uninstall", "pycowsay"])
     assert uninstall_rc == 0
     assert not metadata_file.exists()
+
+
+@pytest.mark.skipif(shutil.which("uv") is None, reason="uv binary not on PATH; skipping uv integration smoke")
+def test_install_exact_reinstalls_backend_drift(pipx_temp_env: None) -> None:
+    assert not run_pipx_cli(["install", "pycowsay", "--backend", "pip", "--python", sys.executable])
+
+    assert not run_pipx_cli(["install", "--exact", "pycowsay", "--backend", "uv", "--python", sys.executable])
+
+    assert PipxMetadata(paths.ctx.venvs / "pycowsay").backend == "uv"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,3 +1,4 @@
+import json
 import os
 import re
 import shutil
@@ -12,6 +13,7 @@ import pytest
 from helpers import app_name, run_pipx_cli, skip_if_windows, unwrap_log_text
 from package_info import PKG
 from pipx import paths, shared_libs
+from pipx.interpreter import get_default_python
 from pipx.pipx_metadata_file import PipxMetadata
 from pipx.util import PipxError
 from pipx.venv import Venv
@@ -204,6 +206,129 @@ def test_install_upgrade_satisfied_spec_is_offline(pipx_temp_env, capsys, mocker
 def test_install_upgrade_strategy_requires_upgrade(pipx_temp_env, capsys):
     assert run_pipx_cli(["install", "--upgrade-strategy=eager", PKG["black"]["spec"]])
     assert "--upgrade-strategy requires --upgrade" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "python_args",
+    [
+        pytest.param([], id="default"),
+        pytest.param(["--python", sys.executable], id="explicit"),
+    ],
+)
+def test_install_exact_reinstalls_interpreter_drift(
+    installed_pycowsay: None,
+    tmp_path: Path,
+    python_args: list[str],
+) -> None:
+    metadata = PipxMetadata(paths.ctx.venvs / "pycowsay")
+    metadata.source_interpreter = tmp_path / "old-python"
+    metadata.write()
+
+    assert not run_pipx_cli(["install", "--exact", *python_args, PKG["pycowsay"]["spec"]])
+
+    assert PipxMetadata(paths.ctx.venvs / "pycowsay").source_interpreter == Path(
+        sys.executable if python_args else get_default_python()
+    )
+
+
+def test_install_exact_noop(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    capsys.readouterr()
+
+    return_code = run_pipx_cli(["install", "--exact", PKG["pycowsay"]["spec"]])
+
+    captured = capsys.readouterr()
+    assert (
+        return_code,
+        "pycowsay 0.0.0.2 satisfies pycowsay==0.0.0.2" in captured.out,
+        "uninstalled" in captured.out,
+        PipxMetadata(paths.ctx.venvs / "pycowsay").main_package.package_or_url,
+    ) == (0, True, False, PKG["pycowsay"]["spec"])
+
+
+def test_install_exact_installs_missing_package(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert not run_pipx_cli(["install", "--exact", "--upgrade-strategy", "eager", PKG["pycowsay"]["spec"]])
+
+    assert "installed package pycowsay 0.0.0.2" in capsys.readouterr().out
+
+
+def test_install_exact_reinstalls_venv_args(installed_pycowsay: None) -> None:
+    assert not run_pipx_cli(["install", "--exact", "--system-site-packages", PKG["pycowsay"]["spec"]])
+
+    assert PipxMetadata(paths.ctx.venvs / "pycowsay").venv_args == ["--system-site-packages"]
+
+
+def test_install_exact_reinstalls_dependency_exposure(installed_pycowsay: None) -> None:
+    assert not run_pipx_cli(["install", "--exact", "--include-deps", PKG["pycowsay"]["spec"]])
+
+    assert PipxMetadata(paths.ctx.venvs / "pycowsay").main_package.include_dependencies
+
+
+def test_install_exact_clears_pip_args(pipx_temp_env: None) -> None:
+    assert not run_pipx_cli(["install", "--pip-args=--no-cache-dir", PKG["pycowsay"]["spec"]])
+
+    assert not run_pipx_cli(["install", "--exact", PKG["pycowsay"]["spec"]])
+
+    assert PipxMetadata(paths.ctx.venvs / "pycowsay").main_package.pip_args == []
+
+
+def test_install_exact_upgrades_mutable_spec(pipx_temp_env: None) -> None:
+    assert not run_pipx_cli(["install", PKG["black"]["spec"]])
+
+    assert not run_pipx_cli(["install", "--exact", "black"])
+
+    assert PipxMetadata(paths.ctx.venvs / "black").main_package.package_version != "22.8.0"
+
+
+def test_install_exact_restores_failed_reinstall(
+    installed_pycowsay: None,
+    tmp_path: Path,
+) -> None:
+    metadata = PipxMetadata(paths.ctx.venvs / "pycowsay")
+    metadata.source_interpreter = tmp_path / "old-python"
+    metadata.write()
+
+    return_code = run_pipx_cli(["install", "--exact", "--python", sys.executable, "pycowsay==999"])
+
+    restored = PipxMetadata(paths.ctx.venvs / "pycowsay")
+    assert (return_code, restored.main_package.package_version, (paths.ctx.bin_dir / app_name("pycowsay")).exists()) == (
+        1,
+        "0.0.0.2",
+        True,
+    )
+
+
+def test_install_exact_rejects_pinned_change(installed_pycowsay: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert not run_pipx_cli(["pin", "pycowsay"])
+
+    return_code = run_pipx_cli(["install", "--exact", "pycowsay"])
+
+    assert (return_code, "pipx cannot reconcile pinned package pycowsay" in capsys.readouterr().err) == (1, True)
+
+
+def test_install_exact_rejects_unrecorded_preinstall(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+    return_code = run_pipx_cli(["install", "--exact", "--preinstall", "packaging", PKG["pycowsay"]["spec"]])
+
+    assert (return_code, "does not support --preinstall" in capsys.readouterr().err) == (1, True)
+
+
+def test_install_exact_rejects_missing_main_package(
+    installed_pycowsay: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    metadata_path = paths.ctx.venvs / "pycowsay" / "pipx_metadata.json"
+    metadata = json.loads(metadata_path.read_text())
+    metadata["main_package"]["package"] = None
+    metadata_path.write_text(json.dumps(metadata))
+
+    return_code = run_pipx_cli(["install", "--exact", PKG["pycowsay"]["spec"]])
+
+    assert (return_code, "pycowsay has no main package in its metadata" in capsys.readouterr().err) == (1, True)
+
+
+@pytest.fixture
+def installed_pycowsay(pipx_temp_env: None) -> None:
+    assert not run_pipx_cli(["install", PKG["pycowsay"]["spec"]])
 
 
 def test_install_existing_package_skips_shared_lib_maintenance(pipx_temp_env: None, mocker: "MockerFixture") -> None:

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1,0 +1,130 @@
+from dataclasses import replace
+from pathlib import Path
+from typing import Final
+
+import pytest
+
+from pipx.reconcile import (
+    ReconcileAction,
+    ReconcilePlan,
+    ReinstallReason,
+    ToolRequest,
+    ToolState,
+    plan_tool_request,
+)
+
+_REQUEST: Final[ToolRequest] = ToolRequest(
+    package_name="example",
+    package_spec="example==1.0",
+    python=Path("/python"),
+    backend="pip",
+    pip_args=(),
+    venv_args=(),
+    include_dependencies=False,
+)
+_STATE: Final[ToolState] = ToolState(
+    package_name="example",
+    package_spec="example==1.0",
+    version="1.0",
+    source_interpreter=Path("/python"),
+    backend="pip",
+    pip_args=(),
+    venv_args=(),
+    include_dependencies=False,
+    pinned=False,
+)
+
+
+def test_plan_tool_request_install() -> None:
+    assert plan_tool_request(_REQUEST, None) == ReconcilePlan(ReconcileAction.INSTALL)
+
+
+@pytest.mark.parametrize(
+    "package_spec",
+    [
+        pytest.param("example", id="unconstrained"),
+        pytest.param("example>=1", id="range"),
+        pytest.param("example==1.*", id="wildcard"),
+    ],
+)
+def test_plan_tool_request_mutable_spec_upgrades(package_spec: str) -> None:
+    assert plan_tool_request(replace(_REQUEST, package_spec=package_spec), _STATE) == ReconcilePlan(
+        ReconcileAction.UPGRADE
+    )
+
+
+def test_plan_tool_request_fixed_version_noop() -> None:
+    assert plan_tool_request(_REQUEST, _STATE) == ReconcilePlan(ReconcileAction.NOOP)
+
+
+def test_plan_tool_request_same_url_upgrades() -> None:
+    package_spec = "example @ https://example.invalid/example.whl"
+    assert plan_tool_request(
+        replace(_REQUEST, package_spec=package_spec), replace(_STATE, package_spec=package_spec)
+    ) == ReconcilePlan(ReconcileAction.UPGRADE)
+
+
+@pytest.mark.parametrize(
+    ("requested_spec", "installed_spec", "expected_plan"),
+    [
+        pytest.param("./example", "./example", ReconcilePlan(ReconcileAction.UPGRADE), id="same"),
+        pytest.param(
+            "./example",
+            "./other",
+            ReconcilePlan(ReconcileAction.REINSTALL, (ReinstallReason.PACKAGE_SPEC,)),
+            id="changed",
+        ),
+    ],
+)
+def test_plan_tool_request_paths(
+    requested_spec: str,
+    installed_spec: str,
+    expected_plan: ReconcilePlan,
+) -> None:
+    assert (
+        plan_tool_request(
+            replace(_REQUEST, package_spec=requested_spec),
+            replace(_STATE, package_spec=installed_spec),
+        )
+        == expected_plan
+    )
+
+
+@pytest.mark.parametrize(
+    "tool_state",
+    [
+        pytest.param(replace(_STATE, package_spec="example[feature]==1.0"), id="extras"),
+        pytest.param(
+            replace(_STATE, package_spec="example @ https://example.invalid/example.whl"),
+            id="source",
+        ),
+        pytest.param(replace(_STATE, package_name="other"), id="package-name"),
+    ],
+)
+def test_plan_tool_request_package_shape_reinstalls(tool_state: ToolState) -> None:
+    assert plan_tool_request(_REQUEST, tool_state) == ReconcilePlan(
+        ReconcileAction.REINSTALL,
+        (ReinstallReason.PACKAGE_SPEC,),
+    )
+
+
+@pytest.mark.parametrize(
+    ("tool_request", "reason"),
+    [
+        pytest.param(replace(_REQUEST, python=Path("/other-python")), ReinstallReason.PYTHON, id="python"),
+        pytest.param(replace(_REQUEST, backend="uv"), ReinstallReason.BACKEND, id="backend"),
+        pytest.param(replace(_REQUEST, pip_args=("--pre",)), ReinstallReason.PIP_ARGS, id="pip-args"),
+        pytest.param(
+            replace(_REQUEST, venv_args=("--system-site-packages",)),
+            ReinstallReason.VENV_ARGS,
+            id="venv-args",
+        ),
+        pytest.param(
+            replace(_REQUEST, include_dependencies=True),
+            ReinstallReason.INCLUDE_DEPENDENCIES,
+            id="include-dependencies",
+        ),
+    ],
+)
+def test_plan_tool_request_environment_drift_reinstalls(tool_request: ToolRequest, reason: ReinstallReason) -> None:
+    assert plan_tool_request(tool_request, _STATE) == ReconcilePlan(ReconcileAction.REINSTALL, (reason,))


### PR DESCRIPTION
Scripts inspect pipx state. The reporter in [#1538](https://github.com/pypa/pipx/issues/1538) asks for one command that chooses the operation and reaches the same package and environment state on fresh and existing machines.

`pipx install --exact` compares the request with recorded metadata. pipx sends mutable specs to the chosen backend and uses the existing reinstall backup transaction for environment drift. If the rebuild fails, pipx restores the previous environment; injected packages remain part of the installation.

Omitted options use defaults from the current pipx configuration. For a matching fixed spec, pipx skips the backend call and records the requested spec for later commands. pipx rejects `--preinstall` because it does not record preinstalled packages.
