### PR TITLE
✨ feat(expose): hide application resources

### DIFF
--- a/changelog.d/1645.feature.md
+++ b/changelog.d/1645.feature.md
@@ -1,0 +1,1 @@
+Add commands to hide and restore resources exposed from an environment.

--- a/docs/man/pipx.1.rst
+++ b/docs/man/pipx.1.rst
@@ -14,10 +14,10 @@ install and run Python applications in isolated environments
 SYNOPSIS
 --------
 
-**pipx** [*global-options*] [**install** | **install-all** | **uninject** | **inject** | **pin** | **unpin** |
-**upgrade** | **upgrade-all** | **upgrade-shared** | **uninstall** | **uninstall-all** | **reinstall** | **reinstall-
-all** | **health** | **repair** | **list** | **interpreter** | **run** | **runpip** | **ensurepath** | **environment** |
-**completions** | **help**] [*command-options*]
+**pipx** [*global-options*] [**install** | **install-all** | **uninject** | **inject** | **expose** | **unexpose** |
+**pin** | **unpin** | **upgrade** | **upgrade-all** | **upgrade-shared** | **uninstall** | **uninstall-all** |
+**reinstall** | **reinstall-all** | **health** | **repair** | **list** | **interpreter** | **run** | **runpip** |
+**ensurepath** | **environment** | **completions** | **help**] [*command-options*]
 
 DESCRIPTION
 -----------
@@ -39,6 +39,12 @@ COMMANDS
 
 **inject**
     Install packages into an existing Virtual Environment
+
+**expose**
+    Restore resources from a hidden environment
+
+**unexpose**
+    Hide resources without removing an environment
 
 **pin**
     Pin the specified package to prevent it from being upgraded

--- a/docs/tutorial/install-applications.md
+++ b/docs/tutorial/install-applications.md
@@ -41,6 +41,21 @@ apps are exposed on your $PATH at /home/user/.local/bin
 
 ```
 
+### Hiding an application
+
+Use `unexpose` when another command with the same name should take precedence without removing the pipx environment.
+
+```
+pipx unexpose ansible
+```
+
+pipx removes the apps and manual pages recorded for the environment from its global directories. Upgrade and reinstall
+operations keep it hidden. Injected apps stay hidden too. Use `expose` to restore the recorded resources.
+
+```
+pipx expose ansible
+```
+
 ### Keeping an installation within a version range
 
 Use `--upgrade` when you want an installed app to match a package spec:

--- a/src/pipx/commands/__init__.py
+++ b/src/pipx/commands/__init__.py
@@ -1,5 +1,6 @@
 from pipx.commands.ensure_path import ensure_pipx_paths
 from pipx.commands.environment import environment
+from pipx.commands.expose import ExposureData, expose, unexpose
 from pipx.commands.health import HealthData, RepairData, health, repair
 from pipx.commands.inject import inject
 from pipx.commands.install import install, install_all
@@ -14,12 +15,14 @@ from pipx.commands.uninstall import UninstallData, uninstall, uninstall_all
 from pipx.commands.upgrade import upgrade, upgrade_all, upgrade_shared
 
 __all__ = [
+    "ExposureData",
     "HealthData",
     "PinData",
     "RepairData",
     "UninstallData",
     "ensure_pipx_paths",
     "environment",
+    "expose",
     "health",
     "inject",
     "install",
@@ -33,6 +36,7 @@ __all__ = [
     "repair",
     "run",
     "run_pip",
+    "unexpose",
     "uninject",
     "uninstall",
     "uninstall_all",

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -81,6 +81,35 @@ def expose_resources_globally(
             )
 
 
+def expose_package_resources(
+    package_metadata: PackageInfo,
+    local_bin_dir: Path,
+    local_man_dir: Path,
+    *,
+    force: bool,
+) -> None:
+    if package_metadata.include_apps:
+        expose_resources_globally(
+            "app",
+            local_bin_dir,
+            package_metadata.app_paths,
+            force=force,
+            suffix=package_metadata.suffix,
+        )
+        expose_resources_globally("man", local_man_dir, package_metadata.man_paths, force=force)
+    if package_metadata.include_dependencies:
+        for app_paths in package_metadata.app_paths_of_dependencies.values():
+            expose_resources_globally(
+                "app",
+                local_bin_dir,
+                app_paths,
+                force=force,
+                suffix=package_metadata.suffix,
+            )
+        for man_paths in package_metadata.man_paths_of_dependencies.values():
+            expose_resources_globally("man", local_man_dir, man_paths, force=force)
+
+
 _can_symlink_cache: dict[Path, bool] = {}
 
 
@@ -250,30 +279,37 @@ def get_venv_summary(
         return (warning_message, venv_problems)
 
     package_metadata = venv.package_metadata[package_name]
-    apps = package_metadata.apps
-    man_pages = package_metadata.man_pages
-    if package_metadata.include_dependencies:
-        apps += package_metadata.apps_of_dependencies
-        man_pages += package_metadata.man_pages_of_dependencies
-
-    exposed_app_paths = get_exposed_paths_for_package(
-        venv.bin_path,
-        paths.ctx.bin_dir,
-        [add_suffix(app, package_metadata.suffix) for app in apps],
-    )
-    exposed_binary_names = sorted(p.name for p in exposed_app_paths)
-    unavailable_binary_names = sorted(
-        {add_suffix(name, package_metadata.suffix) for name in package_metadata.apps} - set(exposed_binary_names)
-    )
-    exposed_man_paths = set()
-    for man_section in MAN_SECTIONS:
-        exposed_man_paths |= get_exposed_man_paths_for_package(
-            venv.man_path / man_section,
-            paths.ctx.man_dir / man_section,
-            man_pages,
+    exposed_binary_names: list[str] = []
+    exposed_man_pages: list[str] = []
+    unavailable_binary_names: list[str] = []
+    unavailable_man_pages: list[str] = []
+    if venv.pipx_metadata.exposure_enabled:
+        apps = [
+            *package_metadata.apps,
+            *(package_metadata.apps_of_dependencies if package_metadata.include_dependencies else []),
+        ]
+        man_pages = [
+            *package_metadata.man_pages,
+            *(package_metadata.man_pages_of_dependencies if package_metadata.include_dependencies else []),
+        ]
+        exposed_app_paths = get_exposed_paths_for_package(
+            venv.bin_path,
+            paths.ctx.bin_dir,
+            [add_suffix(app, package_metadata.suffix) for app in apps],
         )
-    exposed_man_pages = sorted(str(Path(p.parent.name) / p.name) for p in exposed_man_paths)
-    unavailable_man_pages = sorted(set(package_metadata.man_pages) - set(exposed_man_pages))
+        exposed_binary_names = sorted(path.name for path in exposed_app_paths)
+        unavailable_binary_names = sorted(
+            {add_suffix(name, package_metadata.suffix) for name in package_metadata.apps} - set(exposed_binary_names)
+        )
+        exposed_man_paths = set()
+        for man_section in MAN_SECTIONS:
+            exposed_man_paths |= get_exposed_man_paths_for_package(
+                venv.man_path / man_section,
+                paths.ctx.man_dir / man_section,
+                man_pages,
+            )
+        exposed_man_pages = sorted(str(Path(path.parent.name) / path.name) for path in exposed_man_paths)
+        unavailable_man_pages = sorted(set(package_metadata.man_pages) - set(exposed_man_pages))
     # The following is to satisfy mypy that python_version is str and not
     #   Optional[str]
     python_version = venv.pipx_metadata.python_version if venv.pipx_metadata.python_version is not None else ""
@@ -296,6 +332,7 @@ def get_venv_summary(
             unavailable_man_pages,
             venv.pipx_metadata.injected_packages if include_injected else None,
             suffix=package_metadata.suffix,
+            exposure_enabled=venv.pipx_metadata.exposure_enabled,
         ),
         venv_problems,
     )
@@ -359,6 +396,8 @@ def _get_list_output(
     unavailable_man_pages: list[str],
     injected_packages: dict[str, PackageInfo] | None = None,
     suffix: str = "",
+    *,
+    exposure_enabled: bool,
 ) -> str:
     output = []
     suffix = f" ({bold(shlex.quote(package_name + suffix))})" if suffix else ""
@@ -368,6 +407,8 @@ def _get_list_output(
         + (" (standalone)" if python_is_standalone else "")
     )
 
+    if not exposure_enabled:
+        output.append("    apps and manual pages are not exposed")
     if new_install and (exposed_binary_names or unavailable_binary_names):
         output.append("  These apps are now available")
     output.extend(f"    - {name}" for name in exposed_binary_names)
@@ -473,26 +514,8 @@ def run_post_install_actions(
                 """
             )
 
-    expose_resources_globally(
-        "app",
-        local_bin_dir,
-        package_metadata.app_paths,
-        force=force,
-        suffix=package_metadata.suffix,
-    )
-    expose_resources_globally("man", local_man_dir, package_metadata.man_paths, force=force)
-
-    if include_dependencies:
-        for app_paths in package_metadata.app_paths_of_dependencies.values():
-            expose_resources_globally(
-                "app",
-                local_bin_dir,
-                app_paths,
-                force=force,
-                suffix=package_metadata.suffix,
-            )
-        for man_paths in package_metadata.man_paths_of_dependencies.values():
-            expose_resources_globally("man", local_man_dir, man_paths, force=force)
+    if venv.pipx_metadata.exposure_enabled:
+        expose_package_resources(package_metadata, local_bin_dir, local_man_dir, force=force)
 
     package_summary, _ = get_venv_summary(venv_dir, package_name=package_name, new_install=True)
     pipx_logger = logging.getLogger("pipx")
@@ -529,6 +552,7 @@ __all__ = [
     "VenvProblems",
     "add_suffix",
     "can_symlink",
+    "expose_package_resources",
     "expose_resources_globally",
     "get_exposed_man_paths_for_package",
     "get_exposed_paths_for_package",

--- a/src/pipx/commands/expose.py
+++ b/src/pipx/commands/expose.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from pipx.commands.common import expose_package_resources
+from pipx.commands.uninstall import _get_venv_resource_paths
+from pipx.constants import MAN_SECTIONS, ExitCode
+from pipx.result import OperationData, OperationResult, OutputLevel, OutputMessage, OutputStream
+from pipx.util import safe_unlink
+from pipx.venv import Venv
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def expose(venv_dir: Path, local_bin_dir: Path, local_man_dir: Path, verbose: bool) -> OperationResult[ExposureData]:
+    return _set_exposure(venv_dir, local_bin_dir, local_man_dir, verbose, enabled=True)
+
+
+def unexpose(venv_dir: Path, local_bin_dir: Path, local_man_dir: Path, verbose: bool) -> OperationResult[ExposureData]:
+    return _set_exposure(venv_dir, local_bin_dir, local_man_dir, verbose, enabled=False)
+
+
+def _set_exposure(
+    venv_dir: Path,
+    local_bin_dir: Path,
+    local_man_dir: Path,
+    verbose: bool,
+    *,
+    enabled: bool,
+) -> OperationResult[ExposureData]:
+    command = "expose" if enabled else "unexpose"
+    if not venv_dir.is_dir():
+        return _failure(command, venv_dir.name, f"pipx does not manage package {venv_dir.name}")
+
+    venv = Venv(venv_dir, verbose=verbose)
+    if venv.pipx_metadata.main_package.package is None:
+        return _failure(command, venv.name, f"pipx cannot read metadata for package {venv.name}")
+    if venv.pipx_metadata.exposure_enabled == enabled:
+        status = _ExposureStatus.EXPOSED if enabled else _ExposureStatus.UNEXPOSED
+        return _success(command, venv.name, status, f"{venv.name}: already {status.value}")
+
+    if enabled:
+        for package_metadata in venv.package_metadata.values():
+            expose_package_resources(package_metadata, local_bin_dir, local_man_dir, force=False)
+        status = _ExposureStatus.EXPOSED
+    else:
+        _remove_resources(venv, local_bin_dir, local_man_dir)
+        status = _ExposureStatus.UNEXPOSED
+    venv.pipx_metadata.exposure_enabled = enabled
+    venv.pipx_metadata.write()
+    return _success(command, venv.name, status, f"{venv.name}: {status.value}")
+
+
+def _remove_resources(venv: Venv, local_bin_dir: Path, local_man_dir: Path) -> None:
+    package_infos = tuple(venv.package_metadata.values())
+    resource_paths = _get_venv_resource_paths("app", venv.bin_path, local_bin_dir, package_infos)
+    for man_section in MAN_SECTIONS:
+        resource_paths |= _get_venv_resource_paths(
+            "man",
+            venv.man_path / man_section,
+            local_man_dir / man_section,
+            package_infos,
+        )
+    for resource_path in resource_paths:
+        safe_unlink(resource_path)
+
+
+def _success(command: str, environment: str, status: _ExposureStatus, message: str) -> OperationResult[ExposureData]:
+    return OperationResult(
+        command=command,
+        data=ExposureData(environments=(_EnvironmentExposure(environment, status),), failures=()),
+        messages=(OutputMessage(message),),
+    )
+
+
+def _failure(command: str, environment: str, error: str) -> OperationResult[ExposureData]:
+    return OperationResult(
+        command=command,
+        data=ExposureData(environments=(), failures=(_FailedExposure(environment, error),)),
+        messages=(OutputMessage(error, stream=OutputStream.STDERR, level=OutputLevel.ERROR),),
+        exit_code=ExitCode(1),
+    )
+
+
+class _ExposureStatus(str, Enum):
+    EXPOSED = "exposed"
+    UNEXPOSED = "unexposed"
+
+
+@dataclass(frozen=True)
+class _EnvironmentExposure:
+    environment: str
+    status: _ExposureStatus
+
+
+@dataclass(frozen=True)
+class _FailedExposure:
+    environment: str
+    error: str
+
+
+@dataclass(frozen=True)
+class ExposureData(OperationData):
+    environments: tuple[_EnvironmentExposure, ...]
+    failures: tuple[_FailedExposure, ...]
+
+
+__all__ = [
+    "ExposureData",
+    "expose",
+    "unexpose",
+]

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -8,7 +8,7 @@ from packaging.utils import canonicalize_name
 
 from pipx import commands, paths
 from pipx.backends import PIP
-from pipx.commands.common import expose_resources_globally, package_name_from_spec, run_post_install_actions
+from pipx.commands.common import expose_package_resources, package_name_from_spec, run_post_install_actions
 from pipx.constants import (
     EXIT_CODE_INSTALL_VENV_EXISTS,
     EXIT_CODE_OK,
@@ -60,26 +60,8 @@ def _upgrade_existing_venv(
         upgrade_only_pip_args=([f"--upgrade-strategy={upgrade_strategy}"] if upgrade_strategy is not None else None),
     )
     package_metadata = venv.pipx_metadata.main_package
-    if package_metadata.include_apps:
-        expose_resources_globally(
-            "app",
-            local_bin_dir,
-            package_metadata.app_paths,
-            force=False,
-            suffix=package_metadata.suffix,
-        )
-        expose_resources_globally("man", local_man_dir, package_metadata.man_paths, force=False)
-    if package_metadata.include_dependencies:
-        for app_paths in package_metadata.app_paths_of_dependencies.values():
-            expose_resources_globally(
-                "app",
-                local_bin_dir,
-                app_paths,
-                force=False,
-                suffix=package_metadata.suffix,
-            )
-        for man_paths in package_metadata.man_paths_of_dependencies.values():
-            expose_resources_globally("man", local_man_dir, man_paths, force=False)
+    if venv.pipx_metadata.exposure_enabled:
+        expose_package_resources(package_metadata, local_bin_dir, local_man_dir, force=False)
     print(
         pipx_wrap(
             f"""
@@ -109,6 +91,7 @@ def install(
     python_flag_passed: bool = False,
     backend: str | None = None,
     env_backend: str | None = None,
+    exposure_enabled: bool | None = None,
     upgrade: bool = False,
     upgrade_strategy: str | None = None,
     venv_lock: BaseFileLock | None = None,
@@ -212,6 +195,9 @@ def install(
             try:
                 override_shared = canonicalize_name(package_name) == "pip"
                 venv.create_venv(venv_args, pip_args, override_shared)
+                venv.pipx_metadata.exposure_enabled = (
+                    venv.pipx_metadata.exposure_enabled if exposure_enabled is None else exposure_enabled
+                )
                 for dependency in preinstall_packages or []:
                     venv.upgrade_package_no_metadata(dependency, [])
                 venv.install_package(
@@ -332,6 +318,7 @@ def install_all(
                     suffix=main_package.suffix,
                     backend=backend or venv_metadata.backend,
                     env_backend=env_backend,
+                    exposure_enabled=venv_metadata.exposure_enabled,
                     venv_lock=venv_lock,
                 )
                 for inject_package in venv_metadata.injected_packages.values():

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -46,6 +46,8 @@ def _get_reinstall_resource_paths(venv: Venv, local_bin_dir: Path, local_man_dir
 
 def _get_expected_reinstall_resource_paths(venv: Venv, local_bin_dir: Path, local_man_dir: Path) -> set[Path]:
     resource_paths: set[Path] = set()
+    if not venv.pipx_metadata.exposure_enabled:
+        return resource_paths
     for package_info in venv.package_metadata.values():
         if package_info.include_apps:
             for app_path in package_info.app_paths:
@@ -142,6 +144,7 @@ def reinstall(
             python_flag_passed=python_flag_passed,
             backend=backend or venv.pipx_metadata.backend,
             env_backend=env_backend,
+            exposure_enabled=venv.pipx_metadata.exposure_enabled,
             venv_lock=venv_lock,
         )
 

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -10,7 +10,7 @@ from filelock import BaseFileLock
 
 from pipx import commands, paths
 from pipx.colors import bold, red
-from pipx.commands.common import expose_resources_globally
+from pipx.commands.common import expose_package_resources
 from pipx.constants import EXIT_CODE_OK, ExitCode
 from pipx.emojis import sleep
 from pipx.package_specifier import parse_specifier_for_upgrade
@@ -98,27 +98,8 @@ def _upgrade_package(
     display_name = f"{package_metadata.package}{package_metadata.suffix}"
     new_version = package_metadata.package_version
 
-    if package_metadata.include_apps:
-        expose_resources_globally(
-            "app",
-            paths.ctx.bin_dir,
-            package_metadata.app_paths,
-            force=force,
-            suffix=package_metadata.suffix,
-        )
-        expose_resources_globally("man", paths.ctx.man_dir, package_metadata.man_paths, force=force)
-
-    if package_metadata.include_dependencies:
-        for app_paths in package_metadata.app_paths_of_dependencies.values():
-            expose_resources_globally(
-                "app",
-                paths.ctx.bin_dir,
-                app_paths,
-                force=force,
-                suffix=package_metadata.suffix,
-            )
-        for man_paths in package_metadata.man_paths_of_dependencies.values():
-            expose_resources_globally("man", paths.ctx.man_dir, man_paths, force=force)
+    if venv.pipx_metadata.exposure_enabled:
+        expose_package_resources(package_metadata, paths.ctx.bin_dir, paths.ctx.man_dir, force=force)
 
     return PackageUpgradeResult(
         environment=venv.name,

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -653,6 +653,50 @@ def _cmd_uninject(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
         )
 
 
+def _add_expose(
+    subparsers: argparse._SubParsersAction,
+    venv_completer: VenvCompleter,
+    shared_parser: argparse.ArgumentParser,
+) -> None:
+    parser = subparsers.add_parser(
+        "expose",
+        help="Restore resources from a hidden environment",
+        description="Relink each recorded app and manual page without rebuilding its environment.",
+        parents=[shared_parser],
+    )
+    parser.add_argument("package", help="Installed package to expose").completer = venv_completer
+    parser.add_argument("--json", action="store_true", help="Output a machine-readable result.")
+    parser.set_defaults(func=_cmd_expose)
+
+
+def _cmd_expose(args: argparse.Namespace, ctx: DispatchContext) -> OperationResult[commands.ExposureData]:
+    venv_dir = _venv_dir(args, ctx)
+    with ctx.venv_container.venv_lock(venv_dir):
+        return commands.expose(venv_dir, paths.ctx.bin_dir, paths.ctx.man_dir, ctx.verbose)
+
+
+def _add_unexpose(
+    subparsers: argparse._SubParsersAction,
+    venv_completer: VenvCompleter,
+    shared_parser: argparse.ArgumentParser,
+) -> None:
+    parser = subparsers.add_parser(
+        "unexpose",
+        help="Hide resources without removing an environment",
+        description="Remove global links or copies while retaining the managed environment.",
+        parents=[shared_parser],
+    )
+    parser.add_argument("package", help="Installed package to hide").completer = venv_completer
+    parser.add_argument("--json", action="store_true", help="Output a machine-readable result.")
+    parser.set_defaults(func=_cmd_unexpose)
+
+
+def _cmd_unexpose(args: argparse.Namespace, ctx: DispatchContext) -> OperationResult[commands.ExposureData]:
+    venv_dir = _venv_dir(args, ctx)
+    with ctx.venv_container.venv_lock(venv_dir):
+        return commands.unexpose(venv_dir, paths.ctx.bin_dir, paths.ctx.man_dir, ctx.verbose)
+
+
 def _add_pin(
     subparsers: argparse._SubParsersAction,
     venv_completer: VenvCompleter,
@@ -1327,6 +1371,8 @@ def get_command_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Ar
     _add_install_all(subparsers, shared_parser)
     _add_uninject(subparsers, completer_venvs.use, shared_parser)
     _add_inject(subparsers, completer_venvs.use, shared_parser)
+    _add_expose(subparsers, completer_venvs.use, shared_parser)
+    _add_unexpose(subparsers, completer_venvs.use, shared_parser)
     _add_pin(subparsers, completer_venvs.use, shared_parser)
     _add_unpin(subparsers, completer_venvs.use, shared_parser)
     _add_upgrade(subparsers, completer_venvs.use, shared_parser)

--- a/src/pipx/pipx_metadata_file.py
+++ b/src/pipx/pipx_metadata_file.py
@@ -50,6 +50,7 @@ class _RawMetadata(TypedDict, total=False):
     venv_args: list[str]
     injected_packages: dict[str, _RawPackageInfo]
     backend: str
+    exposure_enabled: bool
     pipx_metadata_version: str
     pinned: bool
 
@@ -105,7 +106,7 @@ class PipxMetadata:
     # V0.4 -> Add source interpreter
     # V0.5 -> Add pinned
     # V0.6 -> Add backend (pip|uv)
-    __METADATA_VERSION__: str = "0.6"
+    __METADATA_VERSION__: str = "0.7"
 
     def __init__(self, venv_dir: Path, read: bool = True):
         self.venv_dir = venv_dir
@@ -132,6 +133,7 @@ class PipxMetadata:
         self.venv_args: list[str] = []
         self.injected_packages: dict[str, PackageInfo] = {}
         self.backend: str = "pip"
+        self.exposure_enabled: bool = True
         # ``None`` until ``read()`` succeeds; lets callers tell a fresh
         # instance from one with authoritative on-disk values.
         self.read_metadata_version: str | None = None
@@ -149,12 +151,13 @@ class PipxMetadata:
             "venv_args": self.venv_args,
             "injected_packages": {name: asdict(data) for (name, data) in self.injected_packages.items()},
             "backend": self.backend,
+            "exposure_enabled": self.exposure_enabled,
             "pipx_metadata_version": self.__METADATA_VERSION__,
         }
 
     def _convert_legacy_metadata(self, metadata_dict: _RawMetadata) -> _RawMetadata:
         version = metadata_dict["pipx_metadata_version"]
-        if version in (self.__METADATA_VERSION__, "0.5"):
+        if version in (self.__METADATA_VERSION__, "0.6", "0.5"):
             pass
         elif version == "0.4":
             metadata_dict["pinned"] = False
@@ -176,6 +179,7 @@ class PipxMetadata:
             )
         # ``backend`` is absent from any pre-0.6 dump; default once here.
         metadata_dict.setdefault("backend", "pip")
+        metadata_dict.setdefault("exposure_enabled", True)
         return metadata_dict
 
     def from_dict(self, input_dict: _RawMetadata) -> None:
@@ -202,6 +206,7 @@ class PipxMetadata:
             )
             recorded_backend = "pip"
         self.backend = recorded_backend
+        self.exposure_enabled = input_dict["exposure_enabled"]
         self.read_metadata_version = input_dict.get("pipx_metadata_version")
 
     def _validate_before_write(self) -> None:

--- a/tests/test_expose.py
+++ b/tests/test_expose.py
@@ -1,0 +1,205 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from pytest import CaptureFixture
+
+from helpers import app_name, mock_legacy_venv, run_pipx_cli
+from package_info import PKG
+from pipx import paths
+from pipx.pipx_metadata_file import PipxMetadata
+
+
+@pytest.fixture
+def installed_pycowsay(pipx_temp_env: None, capsys: CaptureFixture[str]) -> Path:
+    assert run_pipx_cli(["install", "pycowsay"]) == 0
+    capsys.readouterr()
+    return paths.ctx.venvs / "pycowsay"
+
+
+@pytest.fixture
+def unexposed_pycowsay(installed_pycowsay: Path, capsys: CaptureFixture[str]) -> Path:
+    assert run_pipx_cli(["unexpose", "pycowsay"]) == 0
+    capsys.readouterr()
+    return installed_pycowsay
+
+
+def test_unexpose_hides_resources(installed_pycowsay: Path, capsys: CaptureFixture[str]) -> None:
+    assert run_pipx_cli(["unexpose", "pycowsay"]) == 0
+
+    assert not (paths.ctx.bin_dir / app_name("pycowsay")).exists()
+    assert not (paths.ctx.man_dir / "man6" / "pycowsay.6").exists()
+    assert installed_pycowsay.exists()
+    assert PipxMetadata(installed_pycowsay).exposure_enabled is False
+    assert capsys.readouterr().out == "pycowsay: unexposed\n"
+
+
+def test_expose_restores_resources(unexposed_pycowsay: Path, capsys: CaptureFixture[str]) -> None:
+    assert run_pipx_cli(["expose", "pycowsay"]) == 0
+
+    assert (paths.ctx.bin_dir / app_name("pycowsay")).exists()
+    assert (paths.ctx.man_dir / "man6" / "pycowsay.6").exists()
+    assert PipxMetadata(unexposed_pycowsay).exposure_enabled is True
+    assert capsys.readouterr().out == "pycowsay: exposed\n"
+
+
+def test_upgrade_preserves_unexposed_state(pipx_temp_env: None, capsys: CaptureFixture[str]) -> None:
+    assert run_pipx_cli(["install", "pylint==3.0.4"]) == 0
+    assert run_pipx_cli(["unexpose", "pylint"]) == 0
+    venv_dir = paths.ctx.venvs / "pylint"
+    previous_version = PipxMetadata(venv_dir).main_package.package_version
+    capsys.readouterr()
+
+    assert run_pipx_cli(["upgrade", "pylint"]) == 0
+    capsys.readouterr()
+
+    metadata = PipxMetadata(venv_dir)
+    assert metadata.main_package.package_version != previous_version
+    assert not (paths.ctx.bin_dir / app_name("pylint")).exists()
+    assert metadata.exposure_enabled is False
+
+
+def test_install_upgrade_preserves_unexposed_state(pipx_temp_env: None, capsys: CaptureFixture[str]) -> None:
+    assert run_pipx_cli(["install", PKG["black"]["spec"]]) == 0
+    assert run_pipx_cli(["unexpose", "black"]) == 0
+    capsys.readouterr()
+
+    assert run_pipx_cli(["install", "--upgrade", "black==22.10.0"]) == 0
+    output = capsys.readouterr().out
+
+    metadata = PipxMetadata(paths.ctx.venvs / "black")
+    assert "upgraded package black from 22.8.0 to 22.10.0" in output
+    assert not (paths.ctx.bin_dir / app_name("black")).exists()
+    assert metadata.exposure_enabled is False
+
+
+def test_force_install_preserves_unexposed_state(
+    unexposed_pycowsay: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    assert run_pipx_cli(["install", "--force", "pycowsay"]) == 0
+    output = capsys.readouterr().out
+
+    assert "installed package pycowsay" in output
+    assert not (paths.ctx.bin_dir / app_name("pycowsay")).exists()
+    assert PipxMetadata(unexposed_pycowsay).exposure_enabled is False
+
+
+def test_reinstall_preserves_unexposed_state(
+    unexposed_pycowsay: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    marker = unexposed_pycowsay / "marker"
+    marker.touch()
+
+    assert run_pipx_cli(["reinstall", "--python", sys.executable, "pycowsay"]) == 0
+    capsys.readouterr()
+
+    assert not marker.exists()
+    assert not (paths.ctx.bin_dir / app_name("pycowsay")).exists()
+    assert PipxMetadata(unexposed_pycowsay).exposure_enabled is False
+
+
+def test_unexposed_environment_does_not_expose_injected_apps(
+    unexposed_pycowsay: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    assert run_pipx_cli(["inject", "--include-apps", "pycowsay", "pylint"]) == 0
+    capsys.readouterr()
+
+    metadata = PipxMetadata(unexposed_pycowsay)
+    assert "pylint" in metadata.injected_packages
+    assert not (paths.ctx.bin_dir / app_name("pylint")).exists()
+    assert metadata.exposure_enabled is False
+
+
+def test_install_all_preserves_unexposed_state(
+    unexposed_pycowsay: Path,
+    capsys: CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    assert run_pipx_cli(["list", "--json"]) == 0
+    spec_path = tmp_path / "pipx.json"
+    spec_path.write_text(capsys.readouterr().out, encoding="utf-8")
+    assert run_pipx_cli(["uninstall", "pycowsay"]) == 0
+    capsys.readouterr()
+
+    assert run_pipx_cli(["install-all", str(spec_path)]) == 0
+    capsys.readouterr()
+
+    assert not (paths.ctx.bin_dir / app_name("pycowsay")).exists()
+    assert PipxMetadata(unexposed_pycowsay).exposure_enabled is False
+
+
+def test_list_reports_unexposed_environment(unexposed_pycowsay: Path, capsys: CaptureFixture[str]) -> None:
+    assert run_pipx_cli(["list"]) == 0
+
+    output = capsys.readouterr().out
+    assert "apps and manual pages are not exposed" in output
+    assert "symlink missing" not in output
+
+
+def test_unexpose_json(installed_pycowsay: Path, capsys: CaptureFixture[str]) -> None:
+    assert run_pipx_cli(["unexpose", "pycowsay", "--json"]) == 0
+
+    assert json.loads(capsys.readouterr().out) == {
+        "command": "unexpose",
+        "data": {
+            "environments": [{"environment": "pycowsay", "status": "unexposed"}],
+            "failures": [],
+        },
+        "pipx_result_version": "0.1",
+        "status": "success",
+    }
+
+
+@pytest.mark.parametrize(
+    ("command", "setup_command", "message"),
+    [
+        pytest.param("expose", None, "pycowsay: already exposed\n", id="expose"),
+        pytest.param("unexpose", "unexpose", "pycowsay: already unexposed\n", id="unexpose"),
+    ],
+)
+def test_exposure_command_is_idempotent(
+    installed_pycowsay: Path,
+    capsys: CaptureFixture[str],
+    command: str,
+    setup_command: str | None,
+    message: str,
+) -> None:
+    if setup_command is not None:
+        assert run_pipx_cli([setup_command, "pycowsay"]) == 0
+        capsys.readouterr()
+
+    assert run_pipx_cli([command, "pycowsay"]) == 0
+
+    assert capsys.readouterr().out == message
+
+
+def test_legacy_environment_defaults_to_exposed(installed_pycowsay: Path) -> None:
+    mock_legacy_venv("pycowsay", "0.3")
+
+    assert PipxMetadata(installed_pycowsay).exposure_enabled is True
+
+
+def test_exposure_command_reports_unreadable_metadata(
+    pipx_temp_env: None,
+    capsys: CaptureFixture[str],
+) -> None:
+    (paths.ctx.venvs / "broken").mkdir(parents=True)
+
+    assert run_pipx_cli(["expose", "broken"]) == 1
+
+    assert capsys.readouterr().err == "pipx cannot read metadata for package broken\n"
+
+
+@pytest.mark.parametrize("command", [pytest.param("expose", id="expose"), pytest.param("unexpose", id="unexpose")])
+def test_exposure_command_reports_missing_environment(
+    pipx_temp_env: None,
+    capsys: CaptureFixture[str],
+    command: str,
+) -> None:
+    assert run_pipx_cli([command, "missing"]) == 1
+
+    assert capsys.readouterr().err == "pipx does not manage package missing\n"

--- a/tests/test_pipx_metadata_file.py
+++ b/tests/test_pipx_metadata_file.py
@@ -49,7 +49,8 @@ def test_json_encoder_rejects_unsupported_value() -> None:
         json.dumps(1j, cls=JsonEncoderHandlesPath)
 
 
-def test_pipx_metadata_file_create(tmp_path):
+def test_pipx_metadata_file_create(tmp_path: Path) -> None:
+    assert TEST_PACKAGE1.package is not None
     venv_dir = tmp_path / TEST_PACKAGE1.package
     venv_dir.mkdir()
 
@@ -59,6 +60,7 @@ def test_pipx_metadata_file_create(tmp_path):
     pipx_metadata.source_interpreter = Path(sys.executable)
     pipx_metadata.venv_args = ["--system-site-packages"]
     pipx_metadata.injected_packages = {"injected": TEST_PACKAGE2}
+    pipx_metadata.exposure_enabled = False
     pipx_metadata.write()
 
     pipx_metadata2 = PipxMetadata(venv_dir)
@@ -69,8 +71,25 @@ def test_pipx_metadata_file_create(tmp_path):
         "python_version",
         "venv_args",
         "injected_packages",
+        "exposure_enabled",
     ]:
         assert getattr(pipx_metadata, attribute) == getattr(pipx_metadata2, attribute)
+
+
+def test_pipx_metadata_file_defaults_exposure_for_version_0_6(tmp_path: Path) -> None:
+    venv_dir = tmp_path / "venv"
+    venv_dir.mkdir()
+    metadata = PipxMetadata(venv_dir, read=False)
+    metadata.main_package = TEST_PACKAGE1
+    payload = metadata.to_dict()
+    payload["pipx_metadata_version"] = "0.6"
+    payload.pop("exposure_enabled")
+    (venv_dir / PIPX_INFO_FILENAME).write_text(
+        json.dumps(payload, cls=JsonEncoderHandlesPath),
+        encoding="utf-8",
+    )
+
+    assert PipxMetadata(venv_dir).exposure_enabled is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
[#1645](https://github.com/pypa/pipx/issues/1645) asks to hide commands from one pipx environment without uninstalling it. The package stays installed. `pipx unexpose PACKAGE` removes the apps and manual pages owned by that environment; `pipx expose PACKAGE` restores them.

pipx records the requested state in environment metadata and reports hidden environments through `pipx list` and its JSON output. Upgrade and rebuild operations preserve it.

Uninstall ownership rules drive both commands. This gives symlinks and Windows copies the same contract.
