### PR TITLE
🐛 fix(list): show copied injected apps

### DIFF
--- a/changelog.d/997.bugfix.md
+++ b/changelog.d/997.bugfix.md
@@ -1,0 +1,1 @@
+Show injected apps in `pipx list` on systems that copy launchers.

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -278,30 +278,37 @@ def get_venv_summary(
     if venv_problems.any_():
         return (warning_message, venv_problems)
 
-    package_metadata = venv.package_metadata[package_name]
+    package_metadata: Final[PackageInfo] = venv.package_metadata[package_name]
     exposed_binary_names: list[str] = []
     exposed_man_pages: list[str] = []
     unavailable_binary_names: list[str] = []
     unavailable_man_pages: list[str] = []
     if venv.pipx_metadata.exposure_enabled:
-        apps = [
-            *package_metadata.apps,
-            *(package_metadata.apps_of_dependencies if package_metadata.include_dependencies else []),
-        ]
-        man_pages = [
-            *package_metadata.man_pages,
-            *(package_metadata.man_pages_of_dependencies if package_metadata.include_dependencies else []),
-        ]
+        resource_packages: Final[tuple[PackageInfo, ...]] = (
+            (package_metadata,)
+            if new_install
+            else tuple(metadata for metadata in venv.package_metadata.values() if metadata.include_apps)
+        )
         exposed_app_paths = get_exposed_paths_for_package(
             venv.bin_path,
             paths.ctx.bin_dir,
-            [add_suffix(app, package_metadata.suffix) for app in apps],
+            [
+                add_suffix(app, metadata.suffix)
+                for metadata in resource_packages
+                for app in metadata.apps + (metadata.apps_of_dependencies if metadata.include_dependencies else [])
+            ],
         )
         exposed_binary_names = sorted(path.name for path in exposed_app_paths)
         unavailable_binary_names = sorted(
             {add_suffix(name, package_metadata.suffix) for name in package_metadata.apps} - set(exposed_binary_names)
         )
         exposed_man_paths = set()
+        man_pages: Final[list[str]] = [
+            man_page
+            for metadata in resource_packages
+            for man_page in metadata.man_pages
+            + (metadata.man_pages_of_dependencies if metadata.include_dependencies else [])
+        ]
         for man_section in MAN_SECTIONS:
             exposed_man_paths |= get_exposed_man_paths_for_package(
                 venv.man_path / man_section,

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Final
 
 import pytest
+from pytest_mock import MockerFixture
 
 from helpers import (
     PIPX_METADATA_LEGACY_VERSIONS,
@@ -22,6 +23,7 @@ from helpers import (
 )
 from package_info import PKG
 from pipx import constants, paths, shared_libs, venv
+from pipx.commands import common
 from pipx.pipx_metadata_file import PIPX_INFO_FILENAME, PackageInfo, _json_decoder_object_hook
 from pipx.util import PipxError
 
@@ -177,6 +179,21 @@ def test_list_short(pipx_temp_env, monkeypatch, capsys):
 
     assert "pycowsay 0.0.0.2" in captured.out
     assert "pylint 3.0.4" in captured.out
+
+
+def test_list_injected_apps_without_symlinks(
+    pipx_temp_env: None,
+    mocker: MockerFixture,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    mocker.patch.object(common, "can_symlink", autospec=True, return_value=False)
+    assert not run_pipx_cli(["install", PKG["pycowsay"]["spec"]])
+    assert not run_pipx_cli(["inject", "pycowsay", PKG["pylint"]["spec"], "--include-apps"])
+    capsys.readouterr()
+
+    assert not run_pipx_cli(["list", "--include-injected"])
+
+    assert f"    - {PKG['pylint']['apps'][0]}" in capsys.readouterr().out.splitlines()
 
 
 def test_list_waits_for_install(pipx_temp_env: None, tmp_path: Path) -> None:


### PR DESCRIPTION
[#997](https://github.com/pypa/pipx/issues/997) reports injected apps missing from `pipx list` on Windows systems that copy launchers instead of creating symlinks.

Symlink discovery identifies the owning environment from each target. Copy discovery can only compare names, but list supplied names from the main package. Include names from every package whose apps pipx exposed. Installation summaries remain scoped to the package just installed.
