### PR TITLE
Install pipx manpage from wheels

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,7 +70,7 @@ jobs:
       - name: 📖 Build man page
         run: tox run -e man
       - name: Show man page
-        run: man -l pipx.1
+        run: man -l build/man/pipx.1
   zipapp:
     name: 📦 Build zipapp
     runs-on: ubuntu-24.04

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,9 +41,12 @@ repos:
         args: ['--warn-unused-ignores', '--strict-equality', '--no-implicit-optional', '--check-untyped-defs']
         exclude: 'testdata/test_package_specifier/(local_extras|local_manpage)/setup.py'
         additional_dependencies:
+          - "docutils>=0.21"
+          - "hatchling>=1.27"
           - "mkdocs-gen-files"
           - "nox"
           - "packaging>=20"
+          - "types-docutils>=0.21"
           - "platformdirs>=2.1"
           - "pytest"
           - "pytest-mock"

--- a/changelog.d/1657.feature.md
+++ b/changelog.d/1657.feature.md
@@ -1,0 +1,1 @@
+Install the generated pipx manual page from wheels.

--- a/docs/man/pipx.1.rst
+++ b/docs/man/pipx.1.rst
@@ -1,0 +1,133 @@
+:orphan:
+
+====
+pipx
+====
+
+------------------------------------------------------------
+install and run Python applications in isolated environments
+------------------------------------------------------------
+
+:Manual section: 1
+:Manual group: User Commands
+
+SYNOPSIS
+--------
+
+**pipx** [*global-options*] [**install** | **install-all** | **uninject** | **inject** | **pin** | **unpin** |
+**upgrade** | **upgrade-all** | **upgrade-shared** | **uninstall** | **uninstall-all** | **reinstall** | **reinstall-
+all** | **list** | **interpreter** | **run** | **runpip** | **ensurepath** | **environment** | **completions** |
+**help**] [*command-options*]
+
+DESCRIPTION
+-----------
+
+pipx installs and runs Python applications in isolated environments while exposing their commands on your
+``PATH``.
+
+COMMANDS
+--------
+
+**install**
+    Install a package
+
+**install-all**
+    Install all packages
+
+**uninject**
+    Uninstall injected packages from an existing Virtual Environment
+
+**inject**
+    Install packages into an existing Virtual Environment
+
+**pin**
+    Pin the specified package to prevent it from being upgraded
+
+**unpin**
+    Unpin the specified package
+
+**upgrade**
+    Upgrade a package
+
+**upgrade-all**
+    Upgrade all packages. Runs ``pip install -U <pkgname>`` for each package.
+
+**upgrade-shared**
+    Upgrade shared libraries.
+
+**uninstall**
+    Uninstall a package
+
+**uninstall-all**
+    Uninstall all packages
+
+**reinstall**
+    Reinstall a package
+
+**reinstall-all**
+    Reinstall all packages
+
+**list**
+    List installed packages
+
+**interpreter**
+    Interact with interpreters managed by pipx
+
+**run**
+    Download the latest version of a package to a temporary virtual environment, then run an app from it. Also
+    compatible with local ``__pypackages__`` directory (experimental).
+
+**runpip**
+    Run pip in an existing pipx-managed Virtual Environment
+
+**ensurepath**
+    Ensure directories necessary for pipx operation are in your PATH environment variable.
+
+**environment**
+    Print a list of environment variables and paths used by pipx.
+
+**completions**
+    Print instructions on enabling shell completions for pipx
+
+**help**
+    Show help for pipx or a command
+
+Run **pipx** *command* **--help** for command-specific options.
+
+GLOBAL OPTIONS
+--------------
+
+**-h**, **--help**
+    show this help message and exit
+
+**--version**
+    Print version and exit
+
+ENVIRONMENT VARIABLES
+---------------------
+
+**PIPX_HOME**
+    Directory for pipx-managed environments and state.
+
+**PIPX_BIN_DIR**
+    Directory where pipx exposes application commands.
+
+**PIPX_DEFAULT_PYTHON**
+    Default interpreter used to create environments.
+
+**PIPX_USE_EMOJI**
+    Set to ``0`` to disable emoji output.
+
+SEE ALSO
+--------
+
+Full documentation: https://pipx.pypa.io/
+
+**pip**\(1), **virtualenv**\(1)
+
+AUTHORS
+-------
+
+Chad Smith and contributors
+
+https://github.com/pypa/pipx

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TypeVar
+
+from docutils.core import publish_string
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+
+class CustomBuildHook(BuildHookInterface):
+    def initialize(self, _version: str, _build_data: dict[str, _BuildDataValue]) -> None:
+        if self.target_name != "wheel":
+            return
+
+        root = Path(self.root)
+        (output := root / "build" / "man").mkdir(parents=True, exist_ok=True)
+        source = "\n".join(
+            line
+            for line in (root / "docs" / "man" / "pipx.1.rst").read_text(encoding="utf-8").splitlines()
+            if line.strip() != ":orphan:"
+        )
+        (output / "pipx.1").write_bytes(publish_string(source, writer="manpage", settings_overrides={"report_level": 5}))
+
+
+_BuildDataValue = TypeVar("_BuildDataValue")
+
+
+__all__ = [
+    "CustomBuildHook",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 build-backend = "hatchling.build"
 requires = [
+  "docutils>=0.21",
   "hatch-vcs>=0.4",
   "hatchling>=1.27",
 ]
@@ -62,6 +63,7 @@ dev = [
   { include-group = "test" },
 ]
 test = [
+  "docutils>=0.21",
   "pypiserver[cache,passlib]>=2.3.2",
   "pytest>=8",
   "pytest-cov>=4",
@@ -84,7 +86,7 @@ lint = [
   "pre-commit>=3",
 ]
 man = [
-  "argparse-manpage[setuptools]",
+  "docutils>=0.21",
 ]
 zipapp = [
   "shiv>=1.0.6",
@@ -92,9 +94,13 @@ zipapp = [
 
 [tool.hatch]
 version.source = "vcs"
+build.hooks.custom = {}
 build.hooks.vcs.version-file = "src/pipx/version.py"
+build.targets.wheel.shared-data = { "build/man" = "share/man/man1" }
 build.targets.sdist.include = [
   "/*.md",
+  "/docs/man",
+  "/hatch_build.py",
   "/logo.png",
   "/pipx_demo.gif",
   "/src",

--- a/scripts/check_distribution_manpage.py
+++ b/scripts/check_distribution_manpage.py
@@ -1,0 +1,53 @@
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+from docutils.core import publish_string
+
+
+def main() -> None:
+    distribution_dir = Path(sys.argv[1])
+    rst = Path(sys.argv[2]).read_text(encoding="utf-8")
+    generated_manpage = publish_string(
+        "\n".join(line for line in rst.splitlines() if line.strip() != ":orphan:"),
+        writer="manpage",
+        settings_overrides={"report_level": 5},
+    )
+    _check_source_archive(distribution_dir, rst.encode())
+    _check_wheel(distribution_dir, generated_manpage)
+
+
+def _check_source_archive(distribution_dir: Path, rst: bytes) -> None:
+    source_archive_path = _require_one(list(distribution_dir.glob("pipx-*.tar.gz")), "source archive", distribution_dir)
+    with tarfile.open(source_archive_path) as source_archive:
+        sources = [member for member in source_archive.getmembers() if member.name.endswith("/docs/man/pipx.1.rst")]
+        if len(sources) != 1:
+            raise SystemExit(f"Missing docs/man/pipx.1.rst from {source_archive_path.name}")
+        extracted_source = source_archive.extractfile(sources[0])
+        if extracted_source is None or extracted_source.read() != rst:
+            raise SystemExit(f"Manpage source differs in {source_archive_path.name}")
+
+
+def _require_one(paths: list[Path], description: str, distribution_dir: Path) -> Path:
+    if len(paths) != 1:
+        raise SystemExit(f"Expected one pipx {description} in {distribution_dir}; found {len(paths)}")
+    return paths[0]
+
+
+def _check_wheel(distribution_dir: Path, generated_manpage: bytes) -> None:
+    wheel_path = _require_one(list(distribution_dir.glob("pipx-*.whl")), "wheel", distribution_dir)
+
+    with zipfile.ZipFile(wheel_path) as wheel:
+        manpages = [name for name in wheel.namelist() if name.endswith(".data/data/share/man/man1/pipx.1")]
+        if len(manpages) != 1:
+            raise SystemExit(
+                f"Wheel {wheel_path.name} has no manual page at share/man/man1/pipx.1, "
+                "so installers cannot place it in the target shared-data directory"
+            )
+        if wheel.read(manpages[0]) != generated_manpage:
+            raise SystemExit(f"Manual page in {wheel_path.name} differs from generated output")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_man.py
+++ b/scripts/generate_man.py
@@ -1,43 +1,140 @@
 #!/usr/bin/env python3
 
-import os.path
+import os
 import sys
 import textwrap
-from typing import cast
-
-from build_manpages.manpage import Manpage  # type: ignore[import-not-found]
-
-from pipx.main import get_command_parser
+from argparse import SUPPRESS, Action, ArgumentParser, _SubParsersAction  # argparse has no public subparser type.
+from pathlib import Path
 
 
-def main():
+def main() -> None:
+    documented_python = os.environ.get("PIPX__DOC_DEFAULT_PYTHON")
+    os.environ["PIPX__DOC_DEFAULT_PYTHON"] = "python3"
+    original_program = sys.argv[0]
     sys.argv[0] = "pipx"
-    parser, _ = get_command_parser()
-    parser.man_short_description = cast("str", parser.description).splitlines()[1]  # type: ignore[attr-defined]
+    try:
+        from pipx.main import get_command_parser  # noqa: PLC0415  # pipx reads the documentation environment on import.
 
-    manpage = Manpage(parser)
-    body = str(manpage)
+        parser, _ = get_command_parser()
+    finally:
+        sys.argv[0] = original_program
+        if documented_python is None:
+            os.environ.pop("PIPX__DOC_DEFAULT_PYTHON")
+        else:
+            os.environ["PIPX__DOC_DEFAULT_PYTHON"] = documented_python
 
-    # Avoid hardcoding build paths in manpages (and improve readability)
-    body = body.replace(os.path.expanduser("~").replace("-", "\\-"), "~")
+    output = Path(sys.argv[1] if len(sys.argv) > 1 else "docs/man/pipx.1.rst")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(_generate_manpage_rst(parser), encoding="utf-8")
 
-    # Add a credit section
-    body += textwrap.dedent(
-        """
-        .SH AUTHORS
-        .IR pipx (1)
-        was written by Chad Smith and contributors.
-        The project can be found online at
-        .UR https://pipx.pypa.io
-        .UE
-        .SH SEE ALSO
-        .IR pip (1),
-        .IR virtualenv (1)
-        """
-    )
 
-    with open("pipx.1", "w") as f:
-        f.write(body)
+def _generate_manpage_rst(parser: ArgumentParser) -> str:
+    commands = _get_subcommands(parser)
+    synopsis_commands = " | ".join(f"**{name}**" for name, _ in commands)
+    lines = [
+        ":orphan:",
+        "",
+        "====",
+        "pipx",
+        "====",
+        "",
+        "-" * 60,
+        "install and run Python applications in isolated environments",
+        "-" * 60,
+        "",
+        ":Manual section: 1",
+        ":Manual group: User Commands",
+        "",
+        "SYNOPSIS",
+        "--------",
+        "",
+        *textwrap.wrap(f"**pipx** [*global-options*] [{synopsis_commands}] [*command-options*]", width=120),
+        "",
+        "DESCRIPTION",
+        "-----------",
+        "",
+        "pipx installs and runs Python applications in isolated environments while exposing their commands on your",
+        "``PATH``.",
+        "",
+    ]
+    lines.extend(_commands_section(commands))
+    lines.extend(_global_options_section(parser))
+    lines.extend(_static_sections())
+    return "\n".join(lines) + "\n"
+
+
+def _get_subcommands(parser: ArgumentParser) -> list[tuple[str, str]]:
+    if parser._subparsers is None:
+        return []
+    for action in parser._subparsers._actions:
+        if isinstance(action, _SubParsersAction):
+            return [(choice.dest, choice.help or "") for choice in action._choices_actions]
+    return []
+
+
+def _commands_section(commands: list[tuple[str, str]]) -> list[str]:
+    lines = ["COMMANDS", "--------", ""]
+    for name, help_text in commands:
+        lines.append(f"**{name}**")
+        lines.extend(f"    {line}" for line in textwrap.wrap(help_text.replace("`", "``"), width=116))
+        lines.append("")
+    lines.extend(["Run **pipx** *command* **--help** for command-specific options.", ""])
+    return lines
+
+
+def _global_options_section(parser: ArgumentParser) -> list[str]:
+    lines = ["GLOBAL OPTIONS", "--------------", ""]
+    seen: set[int] = set()
+    for action in parser._actions:
+        if id(action) in seen or action.help == SUPPRESS or isinstance(action, _SubParsersAction):
+            continue
+        seen.add(id(action))
+        if option := _format_option(action):
+            lines.extend([option, f"    {action.help}", ""])
+    return lines
+
+
+def _format_option(action: Action) -> str:
+    if not action.option_strings or not action.help:
+        return ""
+    option = ", ".join(f"**{value}**" for value in action.option_strings)
+    if action.metavar:
+        metavar = action.metavar if isinstance(action.metavar, str) else action.metavar[0]
+        option += f" *{metavar}*"
+    return option
+
+
+def _static_sections() -> list[str]:
+    return [
+        "ENVIRONMENT VARIABLES",
+        "---------------------",
+        "",
+        "**PIPX_HOME**",
+        "    Directory for pipx-managed environments and state.",
+        "",
+        "**PIPX_BIN_DIR**",
+        "    Directory where pipx exposes application commands.",
+        "",
+        "**PIPX_DEFAULT_PYTHON**",
+        "    Default interpreter used to create environments.",
+        "",
+        "**PIPX_USE_EMOJI**",
+        "    Set to ``0`` to disable emoji output.",
+        "",
+        "SEE ALSO",
+        "--------",
+        "",
+        "Full documentation: https://pipx.pypa.io/",
+        "",
+        r"**pip**\(1), **virtualenv**\(1)",
+        "",
+        "AUTHORS",
+        "-------",
+        "",
+        "Chad Smith and contributors",
+        "",
+        "https://github.com/pypa/pipx",
+    ]
 
 
 if __name__ == "__main__":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,11 +1,21 @@
 import argparse
+import os
+import re
+import shutil
+import subprocess
 import sys
+from pathlib import Path
+from typing import Final
 from unittest import mock
 
 import pytest
+from docutils.core import publish_string
 
 from helpers import run_pipx_cli
 from pipx import constants, main
+
+_ROOT: Final = Path(__file__).parents[1]
+_MANPAGE_RST: Final = _ROOT / "docs" / "man" / "pipx.1.rst"
 
 
 def test_help_text(monkeypatch, capsys):
@@ -69,6 +79,53 @@ def test_all_subcommands_have_func_registered():
         for nested in (a for a in subparser._actions if isinstance(a, argparse._SubParsersAction)):
             for sub_name, sub_parser in nested.choices.items():
                 assert callable(sub_parser._defaults.get("func")), f"{sub_name!r} missing callable func default"
+
+
+def test_manpage_matches_parser(tmp_path: Path) -> None:
+    generated = tmp_path / "pipx.1.rst"
+    subprocess.run([sys.executable, str(_ROOT / "scripts" / "generate_man.py"), str(generated)], check=True)
+    assert _MANPAGE_RST.read_bytes() == generated.read_bytes()
+
+
+def test_manpage_sections(manpage_troff: bytes) -> None:
+    assert re.findall(r"^\.SH (.+)$", manpage_troff.decode(), re.MULTILINE) == [
+        "Name",
+        "SYNOPSIS",
+        "DESCRIPTION",
+        "COMMANDS",
+        "GLOBAL OPTIONS",
+        "ENVIRONMENT VARIABLES",
+        "SEE ALSO",
+        "AUTHORS",
+    ]
+
+
+def test_manpage_header(manpage_troff: bytes) -> None:
+    assert re.search(r'^\.TH "pipx" "1" .* "User Commands"$', manpage_troff.decode(), re.MULTILINE)
+
+
+@pytest.mark.skipif(shutil.which("man") is None, reason="man is not installed")
+def test_manpage_renders(manpage_troff: bytes, tmp_path: Path) -> None:
+    manpage = tmp_path / "pipx.1"
+    manpage.write_bytes(manpage_troff)
+    result = subprocess.run(
+        ["man", str(manpage)],
+        capture_output=True,
+        text=True,
+        env=os.environ | {"COLUMNS": "200", "MANPAGER": "cat", "PAGER": "cat"},
+        check=False,
+        timeout=5,
+    )
+    rendered = re.sub(r".\x08", "", result.stdout)
+    assert (result.returncode, "pipx" in rendered.lower(), "SYNOPSIS" in rendered) == (0, True, True)
+
+
+@pytest.fixture
+def manpage_troff() -> bytes:
+    source = "\n".join(
+        line for line in _MANPAGE_RST.read_text(encoding="utf-8").splitlines() if line.strip() != ":orphan:"
+    )
+    return publish_string(source, writer="manpage", settings_overrides={"report_level": 5})
 
 
 @pytest.mark.parametrize(

--- a/tox.toml
+++ b/tox.toml
@@ -66,9 +66,18 @@ commands = [
 
 [env.man]
 description = "build man page"
+package = "editable"
 dependency_groups = ["man"]
+allowlist_externals = ["uv"]
 commands = [
-  ["python", "scripts/generate_man.py"],
+  ["python", "scripts/generate_man.py", "{tox_root}{/}docs{/}man{/}pipx.1.rst"],
+  ["uv", "build", "--out-dir", "{env_tmp_dir}{/}dist"],
+  [
+    "python",
+    "scripts/check_distribution_manpage.py",
+    "{env_tmp_dir}{/}dist",
+    "{tox_root}{/}docs{/}man{/}pipx.1.rst",
+  ],
 ]
 
 [env.zipapp]


### PR DESCRIPTION
Maintainers had to run `scripts/generate_man.py` before building a distribution, so published wheels omitted `pipx.1` and `man pipx` failed after installation ([#1657](https://github.com/pypa/pipx/issues/1657)).

tox maintainers settled the packaging layout in [tox-dev/tox#3911](https://github.com/tox-dev/tox/pull/3911). `scripts/generate_man.py` writes committed RST from the parser. Hatch converts the RST to roff and maps `build/man` to `share/man/man1` in the wheel.

The build hook does not import pipx, so Hatch can run it before writing `pipx.version`.
