### PR TITLE
✨ feat(uninstall): add scriptable output

### DIFF
--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -54,6 +54,8 @@ pipx uninstall pycowsay
 
 pipx deletes the isolated environment and removes the command from your `PATH`.
 
+Pass `--json` to read the removal result in a script, or `--quiet` to omit the confirmation.
+
 ### Next steps
 
 Continue with the [install applications](install-applications.md) and [run applications](run-applications.md) tutorials

--- a/src/pipx/commands/__init__.py
+++ b/src/pipx/commands/__init__.py
@@ -9,11 +9,12 @@ from pipx.commands.reinstall import reinstall, reinstall_all
 from pipx.commands.run import run
 from pipx.commands.run_pip import run_pip
 from pipx.commands.uninject import uninject
-from pipx.commands.uninstall import uninstall, uninstall_all
+from pipx.commands.uninstall import UninstallData, uninstall, uninstall_all
 from pipx.commands.upgrade import upgrade, upgrade_all, upgrade_shared
 
 __all__ = [
     "PinData",
+    "UninstallData",
     "ensure_pipx_paths",
     "environment",
     "inject",

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -35,10 +35,10 @@ def _restore_reinstall_backup(venv_dir: Path, restore_venv_dir: Path, backup_dir
 
 def _get_reinstall_resource_paths(venv: Venv, local_bin_dir: Path, local_man_dir: Path) -> set[Path]:
     package_infos = _get_venv_package_infos(venv)
-    resource_paths = _get_venv_resource_paths("app", venv, venv.bin_path, local_bin_dir, package_infos)
+    resource_paths = _get_venv_resource_paths("app", venv.bin_path, local_bin_dir, package_infos)
     for man_section in MAN_SECTIONS:
         resource_paths |= _get_venv_resource_paths(
-            "man", venv, venv.man_path / man_section, local_man_dir / man_section, package_infos
+            "man", venv.man_path / man_section, local_man_dir / man_section, package_infos
         )
     return resource_paths
 

--- a/src/pipx/commands/uninject.py
+++ b/src/pipx/commands/uninject.py
@@ -133,13 +133,10 @@ def uninject_dep(
 
 
 def get_include_resource_paths(package_name: str, venv: Venv, local_bin_dir: Path, local_man_dir: Path) -> set[Path]:
-    bin_dir_app_paths = _get_package_bin_dir_app_paths(
-        venv, venv.package_metadata[package_name], venv.bin_path, local_bin_dir
-    )
+    bin_dir_app_paths = _get_package_bin_dir_app_paths(venv.package_metadata[package_name], venv.bin_path, local_bin_dir)
     man_paths = set()
     for man_section in MAN_SECTIONS:
         man_paths |= _get_package_man_paths(
-            venv,
             venv.package_metadata[package_name],
             venv.man_path / man_section,
             local_man_dir / man_section,

--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 import logging
-from pathlib import Path
+from dataclasses import dataclass
 from shutil import which
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final, Literal
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from pathlib import Path
+
+    from pipx.venv_inspect import VenvMetadata
 
 from pipx.commands.common import (
     add_suffix,
@@ -17,15 +22,123 @@ from pipx.constants import (
     EXIT_CODE_UNINSTALL_ERROR,
     EXIT_CODE_UNINSTALL_VENV_NONEXISTENT,
     MAN_SECTIONS,
-    ExitCode,
 )
 from pipx.emojis import hazard, sleep, stars
 from pipx.pipx_metadata_file import PackageInfo
+from pipx.result import OperationData, OperationResult, OutputMessage
 from pipx.util import rmdir, safe_unlink
 from pipx.venv import Venv, VenvContainer
-from pipx.venv_inspect import VenvMetadata
 
-logger = logging.getLogger(__name__)
+_LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
+
+
+def uninstall_all(
+    venv_container: VenvContainer,
+    local_bin_dir: Path,
+    local_man_dir: Path,
+    verbose: bool,
+) -> OperationResult[UninstallData]:
+    failures: list[_FailedEnvironment] = []
+    messages: list[OutputMessage] = []
+    packages: list[_UninstalledPackage] = []
+    for venv_dir in venv_container.iter_venv_dirs():
+        result = uninstall(venv_dir, local_bin_dir, local_man_dir, verbose)
+        failures.extend(result.data.failures)
+        messages.extend(result.messages)
+        packages.extend(result.data.packages)
+
+    return OperationResult(
+        command="uninstall-all",
+        data=UninstallData(
+            packages=tuple(sorted(packages, key=lambda package: package.environment)),
+            failures=tuple(sorted(failures, key=lambda failure: failure.environment)),
+        ),
+        messages=tuple(messages),
+        exit_code=EXIT_CODE_UNINSTALL_ERROR if failures else EXIT_CODE_OK,
+    )
+
+
+def uninstall(
+    venv_dir: Path,
+    local_bin_dir: Path,
+    local_man_dir: Path,
+    verbose: bool,
+) -> OperationResult[UninstallData]:
+    if not venv_dir.exists():
+        messages = [OutputMessage(f"Nothing to uninstall for {venv_dir.name} {sleep}")]
+        if app := which(venv_dir.name):
+            messages.append(OutputMessage(f"{hazard}  Note: '{app}' still exists on your system and is on your PATH"))
+        return OperationResult(
+            command="uninstall",
+            data=UninstallData(
+                packages=(),
+                failures=(_FailedEnvironment(venv_dir.name, f"Nothing to uninstall for {venv_dir.name}."),),
+            ),
+            messages=tuple(messages),
+            exit_code=EXIT_CODE_UNINSTALL_VENV_NONEXISTENT,
+        )
+
+    venv = Venv(venv_dir, verbose=verbose)
+    package_infos = _get_venv_package_infos(venv)
+    resource_paths = _get_venv_resource_paths("app", venv.bin_path, local_bin_dir, package_infos)
+    for man_section in MAN_SECTIONS:
+        resource_paths |= _get_venv_resource_paths(
+            "man", venv.man_path / man_section, local_man_dir / man_section, package_infos
+        )
+
+    for path in resource_paths:
+        try:
+            safe_unlink(path)
+        except FileNotFoundError:
+            _LOGGER.info("pipx did not find resource %s", path)
+        else:
+            _LOGGER.info("pipx removed resource %s", path)
+
+    package_info = next(
+        (package_info for package_info in package_infos or () if package_info.package == venv.main_package_name),
+        None,
+    )
+    package = _UninstalledPackage(
+        environment=venv.name,
+        package=str(package_info.package) if package_info is not None else venv.name,
+        version=None if package_info is None else package_info.package_version or None,
+        location=str(venv.root),
+    )
+    rmdir(venv_dir)
+    return OperationResult(
+        command="uninstall",
+        data=UninstallData(packages=(package,), failures=()),
+        messages=(OutputMessage(f"uninstalled {venv.name}! {stars}"),),
+    )
+
+
+@dataclass(frozen=True)
+class _FailedEnvironment:
+    environment: str
+    error: str
+
+
+@dataclass(frozen=True)
+class _UninstalledPackage:
+    environment: str
+    package: str
+    version: str | None
+    location: str
+
+
+@dataclass(frozen=True)
+class UninstallData(OperationData):
+    packages: tuple[_UninstalledPackage, ...]
+    failures: tuple[_FailedEnvironment, ...]
+
+
+def _get_venv_package_infos(venv: Venv) -> tuple[PackageInfo, ...] | None:
+    if venv.pipx_metadata.main_package.package is not None:
+        return tuple(venv.package_metadata.values())
+    if not venv.python_path.is_file():
+        return None
+    venv_metadata = venv.get_venv_metadata_for_package(venv.root.name, set())
+    return (_venv_metadata_to_package_info(venv_metadata, venv.root.name),)
 
 
 def _venv_metadata_to_package_info(
@@ -59,122 +172,50 @@ def _venv_metadata_to_package_info(
     )
 
 
-def _get_venv_package_infos(venv: Venv) -> tuple[PackageInfo, ...] | None:
-    if venv.pipx_metadata.main_package.package is not None:
-        return tuple(venv.package_metadata.values())
-    if not venv.python_path.is_file():
-        return None
-    venv_metadata = venv.get_venv_metadata_for_package(venv.root.name, set())
-    return (_venv_metadata_to_package_info(venv_metadata, venv.root.name),)
-
-
-def _get_package_bin_dir_app_paths(
-    venv: Venv, package_info: PackageInfo, venv_bin_path: Path, local_bin_dir: Path
-) -> set[Path]:
-    suffix = package_info.suffix
-    apps = []
-    if package_info.include_apps:
-        apps += package_info.apps
-    if package_info.include_dependencies:
-        apps += package_info.apps_of_dependencies
-    return get_exposed_paths_for_package(venv_bin_path, local_bin_dir, [add_suffix(app, suffix) for app in apps])
-
-
-def _get_package_man_paths(venv: Venv, package_info: PackageInfo, venv_man_path: Path, local_man_dir: Path) -> set[Path]:
-    man_pages = []
-    if package_info.include_apps:
-        man_pages += package_info.man_pages
-    if package_info.include_dependencies:
-        man_pages += package_info.man_pages_of_dependencies
-    return get_exposed_man_paths_for_package(venv_man_path, local_man_dir, man_pages)
-
-
 def _get_venv_resource_paths(
-    resource_type: str,
-    venv: Venv,
+    resource_type: Literal["app", "man"],
     venv_resource_path: Path,
     local_resource_dir: Path,
     package_infos: tuple[PackageInfo, ...] | None,
 ) -> set[Path]:
-    resource_paths = set()
-    assert resource_type in ("app", "man"), "invalid resource type"
-    get_package_resource_paths: Callable[[Venv, PackageInfo, Path, Path], set[Path]]
-    get_package_resource_paths = {
+    get_package_resource_paths: Callable[[PackageInfo, Path, Path], set[Path]] = {
         "app": _get_package_bin_dir_app_paths,
         "man": _get_package_man_paths,
     }[resource_type]
-
     if package_infos is not None:
-        for package_info in package_infos:
-            resource_paths |= get_package_resource_paths(venv, package_info, venv_resource_path, local_resource_dir)
-    else:
-        # No metadata and no valid python interpreter.
-        # We'll take our best guess on what to uninstall here based on symlink
-        # location for symlink-capable systems.
-        # The heuristic here is any symlink in ~/.local/bin pointing to
-        # .local/share/pipx/venvs/VENV_NAME/{bin,Scripts} should be uninstalled.
-
-        # For non-symlink systems we give up and return an empty set.
-        if not local_resource_dir.is_dir() or not can_symlink(local_resource_dir):
-            return set()
-
-        resource_paths = get_exposed_paths_for_package(venv_resource_path, local_resource_dir)
-
-    return resource_paths
-
-
-def uninstall(venv_dir: Path, local_bin_dir: Path, local_man_dir: Path, verbose: bool) -> ExitCode:
-    """Uninstall entire venv_dir, including main package and all injected
-    packages.
-
-    Returns pipx exit code.
-    """
-    if not venv_dir.exists():
-        print(f"Nothing to uninstall for {venv_dir.name} {sleep}")
-        app = which(venv_dir.name)
-        if app:
-            print(f"{hazard}  Note: '{app}' still exists on your system and is on your PATH")
-        return EXIT_CODE_UNINSTALL_VENV_NONEXISTENT
-
-    venv = Venv(venv_dir, verbose=verbose)
-    package_infos = _get_venv_package_infos(venv)
-
-    bin_dir_app_paths = _get_venv_resource_paths("app", venv, venv.bin_path, local_bin_dir, package_infos)
-    man_dir_paths = set()
-    for man_section in MAN_SECTIONS:
-        man_dir_paths |= _get_venv_resource_paths(
-            "man", venv, venv.man_path / man_section, local_man_dir / man_section, package_infos
+        return set().union(
+            *(
+                get_package_resource_paths(package_info, venv_resource_path, local_resource_dir)
+                for package_info in package_infos
+            )
         )
 
-    for path in bin_dir_app_paths | man_dir_paths:
-        try:
-            safe_unlink(path)
-        except FileNotFoundError:
-            logger.info(f"tried to remove but couldn't find {path}")
-        else:
-            logger.info(f"removed file {path}")
-
-    rmdir(venv_dir)
-    print(f"uninstalled {venv.name}! {stars}")
-    return EXIT_CODE_OK
+    # Without metadata, pipx infers ownership from link targets.
+    if not local_resource_dir.is_dir() or not can_symlink(local_resource_dir):
+        return set()
+    return get_exposed_paths_for_package(venv_resource_path, local_resource_dir)
 
 
-def uninstall_all(
-    venv_container: VenvContainer,
-    local_bin_dir: Path,
-    local_man_dir: Path,
-    verbose: bool,
-) -> ExitCode:
-    """Returns pipx exit code."""
-    all_success = True
-    for venv_dir in venv_container.iter_venv_dirs():
-        return_val = uninstall(venv_dir, local_bin_dir, local_man_dir, verbose)
-        all_success &= return_val == 0
+def _get_package_bin_dir_app_paths(package_info: PackageInfo, venv_bin_path: Path, local_bin_dir: Path) -> set[Path]:
+    apps = (package_info.apps if package_info.include_apps else []) + (
+        package_info.apps_of_dependencies if package_info.include_dependencies else []
+    )
+    return get_exposed_paths_for_package(
+        venv_bin_path,
+        local_bin_dir,
+        [add_suffix(app, package_info.suffix) for app in apps],
+    )
 
-    return EXIT_CODE_OK if all_success else EXIT_CODE_UNINSTALL_ERROR
+
+def _get_package_man_paths(package_info: PackageInfo, venv_man_path: Path, local_man_dir: Path) -> set[Path]:
+    man_pages = (package_info.man_pages if package_info.include_apps else []) + (
+        package_info.man_pages_of_dependencies if package_info.include_dependencies else []
+    )
+    return get_exposed_man_paths_for_package(venv_man_path, local_man_dir, man_pages)
 
 
 __all__ = [
+    "UninstallData",
     "_get_package_bin_dir_app_paths",
     "_get_package_man_paths",
     "_get_venv_package_infos",

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -814,10 +814,11 @@ def _add_uninstall(subparsers, venv_completer: VenvCompleter, shared_parser: arg
         parents=[shared_parser],
     )
     p.add_argument("package").completer = venv_completer
+    p.add_argument("--json", action="store_true", help="Output a machine-readable result.")
     p.set_defaults(func=_cmd_uninstall)
 
 
-def _cmd_uninstall(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
+def _cmd_uninstall(args: argparse.Namespace, ctx: DispatchContext) -> OperationResult[commands.UninstallData]:
     return commands.uninstall(_venv_dir(args, ctx), paths.ctx.bin_dir, paths.ctx.man_dir, ctx.verbose)
 
 
@@ -828,10 +829,11 @@ def _add_uninstall_all(subparsers: argparse._SubParsersAction, shared_parser: ar
         description="Uninstall all pipx-managed packages",
         parents=[shared_parser],
     )
+    p.add_argument("--json", action="store_true", help="Output a machine-readable result.")
     p.set_defaults(func=_cmd_uninstall_all)
 
 
-def _cmd_uninstall_all(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
+def _cmd_uninstall_all(args: argparse.Namespace, ctx: DispatchContext) -> OperationResult[commands.UninstallData]:
     return commands.uninstall_all(ctx.venv_container, paths.ctx.bin_dir, paths.ctx.man_dir, ctx.verbose)
 
 

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -1,4 +1,7 @@
+import importlib
+import json
 import sys
+from typing import cast
 
 import pytest
 from pytest_mock import MockerFixture
@@ -28,6 +31,111 @@ def file_or_symlink(filepath):
 def test_uninstall(pipx_temp_env):
     assert not run_pipx_cli(["install", "pycowsay"])
     assert not run_pipx_cli(["uninstall", "pycowsay"])
+
+
+def test_uninstall_json(
+    uninstall_command: tuple[str, list[str]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    command, arguments = uninstall_command
+
+    assert not run_pipx_cli([command, *arguments, "--json"])
+
+    captured = capsys.readouterr()
+    assert (json.loads(captured.out), captured.err) == (
+        {
+            "command": command,
+            "data": {
+                "failures": [],
+                "packages": [
+                    {
+                        "environment": "pycowsay",
+                        "location": str(paths.ctx.venvs / "pycowsay"),
+                        "package": "pycowsay",
+                        "version": "0.0.0.2",
+                    }
+                ],
+            },
+            "pipx_result_version": "0.1",
+            "status": "success",
+        },
+        "",
+    )
+
+
+def test_uninstall_quiet(
+    uninstall_command: tuple[str, list[str]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    command, arguments = uninstall_command
+
+    assert not run_pipx_cli([command, *arguments, "--quiet"])
+
+    captured = capsys.readouterr()
+    assert (captured.out, captured.err) == ("", "")
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(("uninstall", ["pycowsay"]), id="one"),
+        pytest.param(("uninstall-all", []), id="all"),
+    ]
+)
+def uninstall_command(
+    request: pytest.FixtureRequest,
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+) -> tuple[str, list[str]]:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    capsys.readouterr()
+    return cast("tuple[str, list[str]]", request.param)
+
+
+def test_uninstall_json_reports_missing(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch.object(
+        importlib.import_module("pipx.commands.uninstall"),
+        "which",
+        autospec=True,
+        return_value="/usr/bin/missing",
+    )
+    assert run_pipx_cli(["uninstall", "missing", "--json"])
+
+    captured = capsys.readouterr()
+    assert (json.loads(captured.out), captured.err) == (
+        {
+            "command": "uninstall",
+            "data": {
+                "failures": [{"environment": "missing", "error": "Nothing to uninstall for missing."}],
+                "packages": [],
+            },
+            "pipx_result_version": "0.1",
+            "status": "error",
+        },
+        "",
+    )
+
+
+def test_uninstall_ignores_disappearing_resources(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    mocker: MockerFixture,
+) -> None:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    capsys.readouterr()
+    safe_unlink = mocker.patch.object(
+        importlib.import_module("pipx.commands.uninstall"),
+        "safe_unlink",
+        autospec=True,
+        side_effect=FileNotFoundError,
+    )
+
+    result = run_pipx_cli(["uninstall", "pycowsay"])
+
+    assert (result, (paths.ctx.venvs / "pycowsay").exists(), safe_unlink.call_count > 0) == (0, False, True)
 
 
 @skip_if_windows


### PR DESCRIPTION
`uninstall` and `uninstall-all` now follow the scriptable output contract tracked in [#828](https://github.com/pypa/pipx/issues/828). Both commands return package and failure data through the versioned JSON schema.

`--quiet` omits confirmations. When an environment is missing, pipx returns a typed failure and keeps stderr empty under `--json`.
