### PR TITLE
✨ feat(outdated): list available upgrades

### DIFF
--- a/changelog.d/149.feature.md
+++ b/changelog.d/149.feature.md
@@ -1,0 +1,1 @@
+Add `pipx list --outdated` and JSON output.

--- a/docs/explanation/comparisons.md
+++ b/docs/explanation/comparisons.md
@@ -50,7 +50,7 @@ managers writes the same filename. Each manager refuses to overwrite a binary th
 | Remove an injected dep       | `pipx uninject mkdocs mkdocs-material`            | _rebuild without `--with`_                                          |
 | Upgrade one                  | `pipx upgrade ruff`                               | `uv tool upgrade ruff`                                              |
 | Upgrade all                  | `pipx upgrade-all`                                | `uv tool upgrade --all`                                             |
-| List installed               | `pipx list`                                       | `uv tool list` (`--show-with`, `--outdated`, …)                     |
+| List installed or outdated   | `pipx list` (`--outdated`, `--json`)              | `uv tool list` (`--show-with`, `--outdated`, …)                     |
 | Diagnose broken environments | `pipx health`                                     | _no equivalent_                                                     |
 | Repair broken environments   | `pipx repair ruff` / `repair`                     | `uv tool install ruff` / _no bulk equivalent_                       |
 | Reinstall any environment    | `pipx reinstall ruff` / `reinstall-all`           | `uv tool upgrade --reinstall ruff` / `--all`                        |
@@ -75,7 +75,6 @@ managers writes the same filename. Each manager refuses to overwrite a binary th
 
 ### Only in uv tool
 
-- `uv tool list --outdated` queries newer versions without upgrading.
 - `uv tool list` toggles columns via `--show-with`, `--show-paths`, `--show-version-specifiers`, `--show-extras`,
     `--show-python`.
 - `uvx --with-editable PATH` adds editable extras for a one-off run.

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -36,6 +36,15 @@ pipx run pycowsay moooo!
 
 ### Upgrade an installed application
 
+Check available upgrades without changing an environment:
+
+```
+pipx list --outdated
+```
+
+The output shows each package's installed and available versions. Pass `--json` to read the same information in a
+script.
+
 ```
 pipx upgrade pycowsay
 ```

--- a/src/pipx/backends/__init__.py
+++ b/src/pipx/backends/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from functools import cache
 
-from pipx.backends._base import KNOWN_BACKENDS, PIP, UV, Backend
+from pipx.backends._base import KNOWN_BACKENDS, PIP, UV, Backend, OutdatedPackage
 from pipx.backends.pip import PipBackend
 from pipx.backends.uv import UvBackend, find_uv_binary
 from pipx.util import PipxError
@@ -69,6 +69,7 @@ __all__ = [
     "PIP",
     "UV",
     "Backend",
+    "OutdatedPackage",
     "assert_not_pip_under_uv",
     "env_default_backend",
     "find_uv_binary",

--- a/src/pipx/backends/_base.py
+++ b/src/pipx/backends/_base.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import json
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Final
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Final, TypedDict, cast
+
+from pipx.util import PipxError
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -62,6 +66,15 @@ class Backend(ABC):
     ) -> set[str]: ...
 
     @abstractmethod
+    def list_outdated(
+        self,
+        *,
+        venv_root: Path,
+        venv_python: Path,
+        index_args: list[str],
+    ) -> tuple[OutdatedPackage, ...]: ...
+
+    @abstractmethod
     def run_raw_pip(
         self,
         *,
@@ -86,9 +99,43 @@ class Backend(ABC):
     ) -> None: ...
 
 
+def outdated_packages_from_process(process: CompletedProcess[str]) -> tuple[OutdatedPackage, ...]:
+    if process.returncode:
+        raise PipxError(
+            f"Package backend exited with code {process.returncode}.\nstderr: {process.stderr}",
+            wrap_message=False,
+        )
+    return _parse_outdated_packages(process.stdout)
+
+
+def _parse_outdated_packages(output: str) -> tuple[OutdatedPackage, ...]:
+    try:
+        return tuple(
+            OutdatedPackage(entry["name"], entry["version"], entry["latest_version"])
+            for entry in cast("list[_OutdatedEntry]", json.loads(output))
+        )
+    except (json.JSONDecodeError, KeyError, TypeError) as error:
+        raise PipxError("Package backend returned invalid JSON for an outdated query.", wrap_message=False) from error
+
+
+@dataclass(frozen=True)
+class OutdatedPackage:
+    name: str
+    version: str
+    latest_version: str
+
+
+class _OutdatedEntry(TypedDict):
+    name: str
+    version: str
+    latest_version: str
+
+
 __all__ = [
     "KNOWN_BACKENDS",
     "PIP",
     "UV",
     "Backend",
+    "OutdatedPackage",
+    "outdated_packages_from_process",
 ]

--- a/src/pipx/backends/pip.py
+++ b/src/pipx/backends/pip.py
@@ -5,7 +5,7 @@ import logging
 from typing import TYPE_CHECKING, Final
 
 from pipx.animate import animate
-from pipx.backends._base import PIP, Backend
+from pipx.backends._base import PIP, Backend, OutdatedPackage, outdated_packages_from_process
 from pipx.constants import PIPX_SHARED_PTH
 from pipx.shared_libs import shared_libs
 from pipx.util import (
@@ -132,6 +132,19 @@ class PipBackend(Backend):
                 f"stderr: {process.stderr}"
             )
         return {entry["name"] for entry in json.loads(process.stdout.strip())}
+
+    def list_outdated(
+        self,
+        *,
+        venv_root: Path,
+        venv_python: Path,
+        index_args: list[str],
+    ) -> tuple[OutdatedPackage, ...]:
+        process = run_subprocess(
+            [str(venv_python), "-m", "pip", "list", "--outdated", "--format=json", *index_args],
+            run_dir=str(venv_root),
+        )
+        return outdated_packages_from_process(process)
 
     def run_raw_pip(
         self,

--- a/src/pipx/backends/uv.py
+++ b/src/pipx/backends/uv.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Final
 from packaging.version import InvalidVersion, Version
 
 from pipx.animate import animate
-from pipx.backends._base import UV, Backend
+from pipx.backends._base import UV, Backend, OutdatedPackage, outdated_packages_from_process
 from pipx.util import (
     PipxError,
     run_subprocess,
@@ -150,6 +150,18 @@ class UvBackend(Backend):
                 f"stderr: {process.stderr}"
             )
         return {entry["name"] for entry in json.loads(process.stdout.strip())}
+
+    def list_outdated(
+        self,
+        *,
+        venv_root: Path,
+        venv_python: Path,
+        index_args: list[str],
+    ) -> tuple[OutdatedPackage, ...]:
+        cmd = self._uv_pip_command("list", venv_python, verbose=False)
+        cmd += ["--outdated", "--format=json", *index_args]
+        process = run_subprocess(cmd, run_dir=str(venv_root), env_overrides=_UV_ENV_OVERRIDES)
+        return outdated_packages_from_process(process)
 
     def run_raw_pip(
         self,

--- a/src/pipx/commands/__init__.py
+++ b/src/pipx/commands/__init__.py
@@ -5,6 +5,7 @@ from pipx.commands.inject import inject
 from pipx.commands.install import install, install_all
 from pipx.commands.interpreter import list_interpreters, prune_interpreters, upgrade_interpreters
 from pipx.commands.list_packages import list_packages
+from pipx.commands.outdated import OutdatedData, list_outdated
 from pipx.commands.pin import PinData, pin, unpin
 from pipx.commands.reinstall import reinstall, reinstall_all
 from pipx.commands.run import run
@@ -15,6 +16,7 @@ from pipx.commands.upgrade import upgrade, upgrade_all, upgrade_shared
 
 __all__ = [
     "HealthData",
+    "OutdatedData",
     "PinData",
     "RepairData",
     "UninstallData",
@@ -25,6 +27,7 @@ __all__ = [
     "install",
     "install_all",
     "list_interpreters",
+    "list_outdated",
     "list_packages",
     "pin",
     "prune_interpreters",

--- a/src/pipx/commands/list_packages.py
+++ b/src/pipx/commands/list_packages.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import sys
-from collections.abc import Collection, Iterable, Iterator
+from collections.abc import Collection, Iterable
 from pathlib import Path
 from typing import Any
 
@@ -119,16 +119,16 @@ def list_packages(
         print(f"nothing has been installed with pipx {sleep}", file=sys.stderr)
 
     if json_format:
-        all_venv_problems = list_json(_locked_venv_dirs(venv_container, venv_dirs))
+        all_venv_problems = list_json(venv_container.iter_locked_venv_dirs(venv_dirs))
     elif short_format:
-        all_venv_problems = list_short(_locked_venv_dirs(venv_container, venv_dirs))
+        all_venv_problems = list_short(venv_container.iter_locked_venv_dirs(venv_dirs))
     elif pinned_only:
-        all_venv_problems = list_pinned(_locked_venv_dirs(venv_container, venv_dirs), include_injected)
+        all_venv_problems = list_pinned(venv_container.iter_locked_venv_dirs(venv_dirs), include_injected)
     else:
         if not venv_dirs:
             return EXIT_CODE_OK
         all_venv_problems = list_text(
-            _locked_venv_dirs(venv_container, venv_dirs), include_injected, str(venv_container)
+            venv_container.iter_locked_venv_dirs(venv_dirs), include_injected, str(venv_container)
         )
 
     if all_venv_problems.bad_venv_name:
@@ -158,13 +158,6 @@ def list_packages(
         return EXIT_CODE_LIST_PROBLEM
 
     return EXIT_CODE_OK
-
-
-def _locked_venv_dirs(venv_container: VenvContainer, venv_dirs: Collection[Path]) -> Iterator[Path]:
-    for venv_dir in venv_dirs:
-        with venv_container.venv_lock(venv_dir):
-            if venv_dir.is_dir():
-                yield venv_dir
 
 
 __all__ = [

--- a/src/pipx/commands/outdated.py
+++ b/src/pipx/commands/outdated.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from packaging.utils import canonicalize_name
+
+from pipx.constants import ExitCode
+from pipx.package_specifier import extract_index_options, valid_pypi_name
+from pipx.result import OperationData, OperationResult, OutputLevel, OutputMessage, OutputStream
+from pipx.util import PipxError
+from pipx.venv import Venv, VenvContainer
+
+if TYPE_CHECKING:
+    from pipx.pipx_metadata_file import PackageInfo
+
+
+def list_outdated(venv_container: VenvContainer, *, include_injected: bool) -> OperationResult[OutdatedData]:
+    packages_checked = 0
+    failures: list[_FailedEnvironment] = []
+    messages: list[OutputMessage] = []
+    outdated_packages: list[_OutdatedPackage] = []
+    skipped: list[_SkippedPackage] = []
+    for venv_dir in venv_container.iter_locked_venv_dirs(venv_container.iter_venv_dirs()):
+        venv = Venv(venv_dir)
+        if not venv.package_metadata:
+            error = "Missing internal pipx metadata."
+            failures.append(_FailedEnvironment(venv.name, error))
+            messages.append(OutputMessage(f"{venv.name}: {error}", stream=OutputStream.STDERR, level=OutputLevel.ERROR))
+            continue
+        packages_by_index: dict[tuple[str, ...], dict[str, PackageInfo]] = {}
+        for package_name, package_info in venv.package_metadata.items():
+            if package_name != venv.main_package_name and not include_injected:
+                continue
+            display_name = f"{package_name}{package_info.suffix}"
+            if package_info.package_or_url is None:
+                error = f"Package {display_name} has corrupt pipx metadata."
+                failures.append(_FailedEnvironment(venv.name, error))
+                messages.append(
+                    OutputMessage(f"{venv.name}: {error}", stream=OutputStream.STDERR, level=OutputLevel.ERROR)
+                )
+                continue
+            if "--editable" in package_info.pip_args:
+                skipped.append(_SkippedPackage(venv.name, display_name, "editable"))
+                continue
+            if valid_pypi_name(package_info.package_or_url) is None:
+                skipped.append(_SkippedPackage(venv.name, display_name, "non-index"))
+                continue
+            packages_by_index.setdefault(tuple(extract_index_options(package_info.pip_args)), {})[
+                canonicalize_name(package_name)
+            ] = package_info
+
+        for index_args, package_infos in packages_by_index.items():
+            packages_checked += len(package_infos)
+            try:
+                for package in venv.list_outdated_packages(list(index_args)):
+                    if (managed_package := package_infos.get(canonicalize_name(package.name))) is None:
+                        continue
+                    outdated_packages.append(
+                        _OutdatedPackage(
+                            environment=venv.name,
+                            package=f"{managed_package.package}{managed_package.suffix}",
+                            version=package.version,
+                            latest_version=package.latest_version,
+                            injected=managed_package.package != venv.main_package_name,
+                            pinned=managed_package.pinned,
+                        )
+                    )
+            except PipxError as error:
+                failures.append(_FailedEnvironment(venv.name, str(error)))
+                messages.append(
+                    OutputMessage(f"{venv.name}: {error}", stream=OutputStream.STDERR, level=OutputLevel.ERROR)
+                )
+
+    packages = tuple(sorted(outdated_packages, key=lambda package: (package.environment, package.package)))
+    messages.extend(_package_message(package) for package in packages)
+    if not packages and not failures:
+        messages.append(
+            OutputMessage(
+                "pipx found no available upgrades." if packages_checked else "pipx found no index packages to check."
+            )
+        )
+    return OperationResult(
+        command="list",
+        data=OutdatedData(
+            packages_checked=packages_checked,
+            packages=packages,
+            skipped=tuple(sorted(skipped, key=lambda package: (package.environment, package.package))),
+            failures=tuple(sorted(failures, key=lambda failure: (failure.environment, failure.error))),
+        ),
+        messages=tuple(messages),
+        exit_code=ExitCode(1 if failures else 0),
+    )
+
+
+def _package_message(package: _OutdatedPackage) -> OutputMessage:
+    subject = f"{package.package} (injected in {package.environment})" if package.injected else package.package
+    return OutputMessage(
+        f"{subject}{' [pinned]' if package.pinned else ''}: {package.version} -> {package.latest_version}"
+    )
+
+
+@dataclass(frozen=True)
+class _OutdatedPackage:
+    environment: str
+    package: str
+    version: str
+    latest_version: str
+    injected: bool
+    pinned: bool
+
+
+@dataclass(frozen=True)
+class _SkippedPackage:
+    environment: str
+    package: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class _FailedEnvironment:
+    environment: str
+    error: str
+
+
+@dataclass(frozen=True)
+class OutdatedData(OperationData):
+    packages_checked: int
+    packages: tuple[_OutdatedPackage, ...]
+    skipped: tuple[_SkippedPackage, ...]
+    failures: tuple[_FailedEnvironment, ...]
+
+
+__all__ = [
+    "OutdatedData",
+    "list_outdated",
+]

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -992,6 +992,7 @@ def _add_list(subparsers: argparse._SubParsersAction, shared_parser: argparse.Ar
         action="store_true",
         help="Show packages injected into the main app's environment",
     )
+    p.add_argument("--outdated", action="store_true", help="List packages with an available upgrade.")
     g = p.add_mutually_exclusive_group()
     g.add_argument("--json", action="store_true", help="Output rich data in json format.")
     g.add_argument("--short", action="store_true", help="List packages only.")
@@ -1003,7 +1004,11 @@ def _add_list(subparsers: argparse._SubParsersAction, shared_parser: argparse.Ar
     p.set_defaults(func=_cmd_list)
 
 
-def _cmd_list(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
+def _cmd_list(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode | OperationResult[commands.OutdatedData]:
+    if args.outdated:
+        if args.short or args.pinned:
+            raise PipxError("--outdated cannot be combined with --short or --pinned.")
+        return commands.list_outdated(ctx.venv_container, include_injected=args.include_injected)
     return commands.list_packages(ctx.venv_container, args.include_injected, args.json, args.short, args.pinned)
 
 

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -27,6 +27,9 @@ ARCHIVE_EXTENSIONS = (".whl", ".tar.gz", ".zip")
 _LOCAL_VCS_SCHEMES: Final[frozenset[str]] = frozenset({"git+file", "hg+file"})
 _PIP_PATH_OPTIONS: Final[frozenset[str]] = frozenset({"-c", "--constraint", "-f", "--find-links"})
 _PIP_ATTACHED_PATH_OPTIONS: Final[frozenset[str]] = frozenset({"-c", "-f"})
+_PIP_INDEX_VALUE_OPTIONS: Final[frozenset[str]] = frozenset(
+    {"-f", "-i", "--extra-index-url", "--find-links", "--index-url", "--trusted-host"}
+)
 
 
 @dataclass(frozen=True)
@@ -258,6 +261,21 @@ def package_spec_satisfied(
         return False
 
 
+def extract_index_options(pip_args: list[str]) -> list[str]:
+    index_args: list[str] = []
+    iterator = iter(pip_args)
+    for argument in iterator:
+        if argument == "--no-index":
+            index_args.append(argument)
+            continue
+        option, separator = argument.partition("=")[:2]
+        if option in _PIP_INDEX_VALUE_OPTIONS:
+            index_args.extend([argument] if separator else [argument, next(iterator)])
+        elif len(argument) > 2 and argument[:2] in {"-f", "-i"}:
+            index_args.append(argument)
+    return index_args
+
+
 def fix_package_name(package_or_url: str, package_name: str) -> str:
     try:
         package_req = Requirement(package_or_url)
@@ -285,6 +303,7 @@ def fix_package_name(package_or_url: str, package_name: str) -> str:
 
 
 __all__ = [
+    "extract_index_options",
     "fix_package_name",
     "get_extras",
     "package_spec_satisfied",

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -1,7 +1,7 @@
 import logging
 import shutil
 import time
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
 from importlib.metadata import Distribution, EntryPoint
 from pathlib import Path
 from typing import TYPE_CHECKING, Final, NoReturn
@@ -15,7 +15,14 @@ from packaging.utils import canonicalize_name
 from packaging.version import Version
 
 from pipx.animate import animate
-from pipx.backends import Backend, assert_not_pip_under_uv, env_default_backend, get_backend, resolve_backend_name
+from pipx.backends import (
+    Backend,
+    OutdatedPackage,
+    assert_not_pip_under_uv,
+    env_default_backend,
+    get_backend,
+    resolve_backend_name,
+)
 from pipx.constants import PIPX_SHARED_PTH, ExitCode
 from pipx.emojis import hazard
 from pipx.interpreter import get_default_python
@@ -121,6 +128,12 @@ class VenvContainer:
     def get_venv_dir(self, package_name: str) -> Path:
         """Return the expected venv path for given `package_name`."""
         return self._root.joinpath(canonicalize_name(package_name))
+
+    def iter_locked_venv_dirs(self, venv_dirs: Iterable[Path]) -> Generator[Path, None, None]:
+        for venv_dir in venv_dirs:
+            with self.venv_lock(venv_dir):
+                if venv_dir.is_dir():
+                    yield venv_dir
 
     def venv_lock(self, venv_dir: Path) -> BaseFileLock:
         self._root.mkdir(parents=True, exist_ok=True)
@@ -475,6 +488,13 @@ class Venv:
             venv_root=self.root,
             venv_python=self.python_path,
             not_required=not_required,
+        )
+
+    def list_outdated_packages(self, index_args: list[str]) -> tuple[OutdatedPackage, ...]:
+        return self.backend.list_outdated(
+            venv_root=self.root,
+            venv_python=self.python_path,
+            index_args=index_args,
         )
 
     @property

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
 
@@ -11,11 +12,13 @@ from pipx.backends import (
     KNOWN_BACKENDS,
     PIP,
     UV,
+    OutdatedPackage,
     assert_not_pip_under_uv,
     env_default_backend,
     find_uv_binary,
     resolve_backend_name,
 )
+from pipx.backends.pip import PipBackend
 from pipx.backends.uv import UvBackend
 from pipx.commands.run_uv import translate_pip_args_for_uv
 from pipx.constants import PIPX_SHARED_PTH
@@ -307,6 +310,64 @@ def test_uv_list_installed_not_required_uses_distribution_metadata(
         venv_python=tmp_path / "bin" / "python",
         not_required=True,
     ) == {"root-package", "top-package"}
+
+
+@pytest.mark.parametrize("backend_name", [pytest.param(PIP, id="pip"), pytest.param(UV, id="uv")])
+def test_backend_list_outdated_forwards_index_settings(backend_name: str, tmp_path: Path, mocker: MockerFixture) -> None:
+    backend: PipBackend | UvBackend
+    if backend_name == PIP:
+        backend = PipBackend()
+        expected_command: list[str | Path] = [
+            str(tmp_path / "bin" / "python"),
+            "-m",
+            "pip",
+            "list",
+            "--outdated",
+            "--format=json",
+            "--index-url",
+            "https://index.example/simple",
+        ]
+    else:
+        mocker.patch("pipx.backends.uv.shutil.which", autospec=True, return_value=str(tmp_path / "uv"))
+        mocker.patch(
+            "pipx.backends.uv.subprocess.run",
+            autospec=True,
+            return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="uv 0.10.0", stderr=""),
+        )
+        backend = UvBackend()
+        expected_command = [
+            tmp_path / "uv",
+            "pip",
+            "list",
+            "--python",
+            str(tmp_path / "bin" / "python"),
+            "--quiet",
+            "--outdated",
+            "--format=json",
+            "--index-url",
+            "https://index.example/simple",
+        ]
+    run_subprocess = mocker.patch(
+        f"pipx.backends.{'pip' if backend_name == PIP else 'uv'}.run_subprocess",
+        autospec=True,
+        return_value=subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout='[{"name":"demo","version":"1","latest_version":"2"}]',
+            stderr="",
+        ),
+    )
+
+    result = backend.list_outdated(
+        venv_root=tmp_path,
+        venv_python=tmp_path / "bin" / "python",
+        index_args=["--index-url", "https://index.example/simple"],
+    )
+
+    assert (result, run_subprocess.call_args.args[0]) == (
+        (OutdatedPackage(name="demo", version="1", latest_version="2"),),
+        expected_command,
+    )
 
 
 def test_list_not_required_packages_treats_extra_dependencies_as_required(

--- a/tests/test_outdated.py
+++ b/tests/test_outdated.py
@@ -1,0 +1,399 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import replace
+from typing import TYPE_CHECKING, Final, Literal, TypeAlias, cast
+
+import pytest
+
+from helpers import mock_legacy_venv, run_pipx_cli
+from pipx import paths
+from pipx.pipx_metadata_file import PIPX_INFO_FILENAME, PipxMetadata
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from unittest.mock import MagicMock
+
+    from pytest_mock import MockerFixture
+
+_JsonValue: TypeAlias = None | bool | int | float | str | list["_JsonValue"] | dict[str, "_JsonValue"]
+_OUTDATED_JSON: Final[str] = (
+    '[{"name":"pycowsay","version":"0.0.0.2","latest_version":"1.0","latest_filetype":"wheel"},'
+    '{"name":"packaging","version":"20","latest_version":"26","latest_filetype":"wheel"}]'
+)
+_OUTDATED_PROCESS: Final[subprocess.CompletedProcess[str]] = subprocess.CompletedProcess(
+    args=[],
+    returncode=0,
+    stdout=_OUTDATED_JSON,
+    stderr="",
+)
+
+
+@pytest.mark.parametrize("backend", [pytest.param("pip", id="pip"), pytest.param("uv", id="uv")])
+def test_list_outdated_backend(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    backend: str,
+) -> None:
+    assert not run_pipx_cli(["install", "pycowsay", "--backend", backend])
+    capsys.readouterr()
+
+    assert not run_pipx_cli(["list", "--outdated"])
+
+    captured = capsys.readouterr()
+    assert (captured.out, captured.err) == ("pipx found no available upgrades.\n", "")
+
+
+@pytest.mark.parametrize(
+    ("outdated_environment", "expected"),
+    [
+        pytest.param(_OUTDATED_PROCESS, "pycowsay: 0.0.0.2 -> 1.0\n", id="outdated"),
+        pytest.param(
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="[]", stderr=""),
+            "pipx found no available upgrades.\n",
+            id="current",
+        ),
+    ],
+    indirect=["outdated_environment"],
+)
+def test_list_outdated_text(
+    outdated_environment: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+    expected: str,
+) -> None:
+    assert not run_pipx_cli(["list", "--outdated"])
+
+    captured = capsys.readouterr()
+    assert (captured.out, captured.err, outdated_environment.call_count) == (expected, "", 1)
+
+
+def test_list_outdated_json(outdated_environment: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+    assert not run_pipx_cli(["list", "--outdated", "--json"])
+
+    captured = capsys.readouterr()
+    assert (json.loads(captured.out), captured.err) == (
+        _outdated_result(
+            packages_checked=1,
+            packages=(
+                {
+                    "environment": "pycowsay",
+                    "injected": False,
+                    "latest_version": "1.0",
+                    "package": "pycowsay",
+                    "pinned": False,
+                    "version": "0.0.0.2",
+                },
+            ),
+        ),
+        "",
+    )
+
+
+def test_list_outdated_reports_pinned(
+    outdated_environment: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert not run_pipx_cli(["pin", "pycowsay"])
+    capsys.readouterr()
+
+    assert not run_pipx_cli(["list", "--outdated"])
+
+    captured = capsys.readouterr()
+    assert (captured.out, captured.err, outdated_environment.call_count) == (
+        "pycowsay [pinned]: 0.0.0.2 -> 1.0\n",
+        "",
+        1,
+    )
+
+
+@pytest.mark.parametrize(
+    ("options", "expected"),
+    [
+        pytest.param([], "pycowsay: 0.0.0.2 -> 1.0\n", id="main-only"),
+        pytest.param(
+            ["--include-injected"],
+            "black (injected in pycowsay): 23 -> 24\npycowsay: 0.0.0.2 -> 1.0\n",
+            id="include-injected",
+        ),
+    ],
+)
+def test_list_outdated_filters_injected(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    mocker: MockerFixture,
+    options: list[str],
+    expected: str,
+) -> None:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    assert not run_pipx_cli(["inject", "pycowsay", "black"])
+    capsys.readouterr()
+    mocker.patch(
+        "pipx.backends.pip.run_subprocess",
+        autospec=True,
+        return_value=subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=(
+                '[{"name":"pycowsay","version":"0.0.0.2","latest_version":"1.0"},'
+                '{"name":"black","version":"23","latest_version":"24"}]'
+            ),
+            stderr="",
+        ),
+    )
+
+    assert not run_pipx_cli(["list", "--outdated", *options])
+
+    captured = capsys.readouterr()
+    assert (captured.out, captured.err) == (expected, "")
+
+
+@pytest.mark.parametrize(
+    ("outdated_environment", "expected_error"),
+    [
+        pytest.param(
+            subprocess.CompletedProcess(args=["pip", "list"], returncode=1, stdout="", stderr="index unavailable"),
+            "Package backend exited with code 1.\nstderr: index unavailable",
+            id="exit-code",
+        ),
+        pytest.param(
+            subprocess.CompletedProcess(args=["pip", "list"], returncode=0, stdout="not json", stderr=""),
+            "Package backend returned invalid JSON for an outdated query.",
+            id="invalid-json",
+        ),
+        pytest.param(
+            subprocess.CompletedProcess(args=["pip", "list"], returncode=0, stdout='[{"name":"demo"}]', stderr=""),
+            "Package backend returned invalid JSON for an outdated query.",
+            id="missing-key",
+        ),
+        pytest.param(
+            subprocess.CompletedProcess(args=["pip", "list"], returncode=0, stdout="null", stderr=""),
+            "Package backend returned invalid JSON for an outdated query.",
+            id="null",
+        ),
+    ],
+    indirect=["outdated_environment"],
+)
+def test_list_outdated_json_reports_backend_failure(
+    outdated_environment: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+    expected_error: str,
+) -> None:
+    assert run_pipx_cli(["list", "--outdated", "--json"])
+
+    captured = capsys.readouterr()
+    assert (json.loads(captured.out), captured.err, outdated_environment.call_count) == (
+        _outdated_result(
+            packages_checked=1,
+            failures=({"environment": "pycowsay", "error": expected_error},),
+            status="error",
+        ),
+        "",
+        1,
+    )
+
+
+@pytest.mark.parametrize(
+    "outdated_environment",
+    [
+        pytest.param(
+            subprocess.CompletedProcess(args=["pip", "list"], returncode=1, stdout="", stderr="index unavailable"),
+            id="exit-code",
+        )
+    ],
+    indirect=True,
+)
+def test_list_outdated_reports_backend_failure(
+    outdated_environment: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert run_pipx_cli(["list", "--outdated"])
+
+    captured = capsys.readouterr()
+    assert (captured.out, captured.err, outdated_environment.call_count) == (
+        "",
+        "pycowsay: Package backend exited with code 1.\nstderr: index unavailable\n",
+        1,
+    )
+
+
+def test_list_outdated_json_reports_non_index_skip(
+    non_index_environment: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert not run_pipx_cli(["list", "--outdated", "--json"])
+
+    captured = capsys.readouterr()
+    assert (json.loads(captured.out), captured.err, non_index_environment.call_count) == (
+        _outdated_result(skipped=({"environment": "pycowsay", "package": "pycowsay", "reason": "non-index"},)),
+        "",
+        0,
+    )
+
+
+def test_list_outdated_reports_no_index_packages(
+    non_index_environment: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert not run_pipx_cli(["list", "--outdated"])
+
+    captured = capsys.readouterr()
+    assert (captured.out, captured.err, non_index_environment.call_count) == (
+        "pipx found no index packages to check.\n",
+        "",
+        0,
+    )
+
+
+def test_list_outdated_json_reports_editable_skip(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    root: Path,
+) -> None:
+    assert not run_pipx_cli(["install", "--editable", str(root / "testdata" / "empty_project")])
+    capsys.readouterr()
+
+    assert not run_pipx_cli(["list", "--outdated", "--json"])
+
+    captured = capsys.readouterr()
+    assert (json.loads(captured.out), captured.err) == (
+        _outdated_result(skipped=({"environment": "empty-project", "package": "empty-project", "reason": "editable"},)),
+        "",
+    )
+
+
+def test_list_outdated_json_reports_corrupt_package(
+    corrupt_environment: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert run_pipx_cli(["list", "--outdated", "--json"])
+
+    captured = capsys.readouterr()
+    assert (json.loads(captured.out), captured.err, corrupt_environment.call_count) == (
+        _outdated_result(
+            failures=({"environment": "pycowsay", "error": "Package pycowsay has corrupt pipx metadata."},),
+            status="error",
+        ),
+        "",
+        0,
+    )
+
+
+def test_list_outdated_reports_corrupt_package(
+    corrupt_environment: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert run_pipx_cli(["list", "--outdated"])
+
+    captured = capsys.readouterr()
+    assert (captured.out, captured.err, corrupt_environment.call_count) == (
+        "",
+        "pycowsay: Package pycowsay has corrupt pipx metadata.\n",
+        0,
+    )
+
+
+def test_list_outdated_json_reports_missing_metadata(
+    missing_metadata_environment: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert run_pipx_cli(["list", "--outdated", "--json"])
+
+    captured = capsys.readouterr()
+    assert (json.loads(captured.out), captured.err) == (
+        _outdated_result(
+            failures=({"environment": "pycowsay", "error": "Missing internal pipx metadata."},),
+            status="error",
+        ),
+        "",
+    )
+
+
+def test_list_outdated_reports_missing_metadata(
+    missing_metadata_environment: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert run_pipx_cli(["list", "--outdated"])
+
+    captured = capsys.readouterr()
+    assert (captured.out, captured.err) == ("", "pycowsay: Missing internal pipx metadata.\n")
+
+
+@pytest.mark.parametrize(
+    "option",
+    [
+        pytest.param("--pinned", id="pinned"),
+        pytest.param("--short", id="short"),
+    ],
+)
+def test_list_outdated_rejects_other_filters(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    option: str,
+) -> None:
+    assert run_pipx_cli(["list", "--outdated", option])
+    assert capsys.readouterr().err == "--outdated cannot be combined with --short or --pinned.\n"
+
+
+def _outdated_result(
+    *,
+    packages_checked: int = 0,
+    packages: tuple[dict[str, _JsonValue], ...] = (),
+    skipped: tuple[dict[str, _JsonValue], ...] = (),
+    failures: tuple[dict[str, _JsonValue], ...] = (),
+    status: Literal["success", "error"] = "success",
+) -> dict[str, _JsonValue]:
+    return {
+        "command": "list",
+        "data": {
+            "packages_checked": packages_checked,
+            "failures": list(failures),
+            "packages": list(packages),
+            "skipped": list(skipped),
+        },
+        "pipx_result_version": "0.1",
+        "status": status,
+    }
+
+
+@pytest.fixture
+def corrupt_environment(outdated_environment: MagicMock) -> MagicMock:
+    metadata_path = paths.ctx.venvs / "pycowsay" / PIPX_INFO_FILENAME
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    metadata["main_package"]["package_or_url"] = None
+    metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+    return outdated_environment
+
+
+@pytest.fixture
+def outdated_environment(
+    request: pytest.FixtureRequest,
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    mocker: MockerFixture,
+) -> MagicMock:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    capsys.readouterr()
+    process = cast("subprocess.CompletedProcess[str]", getattr(request, "param", _OUTDATED_PROCESS))
+    return mocker.patch("pipx.backends.pip.run_subprocess", autospec=True, return_value=process)
+
+
+@pytest.fixture
+def non_index_environment(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    mocker: MockerFixture,
+) -> MagicMock:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    metadata = PipxMetadata(paths.ctx.venvs / "pycowsay")
+    metadata.main_package = replace(metadata.main_package, package_or_url="git+https://example.com/pycowsay.git")
+    metadata.write()
+    capsys.readouterr()
+    return mocker.patch("pipx.backends.pip.run_subprocess", autospec=True)
+
+
+@pytest.fixture
+def missing_metadata_environment(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    mock_legacy_venv("pycowsay")
+    capsys.readouterr()

--- a/tests/test_package_specifier.py
+++ b/tests/test_package_specifier.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from pipx.package_specifier import (
+    extract_index_options,
     fix_package_name,
     package_spec_satisfied,
     parse_specifier_for_install,
@@ -13,6 +14,30 @@ from pipx.package_specifier import (
 from pipx.util import PipxError
 
 TEST_DATA_PATH = "./testdata/test_package_specifier"
+
+
+@pytest.mark.parametrize(
+    ("pip_args", "expected"),
+    [
+        pytest.param(
+            ["--no-cache-dir", "--index-url", "https://index.example/simple", "--pre"],
+            ["--index-url", "https://index.example/simple"],
+            id="separate-value",
+        ),
+        pytest.param(
+            ["-ihttps://index.example/simple", "-f", "https://files.example", "--no-index"],
+            ["-ihttps://index.example/simple", "-f", "https://files.example", "--no-index"],
+            id="short-options",
+        ),
+        pytest.param(
+            ["--extra-index-url=https://extra.example/simple", "--trusted-host", "extra.example"],
+            ["--extra-index-url=https://extra.example/simple", "--trusted-host", "extra.example"],
+            id="attached-value",
+        ),
+    ],
+)
+def test_extract_index_options(pip_args: list[str], expected: list[str]) -> None:
+    assert extract_index_options(pip_args) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
For [#149](https://github.com/pypa/pipx/issues/149), `pipx list --outdated` queries the pip or uv backend of each environment for newer releases without changing the environment. The text view prints installed and available versions; `--json` exposes the same data for scripts.

pipx forwards index settings from installation metadata and filters backend output to managed packages. It records skip reasons for editable and non-index sources.

The lock spans each query, blocking concurrent metadata changes.
