### PR TITLE
✨ feat(install): guide library setup

### DIFF
--- a/changelog.d/1411.feature.md
+++ b/changelog.d/1411.feature.md
@@ -1,0 +1,1 @@
+Point library install errors to `inject` and `--preinstall`.

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -317,11 +317,8 @@ def get_exposed_paths_for_package(
     symlinks = set()
     for b in local_resource_dir.iterdir():
         try:
-            # sometimes symlinks can resolve to a file of a different name
-            # (in the case of ansible for example) so checking the resolved paths
-            # is not a reliable way to determine if the symlink exists.
-            # We always use the stricter check on non-Windows systems. On
-            # Windows, we use a less strict check if we don't have a symlink.
+            # Some apps expose symlinks whose names differ from their targets, so resolved paths cannot identify them.
+            # Windows setups without symlink support fall back to package resource names.
             is_same_file = False
             if can_symlink(local_resource_dir) and b.is_symlink():
                 is_same_file = b.resolve().parent.samefile(venv_resource_path)
@@ -443,14 +440,19 @@ def run_post_install_actions(
         package_name = display_name
 
     if not package_metadata.apps:
+        library_name = package_metadata.package or package_name
+        library_guidance = (
+            "`pipx install` requires an application entry point. "
+            f"Add this package to an existing environment with `pipx inject <environment> {library_name}`. "
+            f"For a new application environment, place `--preinstall {library_name}` before the application spec."
+        )
         if not package_metadata.apps_of_dependencies:
             if venv.safe_to_remove():
                 venv.remove_venv()
             raise PipxError(
                 f"""
                 No apps associated with package {display_name} or its
-                dependencies. If you are attempting to install a library, pipx
-                should not be used. Consider using pip or a similar tool instead.
+                dependencies. {library_guidance}
                 """
             )
         if package_metadata.apps_of_dependencies and not include_dependencies:
@@ -467,9 +469,7 @@ def run_post_install_actions(
                 f"""
                 No apps associated with package {display_name}. Try again
                 with '--include-deps' to include apps of dependent packages,
-                which are listed above. If you are attempting to install a
-                library, pipx should not be used. Consider using pip or a
-                similar tool instead.
+                which are listed above. {library_guidance}
                 """
             )
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -152,10 +152,37 @@ def test_force_install_does_not_record_internal_pip_args(pipx_temp_env: None) ->
     ) == (0, [])
 
 
-def test_install_no_packages_found(pipx_temp_env, capsys):
-    run_pipx_cli(["install", PKG["pygdbmi"]["spec"]])
-    captured = capsys.readouterr()
-    assert "No apps associated with package pygdbmi" in captured.err
+@pytest.mark.parametrize(
+    ("package_name", "display_name", "install_args", "has_dependency_apps"),
+    [
+        pytest.param(
+            "pygdbmi",
+            "pygdbmi_test",
+            [PKG["pygdbmi"]["spec"], "--suffix=_test"],
+            False,
+            id="library-with-suffix",
+        ),
+        pytest.param("jupyter", "jupyter", [PKG["jupyter"]["spec"]], True, id="dependency-apps"),
+    ],
+)
+def test_install_no_apps_guidance(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    package_name: str,
+    display_name: str,
+    install_args: list[str],
+    has_dependency_apps: bool,
+) -> None:
+    return_code = run_pipx_cli(["install", *install_args])
+
+    error = capsys.readouterr().err
+    assert (
+        return_code,
+        f"No apps associated with package {display_name}" in error,
+        f"pipx inject <environment> {package_name}" in error,
+        f"--preinstall {package_name}" in error,
+        "Try again with '--include-deps'" in error,
+    ) == (1, True, True, True, has_dependency_apps)
 
 
 def test_install_same_package_twice_no_force(pipx_temp_env, capsys):
@@ -224,8 +251,7 @@ def test_install_existing_package_skips_shared_lib_maintenance(pipx_temp_env: No
     run_subprocess.assert_not_called()
 
 
-def test_include_deps(pipx_temp_env, capsys):
-    assert run_pipx_cli(["install", PKG["jupyter"]["spec"]]) == 1
+def test_include_deps(pipx_temp_env: None) -> None:
     assert not run_pipx_cli(["install", PKG["jupyter"]["spec"], "--include-deps"])
 
 


### PR DESCRIPTION
The error sends users to another installer. Packages without application entry points can belong inside a pipx-managed environment; the reporter in [#1411](https://github.com/pypa/pipx/issues/1411) asks pipx to name the supported path.

The error points an existing environment to `pipx inject <environment> <package>` and a new application install to `--preinstall <package>`. pipx keeps `--include-deps` as the first hint when dependencies expose applications. The package name stays unsuffixed.
