### PR TITLE
✨ feat(health): repair broken environments

### DIFF
--- a/changelog.d/1442.feature.md
+++ b/changelog.d/1442.feature.md
@@ -1,0 +1,1 @@
+Add commands to diagnose and repair broken environment interpreters.

--- a/docs/explanation/comparisons.md
+++ b/docs/explanation/comparisons.md
@@ -38,24 +38,26 @@ managers writes the same filename. Each manager refuses to overwrite a binary th
 
 ### Subcommand mapping
 
-| Task                           | pipx                                              | uv tool                                                             |
-| ------------------------------ | ------------------------------------------------- | ------------------------------------------------------------------- |
-| Install from PyPI              | `pipx install ruff`                               | `uv tool install ruff` (or `uvx ruff` for one-off)                  |
-| Install from a git URL         | `pipx install 'git+https://…'`                    | `uv tool install 'git+https://…'`                                   |
-| Install editable from path     | `pipx install -e ./mypkg`                         | `uv tool install -e ./mypkg`                                        |
-| One-off run (no install)       | `pipx run black .`                                | `uvx black .`                                                       |
-| One-off run with extra dep     | _no clean equivalent_                             | `uvx --with mkdocs-material mkdocs`                                 |
-| Pinned-version one-off         | `pipx run --spec 'ruff==0.6.0' ruff check`        | `uvx ruff@0.6.0 check`                                              |
-| Add a dep to existing tool     | `pipx inject mkdocs mkdocs-material`              | `uv tool install mkdocs --with mkdocs-material` (rebuilds)          |
-| Remove an injected dep         | `pipx uninject mkdocs mkdocs-material`            | _rebuild without `--with`_                                          |
-| Upgrade one                    | `pipx upgrade ruff`                               | `uv tool upgrade ruff`                                              |
-| Upgrade all                    | `pipx upgrade-all`                                | `uv tool upgrade --all`                                             |
-| List installed                 | `pipx list`                                       | `uv tool list` (`--show-with`, `--outdated`, …)                     |
-| Reinstall (e.g. after Py bump) | `pipx reinstall ruff` / `reinstall-all`           | `uv tool upgrade --reinstall ruff` / `--all -p 3.13`                |
-| Run pip inside a venv          | `pipx runpip <tool> -- pip ...`                   | _not supported (no pip in uv venvs)_                                |
-| PATH setup                     | `pipx ensurepath`                                 | `uv tool update-shell`                                              |
-| Show resolved env              | `pipx environment`                                | `uv tool dir`, `uv tool dir --bin`, `uv cache dir`, `uv python dir` |
-| PEP 723 inline script          | `pipx run script.py` (with uv backend → `uv run`) | `uv run --script script.py`                                         |
+| Task                         | pipx                                              | uv tool                                                             |
+| ---------------------------- | ------------------------------------------------- | ------------------------------------------------------------------- |
+| Install from PyPI            | `pipx install ruff`                               | `uv tool install ruff` (or `uvx ruff` for one-off)                  |
+| Install from a git URL       | `pipx install 'git+https://…'`                    | `uv tool install 'git+https://…'`                                   |
+| Install editable from path   | `pipx install -e ./mypkg`                         | `uv tool install -e ./mypkg`                                        |
+| One-off run (no install)     | `pipx run black .`                                | `uvx black .`                                                       |
+| One-off run with extra dep   | _no clean equivalent_                             | `uvx --with mkdocs-material mkdocs`                                 |
+| Pinned-version one-off       | `pipx run --spec 'ruff==0.6.0' ruff check`        | `uvx ruff@0.6.0 check`                                              |
+| Add a dep to existing tool   | `pipx inject mkdocs mkdocs-material`              | `uv tool install mkdocs --with mkdocs-material` (rebuilds)          |
+| Remove an injected dep       | `pipx uninject mkdocs mkdocs-material`            | _rebuild without `--with`_                                          |
+| Upgrade one                  | `pipx upgrade ruff`                               | `uv tool upgrade ruff`                                              |
+| Upgrade all                  | `pipx upgrade-all`                                | `uv tool upgrade --all`                                             |
+| List installed               | `pipx list`                                       | `uv tool list` (`--show-with`, `--outdated`, …)                     |
+| Diagnose broken environments | `pipx health`                                     | _no equivalent_                                                     |
+| Repair broken environments   | `pipx repair ruff` / `repair`                     | `uv tool install ruff` / _no bulk equivalent_                       |
+| Reinstall any environment    | `pipx reinstall ruff` / `reinstall-all`           | `uv tool upgrade --reinstall ruff` / `--all`                        |
+| Run pip inside a venv        | `pipx runpip <tool> -- pip ...`                   | _not supported (no pip in uv venvs)_                                |
+| PATH setup                   | `pipx ensurepath`                                 | `uv tool update-shell`                                              |
+| Show resolved env            | `pipx environment`                                | `uv tool dir`, `uv tool dir --bin`, `uv cache dir`, `uv python dir` |
+| PEP 723 inline script        | `pipx run script.py` (with uv backend → `uv run`) | `uv run --script script.py`                                         |
 
 ### Only in pipx
 

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -20,22 +20,35 @@ pipx install my-package --python 3.13 --fetch-python=missing
 Pass `--fetch-python=always` to download a standalone build even when the system already has the requested Python.
 Useful when a distro ships a patched interpreter you'd rather avoid.
 
-## `reinstall-all` fixes most issues
+## Diagnose and repair broken environments
 
-The following command should fix many problems you may encounter as a pipx user:
+Check each managed environment without changing it:
 
 ```
-pipx reinstall-all
+pipx health
 ```
 
-This is a good fix for the following problems:
+The command exits with status 1 when an environment cannot run its Python interpreter. Pass package names to check a
+subset, or pass `--json` to read the result from a script.
 
-- System python was upgraded and the python used with a pipx-installed package is no longer available
-- pipx upgrade causes issues with old pipx-installed packages
+Repair failed environments with the default Python:
 
-pipx has been upgraded a lot over the years. If you are a long-standing pipx user (thanks, by the way!) then you may
-have old pipx-installed packages that have internal data that is different than what pipx currently expects. By
-executing `pipx reinstall-all`, pipx will re-write its internal data and this should fix many issues you may encounter.
+```
+pipx repair
+```
+
+Pass package names to limit the repair. Use `--python` when the rebuilt environments need another interpreter:
+
+```
+pipx repair --python python3.13
+```
+
+`pipx repair` uses the same recorded metadata as `pipx reinstall`. It leaves healthy environments unchanged.
+
+`pipx repair` refuses a pinned package because its recorded source may resolve to another release. Run
+`pipx unpin PACKAGE` before repairing it.
+
+Use `pipx reinstall-all` to rebuild healthy environments, such as installations with metadata from an old pipx release.
 
 **Note:** If your pipx-installed package was installed using a pipx version before 0.15.0.0 and you want to specify
 particular options, then you may want to uninstall and install it manually:
@@ -45,14 +58,13 @@ pipx uninstall <mypackage>
 pipx install <mypackage>
 ```
 
-## Diagnosing problems using `list`
+## Inspect package details with `list`
 
 ```
 pipx list
 ```
 
-will not only list all of your pipx-installed packages, but can also diagnose some problems with them, as well as
-suggest solutions.
+The command prints package versions, applications, and environment paths.
 
 ## Specifying pipx options
 

--- a/docs/man/pipx.1.rst
+++ b/docs/man/pipx.1.rst
@@ -16,8 +16,8 @@ SYNOPSIS
 
 **pipx** [*global-options*] [**install** | **install-all** | **uninject** | **inject** | **pin** | **unpin** |
 **upgrade** | **upgrade-all** | **upgrade-shared** | **uninstall** | **uninstall-all** | **reinstall** | **reinstall-
-all** | **list** | **interpreter** | **run** | **runpip** | **ensurepath** | **environment** | **completions** |
-**help**] [*command-options*]
+all** | **health** | **repair** | **list** | **interpreter** | **run** | **runpip** | **ensurepath** | **environment** |
+**completions** | **help**] [*command-options*]
 
 DESCRIPTION
 -----------
@@ -66,6 +66,12 @@ COMMANDS
 
 **reinstall-all**
     Reinstall all packages
+
+**health**
+    Check installed package environments
+
+**repair**
+    Repair broken package environments
 
 **list**
     List installed packages

--- a/src/pipx/commands/__init__.py
+++ b/src/pipx/commands/__init__.py
@@ -1,5 +1,6 @@
 from pipx.commands.ensure_path import ensure_pipx_paths
 from pipx.commands.environment import environment
+from pipx.commands.health import HealthData, RepairData, health, repair
 from pipx.commands.inject import inject
 from pipx.commands.install import install, install_all
 from pipx.commands.interpreter import list_interpreters, prune_interpreters, upgrade_interpreters
@@ -13,10 +14,13 @@ from pipx.commands.uninstall import UninstallData, uninstall, uninstall_all
 from pipx.commands.upgrade import upgrade, upgrade_all, upgrade_shared
 
 __all__ = [
+    "HealthData",
     "PinData",
+    "RepairData",
     "UninstallData",
     "ensure_pipx_paths",
     "environment",
+    "health",
     "inject",
     "install",
     "install_all",
@@ -26,6 +30,7 @@ __all__ = [
     "prune_interpreters",
     "reinstall",
     "reinstall_all",
+    "repair",
     "run",
     "run_pip",
     "uninject",

--- a/src/pipx/commands/health.py
+++ b/src/pipx/commands/health.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from pipx.commands.reinstall import reinstall
+from pipx.constants import ExitCode
+from pipx.result import OperationData, OperationResult, OutputLevel, OutputMessage, OutputStream
+from pipx.util import PipxError, get_venv_paths, run_subprocess
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+    from pipx.venv import VenvContainer
+
+
+def health(venv_container: VenvContainer, venv_dirs: Iterable[Path]) -> OperationResult[HealthData]:
+    environments: list[_EnvironmentHealth] = []
+    messages: list[OutputMessage] = []
+    for venv_dir in venv_dirs:
+        with venv_container.venv_lock(venv_dir):
+            environment = _check_health(venv_dir)
+        environments.append(environment)
+        if environment.status is _HealthStatus.HEALTHY:
+            messages.append(OutputMessage(f"{environment.environment}: healthy"))
+            continue
+        location = f" at {environment.interpreter}" if environment.interpreter else ""
+        messages.append(OutputMessage(f"{environment.environment}: {environment.error}{location}"))
+    if not messages:
+        messages.append(OutputMessage("pipx manages no packages."))
+    return OperationResult(
+        command="health",
+        data=HealthData(environments=tuple(environments)),
+        messages=tuple(messages),
+        exit_code=ExitCode(
+            1 if any(environment.status is not _HealthStatus.HEALTHY for environment in environments) else 0
+        ),
+    )
+
+
+def repair(
+    venv_container: VenvContainer,
+    venv_dirs: Iterable[Path],
+    local_bin_dir: Path,
+    local_man_dir: Path,
+    python: str,
+    verbose: bool,
+    *,
+    python_flag_passed: bool = False,
+    backend: str | None = None,
+    env_backend: str | None = None,
+) -> OperationResult[RepairData]:
+    failures: list[_FailedRepair] = []
+    messages: list[OutputMessage] = []
+    repaired: list[_RepairedEnvironment] = []
+    skipped: list[_SkippedRepair] = []
+    for venv_dir in venv_dirs:
+        with venv_container.venv_lock(venv_dir) as venv_lock:
+            environment = _check_health(venv_dir)
+            if environment.status is _HealthStatus.HEALTHY:
+                skipped.append(_SkippedRepair(venv_dir.name, "healthy"))
+                messages.append(OutputMessage(f"{venv_dir.name}: healthy"))
+                continue
+            if environment.status is _HealthStatus.MISSING:
+                failure = _FailedRepair(venv_dir.name, environment.error or "environment is missing")
+                failures.append(failure)
+                messages.append(_repair_failure_message(failure))
+                continue
+            try:
+                reinstall(
+                    venv_dir=venv_dir,
+                    local_bin_dir=local_bin_dir,
+                    local_man_dir=local_man_dir,
+                    python=python,
+                    verbose=verbose,
+                    python_flag_passed=python_flag_passed,
+                    backend=backend,
+                    env_backend=env_backend,
+                    venv_lock=venv_lock,
+                )
+            except PipxError as error:
+                failure = _FailedRepair(venv_dir.name, str(error))
+                failures.append(failure)
+                messages.append(_repair_failure_message(failure))
+                continue
+            if (environment := _check_health(venv_dir)).status is not _HealthStatus.HEALTHY:
+                failure = _FailedRepair(venv_dir.name, environment.error or "interpreter remains broken")
+                failures.append(failure)
+                messages.append(_repair_failure_message(failure))
+                continue
+            repaired.append(_RepairedEnvironment(venv_dir.name, environment.interpreter))
+            messages.append(OutputMessage(f"{venv_dir.name}: repaired"))
+
+    if not messages:
+        messages.append(OutputMessage("pipx found no environments to repair."))
+    return OperationResult(
+        command="repair",
+        data=RepairData(repaired=tuple(repaired), skipped=tuple(skipped), failures=tuple(failures)),
+        messages=tuple(messages),
+        exit_code=ExitCode(1 if failures else 0),
+    )
+
+
+def _check_health(venv_dir: Path) -> _EnvironmentHealth:
+    if not venv_dir.is_dir():
+        return _EnvironmentHealth(venv_dir.name, "", _HealthStatus.MISSING, "pipx does not manage this environment")
+
+    _, interpreter, _ = get_venv_paths(venv_dir)
+    if not interpreter.is_file():
+        return _EnvironmentHealth(venv_dir.name, str(interpreter), _HealthStatus.BROKEN, "interpreter is missing")
+    try:
+        process = run_subprocess([interpreter, "--version"], log_stdout=False, log_stderr=False)
+    except OSError as error:
+        return _EnvironmentHealth(
+            venv_dir.name,
+            str(interpreter),
+            _HealthStatus.BROKEN,
+            f"interpreter could not start: {error.strerror or error}",
+        )
+    if process.returncode:
+        return _EnvironmentHealth(
+            venv_dir.name,
+            str(interpreter),
+            _HealthStatus.BROKEN,
+            f"interpreter exited with status {process.returncode}",
+        )
+    return _EnvironmentHealth(venv_dir.name, str(interpreter), _HealthStatus.HEALTHY, None)
+
+
+def _repair_failure_message(failure: _FailedRepair) -> OutputMessage:
+    return OutputMessage(
+        f"{failure.environment}: {failure.error}",
+        stream=OutputStream.STDERR,
+        level=OutputLevel.ERROR,
+    )
+
+
+class _HealthStatus(str, Enum):
+    HEALTHY = "healthy"
+    BROKEN = "broken"
+    MISSING = "missing"
+
+
+@dataclass(frozen=True)
+class _EnvironmentHealth:
+    environment: str
+    interpreter: str
+    status: _HealthStatus
+    error: str | None
+
+
+@dataclass(frozen=True)
+class HealthData(OperationData):
+    environments: tuple[_EnvironmentHealth, ...]
+
+
+@dataclass(frozen=True)
+class _RepairedEnvironment:
+    environment: str
+    interpreter: str
+
+
+@dataclass(frozen=True)
+class _SkippedRepair:
+    environment: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class _FailedRepair:
+    environment: str
+    error: str
+
+
+@dataclass(frozen=True)
+class RepairData(OperationData):
+    repaired: tuple[_RepairedEnvironment, ...]
+    skipped: tuple[_SkippedRepair, ...]
+    failures: tuple[_FailedRepair, ...]
+
+
+__all__ = [
+    "HealthData",
+    "RepairData",
+    "health",
+    "repair",
+]

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -923,6 +923,63 @@ def _cmd_reinstall_all(args: argparse.Namespace, ctx: DispatchContext) -> ExitCo
     )
 
 
+def _add_health(
+    subparsers: argparse._SubParsersAction,
+    venv_completer: VenvCompleter,
+    shared_parser: argparse.ArgumentParser,
+) -> None:
+    parser = subparsers.add_parser(
+        "health",
+        help="Check installed package environments",
+        description="Check whether installed package environments can run their Python interpreter.",
+        parents=[shared_parser],
+    )
+    parser.add_argument("packages", nargs="*", help="Installed packages to check").completer = venv_completer
+    parser.add_argument("--json", action="store_true", help="Output a machine-readable result.")
+    parser.set_defaults(func=_cmd_health)
+
+
+def _cmd_health(args: argparse.Namespace, ctx: DispatchContext) -> OperationResult[commands.HealthData]:
+    return commands.health(ctx.venv_container, _selected_venv_dirs(args, ctx))
+
+
+def _add_repair(
+    subparsers: argparse._SubParsersAction,
+    venv_completer: VenvCompleter,
+    shared_parser: argparse.ArgumentParser,
+) -> None:
+    parser = subparsers.add_parser(
+        "repair",
+        help="Repair broken package environments",
+        description="Reinstall packages whose environments cannot run their Python interpreter.",
+        parents=[shared_parser],
+    )
+    parser.add_argument("packages", nargs="*", help="Installed packages to repair").completer = venv_completer
+    add_python_options(parser)
+    add_backend_arg(parser)
+    parser.set_defaults(func=_cmd_repair)
+
+
+def _cmd_repair(args: argparse.Namespace, ctx: DispatchContext) -> OperationResult[commands.RepairData]:
+    return commands.repair(
+        ctx.venv_container,
+        _selected_venv_dirs(args, ctx),
+        paths.ctx.bin_dir,
+        paths.ctx.man_dir,
+        ctx.python,
+        ctx.verbose,
+        python_flag_passed=ctx.python_flag_passed,
+        backend=ctx.backend,
+        env_backend=ctx.env_backend,
+    )
+
+
+def _selected_venv_dirs(args: argparse.Namespace, ctx: DispatchContext) -> tuple[Path, ...]:
+    if args.packages:
+        return tuple(_venv_dirs(args, ctx).values())
+    return tuple(sorted(ctx.venv_container.iter_venv_dirs()))
+
+
 def _add_list(subparsers: argparse._SubParsersAction, shared_parser: argparse.ArgumentParser) -> None:
     p = subparsers.add_parser(
         "list",
@@ -1279,6 +1336,8 @@ def get_command_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Ar
     _add_uninstall_all(subparsers, shared_parser)
     _add_reinstall(subparsers, completer_venvs.use, shared_parser)
     _add_reinstall_all(subparsers, shared_parser)
+    _add_health(subparsers, completer_venvs.use, shared_parser)
+    _add_repair(subparsers, completer_venvs.use, shared_parser)
     _add_list(subparsers, shared_parser)
     subparsers_with_subcommands["interpreter"] = _add_interpreter(subparsers, shared_parser)
     _add_run(subparsers, shared_parser)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,177 @@
+import importlib
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Final
+
+import pytest
+from pytest import CaptureFixture
+from pytest_mock import MockerFixture
+
+from helpers import remove_venv_interpreter, run_pipx_cli
+from pipx import paths, util
+
+_HEALTH_MODULE: Final[ModuleType] = importlib.import_module("pipx.commands.health")
+
+
+@pytest.fixture
+def installed_pycowsay(pipx_temp_env: None, capsys: CaptureFixture[str]) -> Path:
+    assert run_pipx_cli(["install", "pycowsay"]) == 0
+    capsys.readouterr()
+    return paths.ctx.venvs / "pycowsay"
+
+
+@pytest.mark.parametrize(
+    ("command", "message"),
+    [
+        pytest.param("health", "pipx manages no packages.\n", id="health"),
+        pytest.param("repair", "pipx found no environments to repair.\n", id="repair"),
+    ],
+)
+def test_environment_maintenance_no_packages(
+    pipx_temp_env: None,
+    capsys: CaptureFixture[str],
+    command: str,
+    message: str,
+) -> None:
+    assert run_pipx_cli([command]) == 0
+
+    assert capsys.readouterr().out == message
+
+
+def test_health_json(installed_pycowsay: Path, capsys: CaptureFixture[str]) -> None:
+    assert run_pipx_cli(["health", "pycowsay", "--json"]) == 0
+
+    assert json.loads(capsys.readouterr().out) == {
+        "command": "health",
+        "data": {
+            "environments": [
+                {
+                    "environment": "pycowsay",
+                    "error": None,
+                    "interpreter": str(util.get_venv_paths(installed_pycowsay)[1]),
+                    "status": "healthy",
+                }
+            ]
+        },
+        "pipx_result_version": "0.1",
+        "status": "success",
+    }
+
+
+def test_health_reports_broken_interpreter(installed_pycowsay: Path, capsys: CaptureFixture[str]) -> None:
+    remove_venv_interpreter("pycowsay")
+
+    assert run_pipx_cli(["health"]) == 1
+
+    assert capsys.readouterr().out == (
+        f"pycowsay: interpreter is missing at {util.get_venv_paths(installed_pycowsay)[1]}\n"
+    )
+
+
+@pytest.mark.parametrize(
+    ("failure", "error"),
+    [
+        pytest.param(
+            subprocess.CompletedProcess(["python", "--version"], 7, "", "failure"),
+            "interpreter exited with status 7",
+            id="exit-status",
+        ),
+        pytest.param(PermissionError("denied"), "interpreter could not start: denied", id="start-error"),
+    ],
+)
+def test_health_reports_interpreter_failure(
+    installed_pycowsay: Path,
+    capsys: CaptureFixture[str],
+    mocker: MockerFixture,
+    failure: subprocess.CompletedProcess[str] | OSError,
+    error: str,
+) -> None:
+    if isinstance(failure, OSError):
+        mocker.patch.object(_HEALTH_MODULE, "run_subprocess", autospec=True, side_effect=failure)
+    else:
+        mocker.patch.object(_HEALTH_MODULE, "run_subprocess", autospec=True, return_value=failure)
+
+    assert run_pipx_cli(["health", "pycowsay"]) == 1
+
+    assert capsys.readouterr().out == (f"pycowsay: {error} at {util.get_venv_paths(installed_pycowsay)[1]}\n")
+
+
+@pytest.mark.parametrize(
+    ("command", "output"),
+    [
+        pytest.param("health", ("missing: pipx does not manage this environment\n", ""), id="health"),
+        pytest.param("repair", ("", "missing: pipx does not manage this environment\n"), id="repair"),
+    ],
+)
+def test_environment_maintenance_reports_unmanaged_package(
+    pipx_temp_env: None,
+    capsys: CaptureFixture[str],
+    command: str,
+    output: tuple[str, str],
+) -> None:
+    assert run_pipx_cli([command, "missing"]) == 1
+
+    captured = capsys.readouterr()
+    assert (captured.out, captured.err) == output
+
+
+def test_repair_rebuilds_broken_interpreter(installed_pycowsay: Path, capsys: CaptureFixture[str]) -> None:
+    remove_venv_interpreter("pycowsay")
+
+    assert run_pipx_cli(["repair", "--python", sys.executable]) == 0
+    capsys.readouterr()
+
+    assert run_pipx_cli(["health", "pycowsay"]) == 0
+    assert "pycowsay: healthy" in capsys.readouterr().out
+
+
+@pytest.mark.skipif(shutil.which("uv") is None, reason="uv is not on PATH")
+def test_repair_preserves_uv_backend(pipx_temp_env: None, capsys: CaptureFixture[str]) -> None:
+    assert run_pipx_cli(["install", "--backend", "uv", "--python", sys.executable, "pycowsay"]) == 0
+    remove_venv_interpreter("pycowsay")
+    capsys.readouterr()
+
+    assert run_pipx_cli(["repair", "--python", sys.executable, "pycowsay"]) == 0
+    capsys.readouterr()
+    assert run_pipx_cli(["list", "--json"]) == 0
+
+    assert json.loads(capsys.readouterr().out)["venvs"]["pycowsay"]["metadata"]["backend"] == "uv"
+
+
+def test_repair_skips_healthy_interpreter(installed_pycowsay: Path, capsys: CaptureFixture[str]) -> None:
+    assert run_pipx_cli(["repair", "pycowsay"]) == 0
+
+    assert capsys.readouterr().out == "pycowsay: healthy\n"
+
+
+def test_repair_respects_pin(installed_pycowsay: Path, capsys: CaptureFixture[str]) -> None:
+    assert run_pipx_cli(["pin", "pycowsay"]) == 0
+    remove_venv_interpreter("pycowsay")
+    capsys.readouterr()
+
+    assert run_pipx_cli(["repair", "pycowsay"]) == 1
+
+    assert "is pinned. Run `pipx unpin pycowsay` to unpin it first." in capsys.readouterr().err.replace("\n", " ")
+
+
+def test_repair_verifies_rebuilt_interpreter(
+    installed_pycowsay: Path,
+    capsys: CaptureFixture[str],
+    mocker: MockerFixture,
+) -> None:
+    remove_venv_interpreter("pycowsay")
+    capsys.readouterr()
+    mocker.patch.object(
+        _HEALTH_MODULE,
+        "run_subprocess",
+        autospec=True,
+        return_value=subprocess.CompletedProcess(["python", "--version"], 7, "", "failure"),
+    )
+
+    assert run_pipx_cli(["repair", "--python", sys.executable, "pycowsay"]) == 1
+
+    assert "pycowsay: interpreter exited with status 7" in capsys.readouterr().err


### PR DESCRIPTION
Removing or upgrading Python can leave a managed application without its interpreter, as reported in [#1442](https://github.com/pypa/pipx/issues/1442). `pipx health` checks selected or all managed interpreters. Package state does not change. `--json` exposes the same typed result for scripts.

`pipx repair` rebuilds failed environments through the transactional reinstall path while holding each environment lock. It preserves the recorded package metadata and pip or uv backend, then verifies the replacement interpreter.

Pinned environments remain unchanged because a mutable recorded source could resolve another release. Users must unpin them before repair.
