### PR TITLE
✨ feat(pin): add scriptable output

### DIFF
--- a/changelog.d/828.feature.md
+++ b/changelog.d/828.feature.md
@@ -1,1 +1,1 @@
-Make `upgrade-all` quiet and add JSON results.
+Add quiet and JSON output for package maintenance.

--- a/docs/how-to/pin-packages.md
+++ b/docs/how-to/pin-packages.md
@@ -11,6 +11,8 @@ versions until you unpin it.
 - `pipx unpin PACKAGE` — re-enables upgrades for the package and anything that was pinned with it.
 - `pipx list --pinned` — shows every pinned environment; add `--include-injected` to see pinned injected packages.
 
+Pass `--json` to read changed and skipped packages in a script, or `--quiet` to omit confirmations.
+
 pipx tracks the main package and any injected packages. It does not record individual transitive dependencies, so there
 is no way to pin a single dependency in isolation. Pinning the main package protects its dependency set because pipx
 skips running `pip install --upgrade` for that environment.

--- a/src/pipx/commands/__init__.py
+++ b/src/pipx/commands/__init__.py
@@ -4,7 +4,7 @@ from pipx.commands.inject import inject
 from pipx.commands.install import install, install_all
 from pipx.commands.interpreter import list_interpreters, prune_interpreters, upgrade_interpreters
 from pipx.commands.list_packages import list_packages
-from pipx.commands.pin import pin, unpin
+from pipx.commands.pin import PinData, pin, unpin
 from pipx.commands.reinstall import reinstall, reinstall_all
 from pipx.commands.run import run
 from pipx.commands.run_pip import run_pip
@@ -13,6 +13,7 @@ from pipx.commands.uninstall import uninstall, uninstall_all
 from pipx.commands.upgrade import upgrade, upgrade_all, upgrade_shared
 
 __all__ = [
+    "PinData",
     "ensure_pipx_paths",
     "environment",
     "inject",

--- a/src/pipx/commands/pin.py
+++ b/src/pipx/commands/pin.py
@@ -1,29 +1,18 @@
-import logging
-from collections.abc import Sequence
-from pathlib import Path
-from typing import Final
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
 
 from pipx.colors import bold
 from pipx.constants import ExitCode
 from pipx.emojis import sleep
-from pipx.util import PipxError
+from pipx.result import OperationData, OperationResult, OutputLevel, OutputMessage, OutputStream
 from pipx.venv import Venv
 
-_LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
-
-
-def _update_pin_info(venv: Venv, package_name: str, is_main_package: bool, unpin: bool) -> None:
-    package_metadata = venv.package_metadata[package_name]
-    venv.update_package_metadata(
-        package_name=str(package_metadata.package),
-        package_or_url=str(package_metadata.package_or_url),
-        pip_args=package_metadata.pip_args,
-        include_dependencies=package_metadata.include_dependencies,
-        include_apps=package_metadata.include_apps,
-        is_main_package=is_main_package,
-        suffix=package_metadata.suffix,
-        pinned=not unpin,
-    )
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
 
 
 def pin(
@@ -31,73 +20,167 @@ def pin(
     verbose: bool,
     skip: Sequence[str],
     injected_only: bool = False,
-) -> ExitCode:
+) -> OperationResult[PinData]:
     venv = Venv(venv_dir, verbose=verbose)
-    try:
-        main_package_metadata = venv.package_metadata[venv.main_package_name]
-    except KeyError as e:
-        raise PipxError(f"Package {venv.name} is not installed") from e
+    if (main_package := venv.package_metadata.get(venv.main_package_name)) is None:
+        return _missing_result("pin", venv)
 
+    messages: list[OutputMessage] = []
+    packages: list[_ChangedPackage] = []
+    skipped: list[_SkippedPackage] = []
     if injected_only or skip:
-        pinned_packages_list: list[str] = []
-        for package_name in venv.package_metadata:
-            if package_name == venv.main_package_name or package_name in skip:
-                continue
-
-            if venv.package_metadata[package_name].pinned:
-                print(f"{package_name} was pinned. Not modifying.")
-                continue
-
-            _update_pin_info(venv, package_name, is_main_package=False, unpin=False)
-            pinned_packages_list.append(f"{package_name} {venv.package_metadata[package_name].package_version}")
-
-        if pinned_packages_list:
-            print(bold(f"Pinned {len(pinned_packages_list)} packages in venv {venv.name}"))
-            for package in pinned_packages_list:
-                print("  -", package)
-    elif main_package_metadata.pinned:
-        _LOGGER.warning(f"Package {main_package_metadata.package} already pinned {sleep}")
-    else:
+        skip_names = set(skip)
         for package_name in venv.package_metadata:
             if package_name == venv.main_package_name:
-                _update_pin_info(venv, venv.main_package_name, is_main_package=True, unpin=False)
-            else:
-                _update_pin_info(venv, package_name, is_main_package=False, unpin=False)
+                continue
+            if package_name in skip_names:
+                skipped.append(_SkippedPackage(venv.name, package_name, "requested"))
+                continue
+            if venv.package_metadata[package_name].pinned:
+                skipped.append(_SkippedPackage(venv.name, package_name, "already-pinned"))
+                messages.append(OutputMessage(f"pipx already pins {package_name}; skipping it."))
+                continue
+            _update_pin_info(venv, package_name, is_main_package=False, pinned=True)
+            packages.append(_changed_package(venv, package_name, _PinStatus.PINNED))
 
-    return ExitCode(0)
+        if packages:
+            messages.append(_summary_message(venv, _PinStatus.PINNED, len(packages)))
+            messages.extend(OutputMessage(f"  - {package.package} {package.version}") for package in packages)
+    elif main_package.pinned:
+        skipped.append(_SkippedPackage(venv.name, str(main_package.package), "already-pinned"))
+        messages.append(
+            OutputMessage(f"pipx already pins package {main_package.package} {sleep}", stream=OutputStream.LOG)
+        )
+    else:
+        for package_name in venv.package_metadata:
+            if venv.package_metadata[package_name].pinned:
+                skipped.append(_SkippedPackage(venv.name, package_name, "already-pinned"))
+                continue
+            _update_pin_info(
+                venv,
+                package_name,
+                is_main_package=package_name == venv.main_package_name,
+                pinned=True,
+            )
+            packages.append(_changed_package(venv, package_name, _PinStatus.PINNED))
+
+    return OperationResult(
+        command="pin",
+        data=PinData(packages=tuple(packages), skipped=tuple(skipped), failures=()),
+        messages=tuple(messages),
+    )
 
 
-def unpin(venv_dir: Path, verbose: bool) -> ExitCode:
+def unpin(venv_dir: Path, verbose: bool) -> OperationResult[PinData]:
     venv = Venv(venv_dir, verbose=verbose)
-    try:
-        main_package_metadata = venv.package_metadata[venv.main_package_name]
-    except KeyError as e:
-        raise PipxError(f"Package {venv.name} is not installed") from e
+    if venv.package_metadata.get(venv.main_package_name) is None:
+        return _missing_result("unpin", venv)
 
-    unpinned_packages_list: list[str] = []
-
+    packages: list[_ChangedPackage] = []
+    skipped: list[_SkippedPackage] = []
     for package_name in venv.package_metadata:
         if not venv.package_metadata[package_name].pinned:
+            skipped.append(_SkippedPackage(venv.name, package_name, "not-pinned"))
             continue
         _update_pin_info(
             venv,
             package_name,
-            is_main_package=package_name == main_package_metadata.package,
-            unpin=True,
+            is_main_package=package_name == venv.main_package_name,
+            pinned=False,
         )
-        unpinned_packages_list.append(package_name)
+        packages.append(_changed_package(venv, package_name, _PinStatus.UNPINNED))
 
-    if unpinned_packages_list:
-        print(bold(f"Unpinned {len(unpinned_packages_list)} packages in venv {venv.name}"))
-        for package in unpinned_packages_list:
-            print("  -", package)
+    if packages:
+        messages = [_summary_message(venv, _PinStatus.UNPINNED, len(packages))]
+        messages.extend(OutputMessage(f"  - {package.package}") for package in packages)
     else:
-        _LOGGER.warning(f"No packages to unpin in venv {venv.name}")
+        messages = [OutputMessage(f"pipx found no pinned packages in venv {venv.name}", stream=OutputStream.LOG)]
 
-    return ExitCode(0)
+    return OperationResult(
+        command="unpin",
+        data=PinData(packages=tuple(packages), skipped=tuple(skipped), failures=()),
+        messages=tuple(messages),
+    )
+
+
+def _missing_result(command: str, venv: Venv) -> OperationResult[PinData]:
+    error = f"pipx does not manage package {venv.name}"
+    return OperationResult(
+        command=command,
+        data=PinData(packages=(), skipped=(), failures=(_FailedEnvironment(venv.name, error),)),
+        messages=(OutputMessage(error, stream=OutputStream.STDERR, level=OutputLevel.ERROR),),
+        exit_code=ExitCode(1),
+    )
+
+
+def _update_pin_info(venv: Venv, package_name: str, *, is_main_package: bool, pinned: bool) -> None:
+    package = venv.package_metadata[package_name]
+    venv.update_package_metadata(
+        package_name=str(package.package),
+        package_or_url=str(package.package_or_url),
+        pip_args=package.pip_args,
+        include_dependencies=package.include_dependencies,
+        include_apps=package.include_apps,
+        is_main_package=is_main_package,
+        suffix=package.suffix,
+        pinned=pinned,
+    )
+
+
+def _changed_package(venv: Venv, package_name: str, status: _PinStatus) -> _ChangedPackage:
+    package = venv.package_metadata[package_name]
+    return _ChangedPackage(
+        environment=venv.name,
+        package=f"{package.package}{package.suffix}",
+        version=package.package_version,
+        status=status,
+        injected=package_name != venv.main_package_name,
+        location=str(venv.root),
+    )
+
+
+def _summary_message(venv: Venv, status: _PinStatus, package_count: int) -> OutputMessage:
+    package_label = "package" if package_count == 1 else "packages"
+    return OutputMessage(bold(f"pipx {status.value} {package_count} {package_label} in venv {venv.name}"))
+
+
+class _PinStatus(str, Enum):
+    PINNED = "pinned"
+    UNPINNED = "unpinned"
+
+
+@dataclass(frozen=True)
+class _ChangedPackage:
+    environment: str
+    package: str
+    version: str
+    status: _PinStatus
+    injected: bool
+    location: str
+
+
+@dataclass(frozen=True)
+class _SkippedPackage:
+    environment: str
+    package: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class _FailedEnvironment:
+    environment: str
+    error: str
+
+
+@dataclass(frozen=True)
+class PinData(OperationData):
+    packages: tuple[_ChangedPackage, ...]
+    skipped: tuple[_SkippedPackage, ...]
+    failures: tuple[_FailedEnvironment, ...]
 
 
 __all__ = [
+    "PinData",
     "pin",
     "unpin",
 ]

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -649,7 +649,11 @@ def _cmd_uninject(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
     )
 
 
-def _add_pin(subparsers, venv_completer: VenvCompleter, shared_parser: argparse.ArgumentParser) -> None:
+def _add_pin(
+    subparsers: argparse._SubParsersAction,
+    venv_completer: VenvCompleter,
+    shared_parser: argparse.ArgumentParser,
+) -> None:
     p = subparsers.add_parser(
         "pin",
         help="Pin the specified package to prevent it from being upgraded",
@@ -671,14 +675,19 @@ def _add_pin(subparsers, venv_completer: VenvCompleter, shared_parser: argparse.
         default=[],
         help="Skip these packages. Implies `--injected-only`.",
     )
+    p.add_argument("--json", action="store_true", help="Output a machine-readable result.")
     p.set_defaults(func=_cmd_pin)
 
 
-def _cmd_pin(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
+def _cmd_pin(args: argparse.Namespace, ctx: DispatchContext) -> OperationResult[commands.PinData]:
     return commands.pin(_venv_dir(args, ctx), ctx.verbose, ctx.skip_list, args.injected_only)
 
 
-def _add_unpin(subparsers, venv_completer: VenvCompleter, shared_parser: argparse.ArgumentParser) -> None:
+def _add_unpin(
+    subparsers: argparse._SubParsersAction,
+    venv_completer: VenvCompleter,
+    shared_parser: argparse.ArgumentParser,
+) -> None:
     p = subparsers.add_parser(
         "unpin",
         help="Unpin the specified package",
@@ -686,10 +695,11 @@ def _add_unpin(subparsers, venv_completer: VenvCompleter, shared_parser: argpars
         parents=[shared_parser],
     )
     p.add_argument("package", help="Installed package to unpin")
+    p.add_argument("--json", action="store_true", help="Output a machine-readable result.")
     p.set_defaults(func=_cmd_unpin)
 
 
-def _cmd_unpin(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
+def _cmd_unpin(args: argparse.Namespace, ctx: DispatchContext) -> OperationResult[commands.PinData]:
     return commands.unpin(_venv_dir(args, ctx), ctx.verbose)
 
 

--- a/tests/test_pin.py
+++ b/tests/test_pin.py
@@ -1,8 +1,13 @@
+import json
+
+import pytest
+
 from helpers import run_pipx_cli
 from package_info import PKG
+from pipx import paths
 
 
-def test_pin(capsys, pipx_temp_env, caplog):
+def test_pin(pipx_temp_env: None, caplog: pytest.LogCaptureFixture) -> None:
     assert not run_pipx_cli(["install", "pycowsay"])
     assert not run_pipx_cli(["pin", "pycowsay"])
     assert not run_pipx_cli(["upgrade", "pycowsay"])
@@ -10,7 +15,111 @@ def test_pin(capsys, pipx_temp_env, caplog):
     assert "Not upgrading pinned package pycowsay" in caplog.text
 
 
-def test_pin_with_suffix(capsys, pipx_temp_env, caplog):
+def test_pin_json(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    capsys.readouterr()
+
+    assert not run_pipx_cli(["pin", "pycowsay", "--json"])
+
+    captured = capsys.readouterr()
+    assert (json.loads(captured.out), captured.err) == (
+        {
+            "command": "pin",
+            "data": {
+                "failures": [],
+                "packages": [
+                    {
+                        "environment": "pycowsay",
+                        "injected": False,
+                        "location": str(paths.ctx.venvs / "pycowsay"),
+                        "package": "pycowsay",
+                        "status": "pinned",
+                        "version": "0.0.0.2",
+                    }
+                ],
+                "skipped": [],
+            },
+            "pipx_result_version": "0.1",
+            "status": "success",
+        },
+        "",
+    )
+
+
+def test_pin_json_reports_missing(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert run_pipx_cli(["pin", "missing", "--json"])
+
+    captured = capsys.readouterr()
+    assert (json.loads(captured.out), captured.err) == (
+        {
+            "command": "pin",
+            "data": {
+                "failures": [{"environment": "missing", "error": "pipx does not manage package missing"}],
+                "packages": [],
+                "skipped": [],
+            },
+            "pipx_result_version": "0.1",
+            "status": "error",
+        },
+        "",
+    )
+
+
+def test_pin_quiet(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    assert not run_pipx_cli(["inject", "pycowsay", "black"])
+    capsys.readouterr()
+
+    assert not run_pipx_cli(["pin", "pycowsay", "--injected-only", "--quiet"])
+
+    captured = capsys.readouterr()
+    assert (captured.out, captured.err) == ("", "")
+
+
+def test_pin_json_reports_already_pinned_injected(
+    pinned_injected_environment: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert not run_pipx_cli(["pin", "pycowsay", "--injected-only", "--json"])
+
+    assert json.loads(capsys.readouterr().out)["data"] == {
+        "failures": [],
+        "packages": [],
+        "skipped": [{"environment": "pycowsay", "package": "black", "reason": "already-pinned"}],
+    }
+
+
+def test_pin_json_pins_main_after_injected(
+    pinned_injected_environment: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert not run_pipx_cli(["pin", "pycowsay", "--json"])
+
+    assert json.loads(capsys.readouterr().out)["data"] == {
+        "failures": [],
+        "packages": [
+            {
+                "environment": "pycowsay",
+                "injected": False,
+                "location": str(paths.ctx.venvs / "pycowsay"),
+                "package": "pycowsay",
+                "status": "pinned",
+                "version": "0.0.0.2",
+            }
+        ],
+        "skipped": [{"environment": "pycowsay", "package": "black", "reason": "already-pinned"}],
+    }
+
+
+@pytest.fixture
+def pinned_injected_environment(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    assert not run_pipx_cli(["inject", "pycowsay", "black"])
+    assert not run_pipx_cli(["pin", "pycowsay", "--injected-only"])
+    capsys.readouterr()
+
+
+def test_pin_with_suffix(pipx_temp_env: None, caplog: pytest.LogCaptureFixture) -> None:
     assert not run_pipx_cli(["install", PKG["black"]["spec"], "--suffix", "@1"])
     assert not run_pipx_cli(["pin", "black@1"])
     assert not run_pipx_cli(["upgrade", "black@1"])
@@ -18,22 +127,26 @@ def test_pin_with_suffix(capsys, pipx_temp_env, caplog):
     assert "Not upgrading pinned package black@1" in caplog.text
 
 
-def test_pin_warning(capsys, pipx_temp_env, caplog):
+def test_pin_warning(pipx_temp_env: None, caplog: pytest.LogCaptureFixture) -> None:
     assert not run_pipx_cli(["install", PKG["nox"]["spec"]])
     assert not run_pipx_cli(["pin", "nox"])
     assert not run_pipx_cli(["pin", "nox"])
 
-    assert "Package nox already pinned 😴" in caplog.text
+    assert "pipx already pins package nox 😴" in caplog.text
 
 
-def test_pin_not_installed_package(capsys, pipx_temp_env):
+def test_pin_not_installed_package(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
     assert run_pipx_cli(["pin", "abc"])
 
     captured = capsys.readouterr()
-    assert "Package abc is not installed" in captured.err
+    assert "pipx does not manage package abc" in captured.err
 
 
-def test_pin_injected_packages_only(capsys, pipx_temp_env, caplog):
+def test_pin_injected_packages_only(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     assert not run_pipx_cli(["install", "pycowsay"])
     assert not run_pipx_cli(["inject", "pycowsay", "black", PKG["pylint"]["spec"]])
 
@@ -41,7 +154,7 @@ def test_pin_injected_packages_only(capsys, pipx_temp_env, caplog):
 
     captured = capsys.readouterr()
 
-    assert "Pinned 2 packages in venv pycowsay" in captured.out
+    assert "pipx pinned 2 packages in venv pycowsay" in captured.out
     assert "black" in captured.out
     assert "pylint" in captured.out
 
@@ -51,7 +164,11 @@ def test_pin_injected_packages_only(capsys, pipx_temp_env, caplog):
     assert "Not upgrading pinned package pylint in venv pycowsay" in caplog.text
 
 
-def test_pin_injected_packages_only_when_main_package_pinned(capsys, pipx_temp_env, caplog):
+def test_pin_injected_packages_only_when_main_package_pinned(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     assert not run_pipx_cli(["install", "pycowsay"])
     assert not run_pipx_cli(["pin", "pycowsay"])
     assert not run_pipx_cli(["inject", "pycowsay", "black", PKG["pylint"]["spec"]])
@@ -63,10 +180,10 @@ def test_pin_injected_packages_only_when_main_package_pinned(capsys, pipx_temp_e
 
     captured = capsys.readouterr()
 
-    assert "Pinned 2 packages in venv pycowsay" in captured.out
+    assert "pipx pinned 2 packages in venv pycowsay" in captured.out
     assert "black" in captured.out
     assert "pylint" in captured.out
-    assert "Package pycowsay already pinned" not in caplog.text
+    assert "pipx already pins package pycowsay" not in caplog.text
 
     assert not run_pipx_cli(["upgrade", "pycowsay", "--include-injected"])
 
@@ -75,7 +192,10 @@ def test_pin_injected_packages_only_when_main_package_pinned(capsys, pipx_temp_e
     assert "Not upgrading pinned package pylint in venv pycowsay" in caplog.text
 
 
-def test_pin_injected_packages_with_skip(capsys, pipx_temp_env):
+def test_pin_injected_packages_with_skip(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     assert not run_pipx_cli(["install", "black"])
     assert not run_pipx_cli(["inject", "black", PKG["pylint"]["spec"], PKG["isort"]["spec"]])
 

--- a/tests/test_unpin.py
+++ b/tests/test_unpin.py
@@ -1,12 +1,14 @@
+import json
 from pathlib import Path
 
 import pytest
 
 from helpers import run_pipx_cli
 from package_info import PKG
+from pipx import paths
 
 
-def test_unpin(capsys, pipx_temp_env, caplog):
+def test_unpin(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
     assert not run_pipx_cli(["install", PKG["nox"]["spec"]])
     assert not run_pipx_cli(["pin", "nox"])
 
@@ -17,13 +19,56 @@ def test_unpin(capsys, pipx_temp_env, caplog):
     assert "nox is already at latest version" in captured.out
 
 
-def test_unpin_with_suffix(capsys, pipx_temp_env):
+def test_unpin_json(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    assert not run_pipx_cli(["pin", "pycowsay"])
+    capsys.readouterr()
+
+    assert not run_pipx_cli(["unpin", "pycowsay", "--json"])
+
+    captured = capsys.readouterr()
+    assert (json.loads(captured.out), captured.err) == (
+        {
+            "command": "unpin",
+            "data": {
+                "failures": [],
+                "packages": [
+                    {
+                        "environment": "pycowsay",
+                        "injected": False,
+                        "location": str(paths.ctx.venvs / "pycowsay"),
+                        "package": "pycowsay",
+                        "status": "unpinned",
+                        "version": "0.0.0.2",
+                    }
+                ],
+                "skipped": [],
+            },
+            "pipx_result_version": "0.1",
+            "status": "success",
+        },
+        "",
+    )
+
+
+def test_unpin_quiet(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    assert not run_pipx_cli(["pin", "pycowsay"])
+    capsys.readouterr()
+
+    assert not run_pipx_cli(["unpin", "pycowsay", "--quiet"])
+
+    captured = capsys.readouterr()
+    assert (captured.out, captured.err) == ("", "")
+
+
+def test_unpin_with_suffix(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
     assert not run_pipx_cli(["install", PKG["black"]["spec"], "--suffix", "@1"])
     assert not run_pipx_cli(["pin", "black@1"])
     assert not run_pipx_cli(["unpin", "black@1"])
 
     captured = capsys.readouterr()
-    assert "Unpinned 1 packages in venv black@1" in captured.out
+    assert "pipx unpinned 1 package in venv black@1" in captured.out
 
     assert not run_pipx_cli(["upgrade", "black@1"])
 
@@ -31,30 +76,30 @@ def test_unpin_with_suffix(capsys, pipx_temp_env):
     assert "upgraded package black@1 from 22.8.0 to 22.10.0" in captured.out
 
 
-def test_unpin_warning(capsys, pipx_temp_env, caplog):
+def test_unpin_warning(pipx_temp_env: None, caplog: pytest.LogCaptureFixture) -> None:
     assert not run_pipx_cli(["install", PKG["nox"]["spec"]])
     assert not run_pipx_cli(["pin", "nox"])
     assert not run_pipx_cli(["unpin", "nox"])
     assert not run_pipx_cli(["unpin", "nox"])
 
-    assert "No packages to unpin in venv nox" in caplog.text
+    assert "pipx found no pinned packages in venv nox" in caplog.text
 
 
-def test_unpin_not_installed_package(capsys, pipx_temp_env):
+def test_unpin_not_installed_package(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
     assert run_pipx_cli(["unpin", "abc"])
 
     captured = capsys.readouterr()
-    assert "Package abc is not installed" in captured.err
+    assert "pipx does not manage package abc" in captured.err
 
 
-def test_unpin_injected_packages(capsys, pipx_temp_env):
+def test_unpin_injected_packages(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
     assert not run_pipx_cli(["install", "black"])
     assert not run_pipx_cli(["inject", "black", "nox", "pylint"])
     assert not run_pipx_cli(["pin", "black"])
     assert not run_pipx_cli(["unpin", "black"])
 
     captured = capsys.readouterr()
-    assert "Unpinned 3 packages in venv black" in captured.out
+    assert "pipx unpinned 3 packages in venv black" in captured.out
 
 
 def test_unpin_reports_only_changed_packages(
@@ -69,6 +114,6 @@ def test_unpin_reports_only_changed_packages(
 
     assert not run_pipx_cli(["unpin", "pycowsay"])
     output = capsys.readouterr().out
-    assert "Unpinned 1 packages in venv pycowsay" in output
+    assert "pipx unpinned 1 package in venv pycowsay" in output
     assert "  - empty-project" in output
     assert "  - pycowsay" not in output


### PR DESCRIPTION
`pin` and `unpin` now follow the shared scriptable output contract tracked in [#828](https://github.com/pypa/pipx/issues/828). Shell callers no longer need to parse terminal text.

Callers receive changes and failures through `--json`, including a reason when pipx skips a package. Pass `--quiet` to omit confirmations.
