### PR TITLE
🐛 fix(cli): use per-environment state locks

### DIFF
--- a/changelog.d/1056.bugfix.2.md
+++ b/changelog.d/1056.bugfix.2.md
@@ -1,0 +1,1 @@
+Wait for an installation before listing its environment.

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -3,6 +3,7 @@ import sys
 from collections.abc import Iterator
 from pathlib import Path
 
+from filelock import BaseFileLock
 from packaging.utils import canonicalize_name
 
 from pipx import commands, paths
@@ -110,6 +111,7 @@ def install(
     env_backend: str | None = None,
     upgrade: bool = False,
     upgrade_strategy: str | None = None,
+    venv_lock: BaseFileLock | None = None,
 ) -> ExitCode:
     """Returns pipx exit code."""
     # package_spec is anything pip-installable, including package_name, vcs spec,
@@ -134,109 +136,108 @@ def install(
             for package_spec in package_specs
         ]
 
+    venv_container = VenvContainer(venv_dir.parent if venv_dir is not None else paths.ctx.venvs)
     for package_name, package_spec in zip(package_names, package_specs, strict=False):
         if venv_dir is None:
-            venv_container = VenvContainer(paths.ctx.venvs)
             venv_dir = venv_container.get_venv_dir(f"{package_name}{suffix}")
 
-        try:
-            exists = venv_dir.exists() and bool(next(venv_dir.iterdir()))
-        except StopIteration:
-            exists = False
+        with venv_lock or venv_container.venv_lock(venv_dir):
+            try:
+                exists = venv_dir.exists() and bool(next(venv_dir.iterdir()))
+            except StopIteration:
+                exists = False
 
-        # ``pipx install pip`` always uses pip (uv venvs ship no pip). Override
-        # only the implicit env path; ``--backend uv`` still falls through to
-        # ``assert_not_pip_under_uv`` so an explicit conflict fails loudly.
-        install_backend, install_env_backend = backend, env_backend
-        if canonicalize_name(package_name) == "pip":
-            install_backend = backend or PIP
-            install_env_backend = None
+            # ``pipx install pip`` always uses pip (uv venvs ship no pip). Override
+            # only the implicit env path; ``--backend uv`` still falls through to
+            # ``assert_not_pip_under_uv`` so an explicit conflict fails loudly.
+            install_backend, install_env_backend = backend, env_backend
+            if canonicalize_name(package_name) == "pip":
+                install_backend = backend or PIP
+                install_env_backend = None
 
-        venv = Venv(
-            venv_dir,
-            python=python,
-            verbose=verbose,
-            backend=install_backend,
-            env_backend=install_env_backend,
-        )
-        if exists:
-            if not reinstall and force and python_flag_passed:
-                print(
-                    pipx_wrap(
-                        f"""
-                        --python is ignored when --force is passed.
-                        If you want to reinstall {package_name} with {python},
-                        run `pipx reinstall {package_spec} --python {python}` instead.
-                        """
+            venv = Venv(
+                venv_dir,
+                python=python,
+                verbose=verbose,
+                backend=install_backend,
+                env_backend=install_env_backend,
+            )
+            if exists:
+                if not reinstall and force and python_flag_passed:
+                    print(
+                        pipx_wrap(
+                            f"""
+                            --python is ignored when --force is passed.
+                            If you want to reinstall {package_name} with {python},
+                            run `pipx reinstall {package_spec} --python {python}` instead.
+                            """
+                        )
                     )
+                if force:
+                    print(f"Installing to existing venv {venv.name!r}")
+                elif upgrade:
+                    _upgrade_existing_venv(
+                        venv,
+                        package_name,
+                        package_spec,
+                        local_bin_dir,
+                        local_man_dir,
+                        pip_args,
+                        verbose,
+                        upgrade_strategy,
+                    )
+                    if len(package_specs) == 1:
+                        return EXIT_CODE_OK
+                    venv_dir = None
+                    continue
+                else:
+                    installed_version = venv.pipx_metadata.main_package.package_version
+                    version_info = f" ({installed_version})" if installed_version else ""
+                    print(
+                        pipx_wrap(
+                            f"""
+                            {venv.name!r}{version_info} already seems to be installed. Not
+                            modifying existing installation in '{venv_dir}'.
+                            Pass '--force' to force installation, or use
+                            'pipx upgrade {venv.name}' to upgrade.
+                            """
+                        )
+                    )
+                    if len(package_specs) == 1:
+                        return EXIT_CODE_INSTALL_VENV_EXISTS
+                    venv_dir = None
+                    continue
+
+            venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
+            try:
+                override_shared = canonicalize_name(package_name) == "pip"
+                venv.create_venv(venv_args, pip_args, override_shared)
+                for dependency in preinstall_packages or []:
+                    venv.upgrade_package_no_metadata(dependency, [])
+                venv.install_package(
+                    package_name=package_name,
+                    package_or_url=package_spec,
+                    pip_args=pip_args,
+                    install_only_pip_args=["--force-reinstall"] if force and exists else None,
+                    include_dependencies=include_dependencies,
+                    include_apps=True,
+                    is_main_package=True,
+                    suffix=suffix,
                 )
-            if force:
-                print(f"Installing to existing venv {venv.name!r}")
-            elif upgrade:
-                _upgrade_existing_venv(
+                run_post_install_actions(
                     venv,
                     package_name,
-                    package_spec,
                     local_bin_dir,
                     local_man_dir,
-                    pip_args,
-                    verbose,
-                    upgrade_strategy,
+                    venv_dir,
+                    include_dependencies,
+                    force=force,
                 )
-                if len(package_specs) == 1:
-                    return EXIT_CODE_OK
-                venv_dir = None
-                continue
-            else:
-                installed_version = venv.pipx_metadata.main_package.package_version
-                version_info = f" ({installed_version})" if installed_version else ""
-                print(
-                    pipx_wrap(
-                        f"""
-                        {venv.name!r}{version_info} already seems to be installed. Not
-                        modifying existing installation in '{venv_dir}'.
-                        Pass '--force' to force installation, or use
-                        'pipx upgrade {venv.name}' to upgrade.
-                        """
-                    )
-                )
-                if len(package_specs) == 1:
-                    return EXIT_CODE_INSTALL_VENV_EXISTS
-                # Reset venv_dir to None ready to install the next package in the list
-                venv_dir = None
-                continue
+            except (Exception, KeyboardInterrupt):
+                print()
+                venv.remove_venv()
+                raise
 
-        venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
-        try:
-            override_shared = canonicalize_name(package_name) == "pip"
-            venv.create_venv(venv_args, pip_args, override_shared)
-            for dependency in preinstall_packages or []:
-                venv.upgrade_package_no_metadata(dependency, [])
-            venv.install_package(
-                package_name=package_name,
-                package_or_url=package_spec,
-                pip_args=pip_args,
-                install_only_pip_args=["--force-reinstall"] if force and exists else None,
-                include_dependencies=include_dependencies,
-                include_apps=True,
-                is_main_package=True,
-                suffix=suffix,
-            )
-            run_post_install_actions(
-                venv,
-                package_name,
-                local_bin_dir,
-                local_man_dir,
-                venv_dir,
-                include_dependencies,
-                force=force,
-            )
-        except (Exception, KeyboardInterrupt):
-            print()
-            venv.remove_venv()
-            raise
-
-        # Reset venv_dir to None ready to install the next package in the list
         venv_dir = None
 
     # Any failure to install will raise PipxError, otherwise success
@@ -310,42 +311,41 @@ def install_all(
     installed: list[str] = []
 
     for venv_metadata in extract_venv_metadata(spec_metadata_file):
-        # Install the main package
         main_package = venv_metadata.main_package
         venv_dir = venv_container.get_venv_dir(f"{main_package.package}{main_package.suffix}")
         try:
-            install(
-                venv_dir,
-                None,
-                [generate_package_spec(main_package)],
-                local_bin_dir,
-                local_man_dir,
-                python or get_python_interpreter(venv_metadata.source_interpreter),
-                pip_args,
-                venv_args,
-                verbose,
-                force=force,
-                reinstall=False,
-                include_dependencies=main_package.include_dependencies,
-                preinstall_packages=[],
-                suffix=main_package.suffix,
-                backend=backend or venv_metadata.backend,
-                env_backend=env_backend,
-            )
-
-            # Install the injected packages
-            for inject_package in venv_metadata.injected_packages.values():
-                commands.inject(
-                    venv_dir=venv_dir,
-                    package_specs=[generate_package_spec(inject_package)],
-                    requirement_files=[],
-                    pip_args=pip_args,
-                    verbose=verbose,
-                    include_apps=inject_package.include_apps,
-                    include_dependencies=inject_package.include_dependencies,
+            with venv_container.venv_lock(venv_dir) as venv_lock:
+                install(
+                    venv_dir,
+                    None,
+                    [generate_package_spec(main_package)],
+                    local_bin_dir,
+                    local_man_dir,
+                    python or get_python_interpreter(venv_metadata.source_interpreter),
+                    pip_args,
+                    venv_args,
+                    verbose,
                     force=force,
-                    suffix=inject_package.suffix == main_package.suffix,
+                    reinstall=False,
+                    include_dependencies=main_package.include_dependencies,
+                    preinstall_packages=[],
+                    suffix=main_package.suffix,
+                    backend=backend or venv_metadata.backend,
+                    env_backend=env_backend,
+                    venv_lock=venv_lock,
                 )
+                for inject_package in venv_metadata.injected_packages.values():
+                    commands.inject(
+                        venv_dir=venv_dir,
+                        package_specs=[generate_package_spec(inject_package)],
+                        requirement_files=[],
+                        pip_args=pip_args,
+                        verbose=verbose,
+                        include_apps=inject_package.include_apps,
+                        include_dependencies=inject_package.include_dependencies,
+                        force=force,
+                        suffix=inject_package.suffix == main_package.suffix,
+                    )
         except PipxError as e:
             print(e, file=sys.stderr)
             failed.append(venv_dir.name)

--- a/src/pipx/commands/interpreter.py
+++ b/src/pipx/commands/interpreter.py
@@ -21,9 +21,10 @@ def get_installed_standalone_interpreters() -> list[Path]:
 def get_venvs_using_standalone_interpreter(venv_container: VenvContainer) -> list[Venv]:
     venvs: list[Venv] = []
     for venv_dir in venv_container.iter_venv_dirs():
-        venv = Venv(venv_dir)
-        if venv.pipx_metadata.source_interpreter:
-            venvs.append(venv)
+        with venv_container.venv_lock(venv_dir):
+            venv = Venv(venv_dir)
+            if venv.pipx_metadata.source_interpreter:
+                venvs.append(venv)
     return venvs
 
 
@@ -127,17 +128,20 @@ def upgrade_interpreters(venv_container: VenvContainer, verbose: bool) -> consta
                 if venv.pipx_metadata.source_interpreter is not None and is_paths_relative(
                     venv.pipx_metadata.source_interpreter, interpreter_dir
                 ):
-                    print(
-                        f"Upgrade the interpreter of {venv.name} from {interpreter_full_version} to {latest_micro_version}"
-                    )
-                    commands.reinstall(
-                        venv_dir=venv.root,
-                        local_bin_dir=paths.ctx.bin_dir,
-                        local_man_dir=paths.ctx.man_dir,
-                        python=str(interpreter_python),
-                        verbose=verbose,
-                    )
-                    upgraded.append((venv.name, interpreter_full_version, latest_micro_version))
+                    with venv_container.venv_lock(venv.root) as venv_lock:
+                        print(
+                            f"Upgrade the interpreter of {venv.name} from "
+                            f"{interpreter_full_version} to {latest_micro_version}"
+                        )
+                        commands.reinstall(
+                            venv_dir=venv.root,
+                            local_bin_dir=paths.ctx.bin_dir,
+                            local_man_dir=paths.ctx.man_dir,
+                            python=str(interpreter_python),
+                            verbose=verbose,
+                            venv_lock=venv_lock,
+                        )
+                        upgraded.append((venv.name, interpreter_full_version, latest_micro_version))
 
     if upgraded:
         print("Successfully upgraded the interpreter(s):")

--- a/src/pipx/commands/list_packages.py
+++ b/src/pipx/commands/list_packages.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import sys
-from collections.abc import Collection
+from collections.abc import Collection, Iterable, Iterator
 from pathlib import Path
 from typing import Any
 
@@ -28,7 +28,7 @@ def get_venv_metadata_summary(venv_dir: Path) -> tuple[PipxMetadata, VenvProblem
     return (venv.pipx_metadata, venv_problems, "")
 
 
-def list_short(venv_dirs: Collection[Path]) -> VenvProblems:
+def list_short(venv_dirs: Iterable[Path]) -> VenvProblems:
     all_venv_problems = VenvProblems()
     for venv_dir in venv_dirs:
         venv_metadata, venv_problems, warning_str = get_venv_metadata_summary(venv_dir)
@@ -44,7 +44,7 @@ def list_short(venv_dirs: Collection[Path]) -> VenvProblems:
     return all_venv_problems
 
 
-def list_text(venv_dirs: Collection[Path], include_injected: bool, venv_root_dir: str) -> VenvProblems:
+def list_text(venv_dirs: Iterable[Path], include_injected: bool, venv_root_dir: str) -> VenvProblems:
     print(f"venvs are in {bold(venv_root_dir)}")
     print(f"apps are exposed on your $PATH at {bold(str(paths.ctx.bin_dir))}")
     print(f"manual pages are exposed at {bold(str(paths.ctx.man_dir))}")
@@ -61,7 +61,7 @@ def list_text(venv_dirs: Collection[Path], include_injected: bool, venv_root_dir
     return all_venv_problems
 
 
-def list_json(venv_dirs: Collection[Path]) -> VenvProblems:
+def list_json(venv_dirs: Iterable[Path]) -> VenvProblems:
     warning_messages = []
     spec_metadata: dict[str, Any] = {
         "pipx_spec_version": PIPX_SPEC_VERSION,
@@ -85,7 +85,7 @@ def list_json(venv_dirs: Collection[Path]) -> VenvProblems:
     return all_venv_problems
 
 
-def list_pinned(venv_dirs: Collection[Path], include_injected: bool) -> VenvProblems:
+def list_pinned(venv_dirs: Iterable[Path], include_injected: bool) -> VenvProblems:
     all_venv_problems = VenvProblems()
     for venv_dir in venv_dirs:
         venv_metadata, venv_problems, warning_str = get_venv_metadata_summary(venv_dir)
@@ -119,15 +119,17 @@ def list_packages(
         print(f"nothing has been installed with pipx {sleep}", file=sys.stderr)
 
     if json_format:
-        all_venv_problems = list_json(venv_dirs)
+        all_venv_problems = list_json(_locked_venv_dirs(venv_container, venv_dirs))
     elif short_format:
-        all_venv_problems = list_short(venv_dirs)
+        all_venv_problems = list_short(_locked_venv_dirs(venv_container, venv_dirs))
     elif pinned_only:
-        all_venv_problems = list_pinned(venv_dirs, include_injected)
+        all_venv_problems = list_pinned(_locked_venv_dirs(venv_container, venv_dirs), include_injected)
     else:
         if not venv_dirs:
             return EXIT_CODE_OK
-        all_venv_problems = list_text(venv_dirs, include_injected, str(venv_container))
+        all_venv_problems = list_text(
+            _locked_venv_dirs(venv_container, venv_dirs), include_injected, str(venv_container)
+        )
 
     if all_venv_problems.bad_venv_name:
         logger.warning(
@@ -156,3 +158,15 @@ def list_packages(
         return EXIT_CODE_LIST_PROBLEM
 
     return EXIT_CODE_OK
+
+
+def _locked_venv_dirs(venv_container: VenvContainer, venv_dirs: Collection[Path]) -> Iterator[Path]:
+    for venv_dir in venv_dirs:
+        with venv_container.venv_lock(venv_dir):
+            if venv_dir.is_dir():
+                yield venv_dir
+
+
+__all__ = [
+    "list_packages",
+]

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 from pathlib import Path
 from tempfile import mkdtemp
 
+from filelock import BaseFileLock
 from packaging.utils import canonicalize_name
 
 from pipx.commands.common import add_suffix
@@ -82,6 +83,7 @@ def reinstall(
     python_flag_passed: bool = False,
     backend: str | None = None,
     env_backend: str | None = None,
+    venv_lock: BaseFileLock | None = None,
 ) -> ExitCode:
     """Returns pipx exit code."""
     if not venv_dir.exists():
@@ -140,6 +142,7 @@ def reinstall(
             python_flag_passed=python_flag_passed,
             backend=backend or venv.pipx_metadata.backend,
             env_backend=env_backend,
+            venv_lock=venv_lock,
         )
 
         # now install injected packages
@@ -200,17 +203,19 @@ def reinstall_all(
         if venv_dir.name in skip:
             continue
         try:
-            reinstall(
-                venv_dir=venv_dir,
-                local_bin_dir=local_bin_dir,
-                local_man_dir=local_man_dir,
-                python=python,
-                verbose=verbose,
-                force_reinstall_shared_libs=first_reinstall,
-                python_flag_passed=python_flag_passed,
-                backend=backend,
-                env_backend=env_backend,
-            )
+            with venv_container.venv_lock(venv_dir) as venv_lock:
+                reinstall(
+                    venv_dir=venv_dir,
+                    local_bin_dir=local_bin_dir,
+                    local_man_dir=local_man_dir,
+                    python=python,
+                    verbose=verbose,
+                    force_reinstall_shared_libs=first_reinstall,
+                    python_flag_passed=python_flag_passed,
+                    backend=backend,
+                    env_backend=env_backend,
+                    venv_lock=venv_lock,
+                )
         except PipxError as e:
             print(e, file=sys.stderr)
             failed.append(venv_dir.name)

--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -42,7 +42,8 @@ def uninstall_all(
     messages: list[OutputMessage] = []
     packages: list[_UninstalledPackage] = []
     for venv_dir in venv_container.iter_venv_dirs():
-        result = uninstall(venv_dir, local_bin_dir, local_man_dir, verbose)
+        with venv_container.venv_lock(venv_dir):
+            result = uninstall(venv_dir, local_bin_dir, local_man_dir, verbose)
         failures.extend(result.data.failures)
         messages.extend(result.messages)
         packages.extend(result.data.packages)

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -6,6 +6,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Final
 
+from filelock import BaseFileLock
+
 from pipx import commands, paths
 from pipx.colors import bold, red
 from pipx.commands.common import expose_resources_globally
@@ -182,6 +184,7 @@ def _upgrade_venv(
     env_backend: str | None = None,
     venv: Venv | None = None,
     shared_libs_already_checked: bool = False,
+    venv_lock: BaseFileLock | None = None,
 ) -> tuple[PackageUpgradeResult, ...]:
     """Return package upgrade results.
 
@@ -209,6 +212,7 @@ def _upgrade_venv(
                 python_flag_passed=python_flag_passed,
                 backend=backend,
                 env_backend=env_backend,
+                venv_lock=venv_lock,
             )
             return ()
         else:
@@ -297,21 +301,23 @@ def upgrade(
     results: list[PackageUpgradeResult] = []
 
     for venv_dir in venv_dirs.values():
-        results.extend(
-            _upgrade_venv(
-                venv_dir,
-                pip_args,
-                verbose,
-                include_injected=include_injected,
-                force=force,
-                install=install,
-                venv_args=venv_args,
-                python=python,
-                python_flag_passed=python_flag_passed,
-                backend=backend,
-                env_backend=env_backend,
+        with VenvContainer(venv_dir.parent).venv_lock(venv_dir) as venv_lock:
+            results.extend(
+                _upgrade_venv(
+                    venv_dir,
+                    pip_args,
+                    verbose,
+                    include_injected=include_injected,
+                    force=force,
+                    install=install,
+                    venv_args=venv_args,
+                    python=python,
+                    python_flag_passed=python_flag_passed,
+                    backend=backend,
+                    env_backend=env_backend,
+                    venv_lock=venv_lock,
+                )
             )
-        )
 
     package_results = tuple(results)
     return OperationResult(
@@ -346,30 +352,32 @@ def upgrade_all(
         if venv_dir.name in skip:
             skipped.append(SkippedUpgrade(venv_dir.name, "requested"))
             continue
-        venv = Venv(venv_dir, verbose=verbose, backend=backend, env_backend=env_backend)
-        if "--editable" in venv.pipx_metadata.main_package.pip_args:
-            skipped.append(SkippedUpgrade(venv_dir.name, "editable"))
-            continue
-        venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
-        try:
-            package_results = _upgrade_venv(
-                venv_dir,
-                pip_args,
-                verbose=verbose,
-                include_injected=include_injected,
-                force=force,
-                python_flag_passed=python_flag_passed,
-                backend=backend,
-                env_backend=env_backend,
-                venv=venv,
-                shared_libs_already_checked=True,
-            )
-            results.extend(package_results)
-            for result in package_results:
-                messages.extend(_package_messages(result, upgrading_all=True))
-        except PipxError as e:
-            failures.append(FailedUpgrade(venv_dir.name, str(e)))
-            messages.append(OutputMessage(str(e), stream=OutputStream.STDERR, level=OutputLevel.ERROR))
+        with venv_container.venv_lock(venv_dir) as venv_lock:
+            venv = Venv(venv_dir, verbose=verbose, backend=backend, env_backend=env_backend)
+            if "--editable" in venv.pipx_metadata.main_package.pip_args:
+                skipped.append(SkippedUpgrade(venv_dir.name, "editable"))
+                continue
+            venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
+            try:
+                package_results = _upgrade_venv(
+                    venv_dir,
+                    pip_args,
+                    verbose=verbose,
+                    include_injected=include_injected,
+                    force=force,
+                    python_flag_passed=python_flag_passed,
+                    backend=backend,
+                    env_backend=env_backend,
+                    venv=venv,
+                    shared_libs_already_checked=True,
+                    venv_lock=venv_lock,
+                )
+                results.extend(package_results)
+                for result in package_results:
+                    messages.extend(_package_messages(result, upgrading_all=True))
+            except PipxError as e:
+                failures.append(FailedUpgrade(venv_dir.name, str(e)))
+                messages.append(OutputMessage(str(e), stream=OutputStream.STDERR, level=OutputLevel.ERROR))
     if not any(result.status is UpgradeStatus.UPGRADED for result in results):
         messages.append(OutputMessage(f"No packages upgraded after running 'pipx upgrade-all' {sleep}"))
     if failures:

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -599,19 +599,21 @@ def _add_inject(subparsers, venv_completer: VenvCompleter, shared_parser: argpar
 
 
 def _cmd_inject(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
-    return commands.inject(
-        _venv_dir(args, ctx),
-        args.dependencies,
-        args.requirements,
-        ctx.pip_args,
-        verbose=ctx.verbose,
-        include_apps=args.include_apps,
-        include_dependencies=args.include_deps,
-        force=args.force,
-        suffix=args.with_suffix,
-        backend=ctx.backend,
-        env_backend=ctx.env_backend,
-    )
+    venv_dir = _venv_dir(args, ctx)
+    with ctx.venv_container.venv_lock(venv_dir):
+        return commands.inject(
+            venv_dir,
+            args.dependencies,
+            args.requirements,
+            ctx.pip_args,
+            verbose=ctx.verbose,
+            include_apps=args.include_apps,
+            include_dependencies=args.include_deps,
+            force=args.force,
+            suffix=args.with_suffix,
+            backend=ctx.backend,
+            env_backend=ctx.env_backend,
+        )
 
 
 def _add_uninject(subparsers, venv_completer: VenvCompleter, shared_parser: argparse.ArgumentParser):
@@ -639,14 +641,16 @@ def _add_uninject(subparsers, venv_completer: VenvCompleter, shared_parser: argp
 
 
 def _cmd_uninject(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
-    return commands.uninject(
-        _venv_dir(args, ctx),
-        args.dependencies,
-        local_bin_dir=paths.ctx.bin_dir,
-        local_man_dir=paths.ctx.man_dir,
-        leave_deps=args.leave_deps,
-        verbose=ctx.verbose,
-    )
+    venv_dir = _venv_dir(args, ctx)
+    with ctx.venv_container.venv_lock(venv_dir):
+        return commands.uninject(
+            venv_dir,
+            args.dependencies,
+            local_bin_dir=paths.ctx.bin_dir,
+            local_man_dir=paths.ctx.man_dir,
+            leave_deps=args.leave_deps,
+            verbose=ctx.verbose,
+        )
 
 
 def _add_pin(
@@ -680,7 +684,9 @@ def _add_pin(
 
 
 def _cmd_pin(args: argparse.Namespace, ctx: DispatchContext) -> OperationResult[commands.PinData]:
-    return commands.pin(_venv_dir(args, ctx), ctx.verbose, ctx.skip_list, args.injected_only)
+    venv_dir = _venv_dir(args, ctx)
+    with ctx.venv_container.venv_lock(venv_dir):
+        return commands.pin(venv_dir, ctx.verbose, ctx.skip_list, args.injected_only)
 
 
 def _add_unpin(
@@ -700,7 +706,9 @@ def _add_unpin(
 
 
 def _cmd_unpin(args: argparse.Namespace, ctx: DispatchContext) -> OperationResult[commands.PinData]:
-    return commands.unpin(_venv_dir(args, ctx), ctx.verbose)
+    venv_dir = _venv_dir(args, ctx)
+    with ctx.venv_container.venv_lock(venv_dir):
+        return commands.unpin(venv_dir, ctx.verbose)
 
 
 def _add_upgrade(subparsers, venv_completer: VenvCompleter, shared_parser: argparse.ArgumentParser) -> None:
@@ -819,7 +827,9 @@ def _add_uninstall(subparsers, venv_completer: VenvCompleter, shared_parser: arg
 
 
 def _cmd_uninstall(args: argparse.Namespace, ctx: DispatchContext) -> OperationResult[commands.UninstallData]:
-    return commands.uninstall(_venv_dir(args, ctx), paths.ctx.bin_dir, paths.ctx.man_dir, ctx.verbose)
+    venv_dir = _venv_dir(args, ctx)
+    with ctx.venv_container.venv_lock(venv_dir):
+        return commands.uninstall(venv_dir, paths.ctx.bin_dir, paths.ctx.man_dir, ctx.verbose)
 
 
 def _add_uninstall_all(subparsers: argparse._SubParsersAction, shared_parser: argparse.ArgumentParser) -> None:
@@ -860,16 +870,19 @@ def _add_reinstall(subparsers, venv_completer: VenvCompleter, shared_parser: arg
 
 
 def _cmd_reinstall(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
-    return commands.reinstall(
-        venv_dir=_venv_dir(args, ctx),
-        local_bin_dir=paths.ctx.bin_dir,
-        local_man_dir=paths.ctx.man_dir,
-        python=ctx.python,
-        verbose=ctx.verbose,
-        python_flag_passed=ctx.python_flag_passed,
-        backend=ctx.backend,
-        env_backend=ctx.env_backend,
-    )
+    venv_dir = _venv_dir(args, ctx)
+    with ctx.venv_container.venv_lock(venv_dir) as venv_lock:
+        return commands.reinstall(
+            venv_dir=venv_dir,
+            local_bin_dir=paths.ctx.bin_dir,
+            local_man_dir=paths.ctx.man_dir,
+            python=ctx.python,
+            verbose=ctx.verbose,
+            python_flag_passed=ctx.python_flag_passed,
+            backend=ctx.backend,
+            env_backend=ctx.env_backend,
+            venv_lock=venv_lock,
+        )
 
 
 def _add_reinstall_all(subparsers: argparse._SubParsersAction, shared_parser: argparse.ArgumentParser) -> None:
@@ -1084,7 +1097,9 @@ def _add_runpip(subparsers, venv_completer: VenvCompleter, shared_parser: argpar
 
 
 def _cmd_runpip(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
-    return commands.run_pip(args.package, _venv_dir(args, ctx), get_runpip_args(args.pipargs), ctx.verbose)
+    venv_dir = _venv_dir(args, ctx)
+    with ctx.venv_container.venv_lock(venv_dir):
+        return commands.run_pip(args.package, venv_dir, get_runpip_args(args.pipargs), ctx.verbose)
 
 
 def _add_ensurepath(subparsers: argparse._SubParsersAction, shared_parser: argparse.ArgumentParser) -> None:

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -6,6 +6,8 @@ from importlib.metadata import Distribution, EntryPoint
 from pathlib import Path
 from typing import TYPE_CHECKING, Final, NoReturn
 
+from filelock import BaseFileLock, FileLock
+
 if TYPE_CHECKING:
     from subprocess import CompletedProcess
 
@@ -119,6 +121,10 @@ class VenvContainer:
     def get_venv_dir(self, package_name: str) -> Path:
         """Return the expected venv path for given `package_name`."""
         return self._root.joinpath(canonicalize_name(package_name))
+
+    def venv_lock(self, venv_dir: Path) -> BaseFileLock:
+        self._root.mkdir(parents=True, exist_ok=True)
+        return FileLock(self._root / f".{canonicalize_name(venv_dir.name)}.lock")
 
 
 class Venv:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -12,6 +12,7 @@ import pytest
 from helpers import app_name, run_pipx_cli, skip_if_windows, unwrap_log_text
 from package_info import PKG
 from pipx import paths, shared_libs
+from pipx.constants import EXIT_CODE_OK
 from pipx.pipx_metadata_file import PipxMetadata
 from pipx.util import PipxError
 from pipx.venv import Venv
@@ -214,6 +215,27 @@ def test_install_upgrade_reconciles_package_spec(pipx_temp_env, capsys):
     captured = capsys.readouterr()
     assert "upgraded package black from 22.10.0 to 22.8.0" in captured.out
     assert PipxMetadata(paths.ctx.venvs / "black").main_package.package_version == "22.8.0"
+
+
+def test_install_upgrade_multiple_existing(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+    package_specs = [PKG["black"]["spec"], PKG["pycowsay"]["spec"]]
+    assert run_pipx_cli(["install", *package_specs]) == EXIT_CODE_OK
+    capsys.readouterr()
+
+    assert run_pipx_cli(["install", "--upgrade", *package_specs]) == EXIT_CODE_OK
+    output = capsys.readouterr().out
+    assert ("black 22.8.0 already satisfies" in output, "pycowsay 0.0.0.2 already satisfies" in output) == (
+        True,
+        True,
+    )
+
+
+def test_install_reuses_empty_environment_dir(pipx_temp_env: None) -> None:
+    (paths.ctx.venvs / "pycowsay").mkdir(parents=True)
+    assert (
+        run_pipx_cli(["install", PKG["pycowsay"]["spec"]]),
+        PipxMetadata(paths.ctx.venvs / "pycowsay").main_package.package,
+    ) == (EXIT_CODE_OK, "pycowsay")
 
 
 def test_install_upgrade_satisfied_spec_is_offline(pipx_temp_env, capsys, mocker: "MockerFixture"):

--- a/tests/test_install_all.py
+++ b/tests/test_install_all.py
@@ -1,26 +1,32 @@
+import json
 from pathlib import Path
+
+import pytest
 
 from helpers import run_pipx_cli
 from pipx import paths
 
 
-def test_install_all(pipx_temp_env, tmp_path, capsys):
+def test_install_all(pipx_temp_env: None, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     assert not run_pipx_cli(["install", "pycowsay"])
     assert not run_pipx_cli(["install", "black"])
-    _ = capsys.readouterr()
+    assert not run_pipx_cli(["inject", "black", "pycowsay"])
+    capsys.readouterr()
 
     assert not run_pipx_cli(["list", "--json"])
-    captured = capsys.readouterr()
+    pipx_list_path = tmp_path / "pipx_list.json"
+    pipx_list_path.write_text(capsys.readouterr().out, encoding="utf-8")
 
-    pipx_list_path = Path(tmp_path) / "pipx_list.json"
-    with open(pipx_list_path, "w") as pipx_list_fh:
-        pipx_list_fh.write(captured.out)
-
+    assert not run_pipx_cli(["uninstall-all"])
     assert not run_pipx_cli(["install-all", str(pipx_list_path)])
+    capsys.readouterr()
+    assert not run_pipx_cli(["list", "--json"])
 
-    captured = capsys.readouterr()
-    assert "black" in captured.out
-    assert "pycowsay" in captured.out
+    installed = json.loads(capsys.readouterr().out)["venvs"]
+    assert (sorted(installed), sorted(installed["black"]["metadata"]["injected_packages"])) == (
+        ["black", "pycowsay"],
+        ["pycowsay"],
+    )
 
 
 def test_install_all_multiple_errors(pipx_temp_env, root, capsys):

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -2,8 +2,11 @@ import json
 import os
 import re
 import shutil
+import subprocess
 import sys
 import time
+from pathlib import Path
+from typing import Final
 
 import pytest
 
@@ -21,6 +24,8 @@ from package_info import PKG
 from pipx import constants, paths, shared_libs, venv
 from pipx.pipx_metadata_file import PIPX_INFO_FILENAME, PackageInfo, _json_decoder_object_hook
 from pipx.util import PipxError
+
+_COMMAND_TIMEOUT: Final[int] = 30
 
 
 def test_cli(pipx_temp_env, monkeypatch, capsys):
@@ -174,6 +179,69 @@ def test_list_short(pipx_temp_env, monkeypatch, capsys):
     assert "pylint 3.0.4" in captured.out
 
 
+def test_list_waits_for_install(pipx_temp_env: None, tmp_path: Path) -> None:
+    package_dir = _create_package(tmp_path, "slow-app", "from time import sleep\nsleep(1)\n")
+    install = _start_install(package_dir)
+    try:
+        _wait_for_path(paths.ctx.venvs / "slow-app", install)
+        listed = subprocess.run(
+            [sys.executable, "-m", "pipx", "list", "--short"],
+            env=_subprocess_env(),
+            capture_output=True,
+            text=True,
+            timeout=_COMMAND_TIMEOUT,
+            check=False,
+        )
+        install_stdout, install_stderr = install.communicate(timeout=_COMMAND_TIMEOUT)
+    finally:
+        _stop_process(install)
+
+    assert (install.returncode, listed.returncode, listed.stdout.strip()) == (0, 0, "slow-app 1"), (
+        install_stdout,
+        install_stderr,
+        listed.stdout,
+        listed.stderr,
+    )
+
+
+def test_install_does_not_wait_for_other_environment(pipx_temp_env: None, tmp_path: Path) -> None:
+    entered = tmp_path / "entered"
+    release = tmp_path / "release"
+    pause = (
+        "from pathlib import Path\n"
+        "from time import sleep\n"
+        f"Path({str(entered)!r}).touch()\n"
+        f"while not Path({str(release)!r}).exists():\n    sleep(0.01)\n"
+    )
+    blocked_install = _start_install(_create_package(tmp_path, "blocked-app", pause))
+    try:
+        _wait_for_path(entered, blocked_install)
+        installed = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pipx",
+                "install",
+                str(_create_package(tmp_path, "other-app")),
+                "--skip-maintenance",
+            ],
+            env=_subprocess_env(),
+            capture_output=True,
+            text=True,
+            timeout=_COMMAND_TIMEOUT,
+            check=False,
+        )
+        blocked_returncode = blocked_install.poll()
+    finally:
+        release.touch()
+        _stop_process(blocked_install, terminate=False)
+
+    assert (installed.returncode, blocked_returncode, (paths.ctx.venvs / "other-app").is_dir()) == (0, None, True), (
+        installed.stdout,
+        installed.stderr,
+    )
+
+
 def test_list_standalone_interpreter(pipx_temp_env, monkeypatch, mocked_github_api, capsys):
     def which(name):
         return None
@@ -275,3 +343,52 @@ def test_list_installed_packages_error(monkeypatch, tmp_path, fake_process):
     assert "Failed to execute" in rendered
     assert "Process exited with return code 1" in rendered
     assert "unit test stderr" in rendered
+
+
+def _create_package(tmp_path: Path, name: str, setup_prefix: str = "") -> Path:
+    package_dir = tmp_path / name
+    package_dir.mkdir()
+    module = name.replace("-", "_")
+    (package_dir / "setup.py").write_text(
+        f"{setup_prefix}from setuptools import setup\n"
+        f"setup(name={name!r}, version='1', py_modules=[{module!r}], "
+        f"entry_points={{'console_scripts': [{f'{name}={module}:main'!r}]}})\n",
+        encoding="utf-8",
+    )
+    (package_dir / f"{module}.py").write_text(f"def main() -> None:\n    print({name!r})\n", encoding="utf-8")
+    return package_dir
+
+
+def _start_install(package_dir: Path) -> subprocess.Popen[str]:
+    return subprocess.Popen(
+        [sys.executable, "-m", "pipx", "install", str(package_dir), "--skip-maintenance"],
+        env=_subprocess_env(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def _subprocess_env() -> dict[str, str]:
+    return os.environ | {
+        "PIPX_BIN_DIR": str(paths.ctx.bin_dir),
+        "PIPX_HOME": str(paths.ctx.home),
+        "PIPX_MAN_DIR": str(paths.ctx.man_dir),
+        "PIPX_SHARED_LIBS": str(paths.ctx.shared_libs),
+    }
+
+
+def _wait_for_path(path: Path, process: subprocess.Popen[str]) -> None:
+    deadline = time.monotonic() + _COMMAND_TIMEOUT
+    while not path.exists():
+        if process.poll() is not None:
+            pytest.fail(f"install exited before creating {path}: {process.communicate()!r}")
+        if time.monotonic() >= deadline:
+            pytest.fail(f"install did not create {path} within {_COMMAND_TIMEOUT} seconds")
+        time.sleep(0.01)
+
+
+def _stop_process(process: subprocess.Popen[str], *, terminate: bool = True) -> None:
+    if process.poll() is None and terminate:
+        process.terminate()
+    process.communicate(timeout=_COMMAND_TIMEOUT)


### PR DESCRIPTION
During a concurrent install, `pipx list` can inspect an environment before `pipx_metadata.json` exists and misreport a corrupt installation with status 1, matching [#1056](https://github.com/pypa/pipx/issues/1056).

Each state command holds one cross-process lock for the canonical environment name while it reads or changes that tool; bulk commands release the lock before moving to the next environment, and installations of unrelated tools proceed in parallel.

pipx stores the lock beside its environment; replacement leaves the lock in place.
