### PR TITLE
✨ feat(install): require application names

### DIFF
--- a/changelog.d/1908.feature.md
+++ b/changelog.d/1908.feature.md
@@ -1,0 +1,1 @@
+Validate requested apps and restore prior environments on failure.

--- a/docs/tutorial/install-applications.md
+++ b/docs/tutorial/install-applications.md
@@ -56,6 +56,21 @@ operations keep it hidden. Injected apps stay hidden too. Use `expose` to restor
 pipx expose ansible
 ```
 
+### Requiring an application entry point
+
+Pass `--app` when automation depends on a specific command.
+
+```
+pipx install --app http httpie
+```
+
+pipx checks the exact entry-point name before exposing files. If the package lacks the entry point, installation fails
+and pipx removes the new environment. pipx records the name; if a later force install, upgrade, or reinstall drops the
+entry point, pipx restores the existing environment.
+
+Use one package spec with `--app`. Repeat the option to require more than one entry point. Dependency entry points
+qualify when you also pass `--include-deps`.
+
 ### Keeping an installation within a version range
 
 Use `--upgrade` when you want an installed app to match a package spec:

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -6,6 +6,7 @@ import shutil
 import sys
 import tempfile
 import time
+from collections.abc import Sequence
 from pathlib import Path
 from shutil import which
 from tempfile import TemporaryDirectory
@@ -525,6 +526,26 @@ def run_post_install_actions(
         print(f"done! {stars}", file=sys.stderr)
 
 
+def validate_expected_apps(venv: Venv, package_name: str, expected_apps: Sequence[str]) -> None:
+    if not expected_apps:
+        return
+
+    package: Final[PackageInfo] = venv.package_metadata[package_name]
+    available_apps: Final[list[str]] = sorted(
+        {
+            app[:-4] if WINDOWS and app.lower().endswith(".exe") else app
+            for app in [*package.apps, *(package.apps_of_dependencies if package.include_dependencies else ())]
+        }
+    )
+    missing_apps: Final[list[str]] = sorted(set(expected_apps) - set(available_apps))
+    if missing_apps:
+        raise PipxError(
+            f"Package {package_name} does not provide expected {'app' if len(missing_apps) == 1 else 'apps'} "
+            f"{', '.join(missing_apps)}. "
+            f"Available apps: {', '.join(available_apps) or 'none'}."
+        )
+
+
 def warn_if_not_on_path(local_bin_dir: Path) -> None:
     if not userpath.in_current_path(str(local_bin_dir)):
         _LOGGER.warning(
@@ -559,5 +580,6 @@ __all__ = [
     "get_venv_summary",
     "package_name_from_spec",
     "run_post_install_actions",
+    "validate_expected_apps",
     "venv_health_check",
 ]

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -1,14 +1,22 @@
 import json
 import sys
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
+from dataclasses import replace
 from pathlib import Path
+from typing import Final
 
 from filelock import BaseFileLock
 from packaging.utils import canonicalize_name
 
 from pipx import commands, paths
 from pipx.backends import PIP
-from pipx.commands.common import expose_package_resources, package_name_from_spec, run_post_install_actions
+from pipx.commands.common import (
+    expose_package_resources,
+    package_name_from_spec,
+    run_post_install_actions,
+    validate_expected_apps,
+)
+from pipx.commands.transaction import preserve_venv
 from pipx.constants import (
     EXIT_CODE_INSTALL_VENV_EXISTS,
     EXIT_CODE_OK,
@@ -20,56 +28,6 @@ from pipx.package_specifier import package_spec_satisfied
 from pipx.pipx_metadata_file import PackageInfo, PipxMetadata, load_spec_file
 from pipx.util import PipxError, pipx_wrap
 from pipx.venv import Venv, VenvContainer
-
-
-def _upgrade_existing_venv(
-    venv: Venv,
-    package_name: str,
-    package_spec: str,
-    local_bin_dir: Path,
-    local_man_dir: Path,
-    pip_args: list[str],
-    verbose: bool,
-    upgrade_strategy: str | None,
-) -> None:
-    package_metadata = venv.pipx_metadata.main_package
-    installed_version = package_metadata.package_version
-    if package_spec_satisfied(
-        package_spec,
-        package_name,
-        installed_version,
-        package_metadata.package_or_url or package_name,
-    ):
-        print(f"{package_name} {installed_version} already satisfies {package_spec}")
-        return
-    if package_metadata.pinned:
-        print(f"Not upgrading pinned package {venv.name}. Run `pipx unpin {venv.name}` to unpin it.")
-        return
-
-    main_pip_args = pip_args or package_metadata.pip_args
-    venv.check_upgrade_shared_libs(pip_args=main_pip_args, verbose=verbose)
-    venv.upgrade_packaging_libraries(main_pip_args)
-    venv.upgrade_package(
-        package_name,
-        package_spec,
-        main_pip_args,
-        include_dependencies=package_metadata.include_dependencies,
-        include_apps=package_metadata.include_apps,
-        is_main_package=True,
-        suffix=package_metadata.suffix,
-        upgrade_only_pip_args=([f"--upgrade-strategy={upgrade_strategy}"] if upgrade_strategy is not None else None),
-    )
-    package_metadata = venv.pipx_metadata.main_package
-    if venv.pipx_metadata.exposure_enabled:
-        expose_package_resources(package_metadata, local_bin_dir, local_man_dir, force=False)
-    print(
-        pipx_wrap(
-            f"""
-            upgraded package {venv.name} from {installed_version} to
-            {package_metadata.package_version} (location: {venv.root!s})
-            """
-        )
-    )
 
 
 def install(
@@ -87,6 +45,7 @@ def install(
     reinstall: bool,
     include_dependencies: bool,
     preinstall_packages: list[str] | None,
+    expected_apps: Sequence[str] = (),
     suffix: str = "",
     python_flag_passed: bool = False,
     backend: str | None = None,
@@ -100,8 +59,7 @@ def install(
     # package_spec is anything pip-installable, including package_name, vcs spec,
     #   zip file, or tar.gz file.
 
-    if upgrade_strategy is not None and not upgrade:
-        raise PipxError("--upgrade-strategy requires --upgrade")
+    _validate_install_options(package_specs, expected_apps, upgrade=upgrade, upgrade_strategy=upgrade_strategy)
 
     python = python or get_default_python()
 
@@ -119,7 +77,7 @@ def install(
             for package_spec in package_specs
         ]
 
-    venv_container = VenvContainer(venv_dir.parent if venv_dir is not None else paths.ctx.venvs)
+    venv_container: Final[VenvContainer] = VenvContainer(venv_dir.parent if venv_dir is not None else paths.ctx.venvs)
     for package_name, package_spec in zip(package_names, package_specs, strict=False):
         if venv_dir is None:
             venv_dir = venv_container.get_venv_dir(f"{package_name}{suffix}")
@@ -145,6 +103,7 @@ def install(
                 backend=install_backend,
                 env_backend=install_env_backend,
             )
+            required_apps = tuple(dict.fromkeys(expected_apps or venv.pipx_metadata.main_package.expected_apps))
             if exists:
                 if not reinstall and force and python_flag_passed:
                     print(
@@ -168,6 +127,7 @@ def install(
                         pip_args,
                         verbose,
                         upgrade_strategy,
+                        required_apps,
                     )
                     if len(package_specs) == 1:
                         return EXIT_CODE_OK
@@ -191,52 +151,199 @@ def install(
                     venv_dir = None
                     continue
 
-            venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
-            try:
-                override_shared = canonicalize_name(package_name) == "pip"
-                venv.create_venv(venv_args, pip_args, override_shared)
-                venv.pipx_metadata.exposure_enabled = (
-                    venv.pipx_metadata.exposure_enabled if exposure_enabled is None else exposure_enabled
-                )
-                for dependency in preinstall_packages or []:
-                    venv.upgrade_package_no_metadata(dependency, [])
-                venv.install_package(
-                    package_name=package_name,
-                    package_or_url=package_spec,
-                    pip_args=pip_args,
-                    install_only_pip_args=["--force-reinstall"] if force and exists else None,
-                    include_dependencies=include_dependencies,
-                    include_apps=True,
-                    is_main_package=True,
-                    suffix=suffix,
-                )
-                run_post_install_actions(
-                    venv,
-                    package_name,
-                    local_bin_dir,
-                    local_man_dir,
-                    venv_dir,
-                    include_dependencies,
-                    force=force,
-                )
-            except (Exception, KeyboardInterrupt):
-                print()
-                venv.remove_venv()
-                raise
-
+            with preserve_venv(venv_dir, enabled=exists and bool(required_apps)):
+                venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
+                try:
+                    override_shared = canonicalize_name(package_name) == "pip"
+                    venv.create_venv(venv_args, pip_args, override_shared)
+                    venv.pipx_metadata.exposure_enabled = (
+                        venv.pipx_metadata.exposure_enabled if exposure_enabled is None else exposure_enabled
+                    )
+                    for dependency in preinstall_packages or []:
+                        venv.upgrade_package_no_metadata(dependency, [])
+                    venv.install_package(
+                        package_name=package_name,
+                        package_or_url=package_spec,
+                        pip_args=pip_args,
+                        install_only_pip_args=["--force-reinstall"] if force and exists else None,
+                        include_dependencies=include_dependencies,
+                        include_apps=True,
+                        is_main_package=True,
+                        suffix=suffix,
+                        expected_apps=required_apps,
+                    )
+                    validate_expected_apps(venv, package_name, required_apps)
+                    run_post_install_actions(
+                        venv,
+                        package_name,
+                        local_bin_dir,
+                        local_man_dir,
+                        venv_dir,
+                        include_dependencies,
+                        force=force,
+                    )
+                except (Exception, KeyboardInterrupt):
+                    print()
+                    venv.remove_venv()
+                    raise
         venv_dir = None
 
-    # Any failure to install will raise PipxError, otherwise success
+    return EXIT_CODE_OK
+
+
+def _validate_install_options(
+    package_specs: Sequence[str],
+    expected_apps: Sequence[str],
+    *,
+    upgrade: bool,
+    upgrade_strategy: str | None,
+) -> None:
+    if upgrade_strategy is not None and not upgrade:
+        raise PipxError("--upgrade-strategy requires --upgrade")
+    if expected_apps and len(package_specs) != 1:
+        raise PipxError("--app accepts one package spec")
+
+
+def _upgrade_existing_venv(
+    venv: Venv,
+    package_name: str,
+    package_spec: str,
+    local_bin_dir: Path,
+    local_man_dir: Path,
+    pip_args: list[str],
+    verbose: bool,
+    upgrade_strategy: str | None,
+    expected_apps: Sequence[str],
+) -> None:
+    package_metadata = venv.pipx_metadata.main_package
+    installed_version: Final[str] = package_metadata.package_version
+    if package_spec_satisfied(
+        package_spec,
+        package_name,
+        installed_version,
+        package_metadata.package_or_url or package_name,
+    ):
+        validate_expected_apps(venv, package_name, expected_apps)
+        _record_expected_apps(venv, expected_apps)
+        print(f"{package_name} {installed_version} already satisfies {package_spec}")
+        return
+    if package_metadata.pinned:
+        validate_expected_apps(venv, package_name, expected_apps)
+        _record_expected_apps(venv, expected_apps)
+        print(f"Not upgrading pinned package {venv.name}. Run `pipx unpin {venv.name}` to unpin it.")
+        return
+
+    with preserve_venv(venv.root, enabled=bool(expected_apps)):
+        main_pip_args: Final[list[str]] = pip_args or package_metadata.pip_args
+        venv.check_upgrade_shared_libs(pip_args=main_pip_args, verbose=verbose)
+        venv.upgrade_packaging_libraries(main_pip_args)
+        venv.upgrade_package(
+            package_name,
+            package_spec,
+            main_pip_args,
+            include_dependencies=package_metadata.include_dependencies,
+            include_apps=package_metadata.include_apps,
+            is_main_package=True,
+            suffix=package_metadata.suffix,
+            upgrade_only_pip_args=([f"--upgrade-strategy={upgrade_strategy}"] if upgrade_strategy is not None else None),
+            expected_apps=expected_apps,
+        )
+        validate_expected_apps(venv, package_name, expected_apps)
+        package_metadata = venv.pipx_metadata.main_package
+        if venv.pipx_metadata.exposure_enabled:
+            expose_package_resources(package_metadata, local_bin_dir, local_man_dir, force=False)
+    print(
+        pipx_wrap(
+            f"""
+            upgraded package {venv.name} from {installed_version} to
+            {package_metadata.package_version} (location: {venv.root!s})
+            """
+        )
+    )
+
+
+def _record_expected_apps(venv: Venv, expected_apps: Sequence[str]) -> None:
+    expected: Final[list[str]] = list(dict.fromkeys(expected_apps))
+    if venv.pipx_metadata.main_package.expected_apps == expected:
+        return
+    venv.pipx_metadata.main_package = replace(venv.pipx_metadata.main_package, expected_apps=expected)
+    venv.pipx_metadata.write()
+
+
+def install_all(
+    spec_metadata_file: Path,
+    local_bin_dir: Path,
+    local_man_dir: Path,
+    python: str | None,
+    pip_args: list[str],
+    venv_args: list[str],
+    verbose: bool,
+    *,
+    force: bool,
+    backend: str | None = None,
+    env_backend: str | None = None,
+) -> ExitCode:
+    venv_container: Final[VenvContainer] = VenvContainer(paths.ctx.venvs)
+    failed: Final[list[str]] = []
+    installed: Final[list[str]] = []
+
+    for venv_metadata in extract_venv_metadata(spec_metadata_file):
+        main_package = venv_metadata.main_package
+        venv_dir = venv_container.get_venv_dir(f"{main_package.package}{main_package.suffix}")
+        try:
+            with venv_container.venv_lock(venv_dir) as venv_lock:
+                install(
+                    venv_dir,
+                    None,
+                    [generate_package_spec(main_package)],
+                    local_bin_dir,
+                    local_man_dir,
+                    python or get_python_interpreter(venv_metadata.source_interpreter),
+                    pip_args,
+                    venv_args,
+                    verbose,
+                    force=force,
+                    reinstall=False,
+                    include_dependencies=main_package.include_dependencies,
+                    preinstall_packages=[],
+                    expected_apps=main_package.expected_apps,
+                    suffix=main_package.suffix,
+                    backend=backend or venv_metadata.backend,
+                    env_backend=env_backend,
+                    exposure_enabled=venv_metadata.exposure_enabled,
+                    venv_lock=venv_lock,
+                )
+                for inject_package in venv_metadata.injected_packages.values():
+                    commands.inject(
+                        venv_dir=venv_dir,
+                        package_specs=[generate_package_spec(inject_package)],
+                        requirement_files=[],
+                        pip_args=pip_args,
+                        verbose=verbose,
+                        include_apps=inject_package.include_apps,
+                        include_dependencies=inject_package.include_dependencies,
+                        force=force,
+                        suffix=inject_package.suffix == main_package.suffix,
+                    )
+        except PipxError as error:
+            print(error, file=sys.stderr)
+            failed.append(venv_dir.name)
+        else:
+            installed.append(venv_dir.name)
+    if not installed:
+        print(f"No packages installed after running 'pipx install-all {spec_metadata_file}' {sleep}")
+    if failed:
+        raise PipxError(f"The following package(s) failed to install: {', '.join(failed)}")
     return EXIT_CODE_OK
 
 
 def extract_venv_metadata(spec_metadata_file: Path) -> Iterator[PipxMetadata]:
     try:
-        spec = load_spec_file(spec_metadata_file)
+        spec: Final = load_spec_file(spec_metadata_file)
     except json.decoder.JSONDecodeError as exc:
         raise PipxError("The spec metadata file is an invalid JSON file.") from exc
 
-    venvs_metadata_dict = spec.get("venvs")
+    venvs_metadata_dict: Final = spec.get("venvs")
     if not venvs_metadata_dict:
         raise PipxError("No packages found in the spec metadata file.")
     if not isinstance(venvs_metadata_dict, dict):
@@ -276,74 +383,6 @@ def get_python_interpreter(
     )
 
     return None
-
-
-def install_all(
-    spec_metadata_file: Path,
-    local_bin_dir: Path,
-    local_man_dir: Path,
-    python: str | None,
-    pip_args: list[str],
-    venv_args: list[str],
-    verbose: bool,
-    *,
-    force: bool,
-    backend: str | None = None,
-    env_backend: str | None = None,
-) -> ExitCode:
-    """Return pipx exit code."""
-    venv_container = VenvContainer(paths.ctx.venvs)
-    failed: list[str] = []
-    installed: list[str] = []
-
-    for venv_metadata in extract_venv_metadata(spec_metadata_file):
-        main_package = venv_metadata.main_package
-        venv_dir = venv_container.get_venv_dir(f"{main_package.package}{main_package.suffix}")
-        try:
-            with venv_container.venv_lock(venv_dir) as venv_lock:
-                install(
-                    venv_dir,
-                    None,
-                    [generate_package_spec(main_package)],
-                    local_bin_dir,
-                    local_man_dir,
-                    python or get_python_interpreter(venv_metadata.source_interpreter),
-                    pip_args,
-                    venv_args,
-                    verbose,
-                    force=force,
-                    reinstall=False,
-                    include_dependencies=main_package.include_dependencies,
-                    preinstall_packages=[],
-                    suffix=main_package.suffix,
-                    backend=backend or venv_metadata.backend,
-                    env_backend=env_backend,
-                    exposure_enabled=venv_metadata.exposure_enabled,
-                    venv_lock=venv_lock,
-                )
-                for inject_package in venv_metadata.injected_packages.values():
-                    commands.inject(
-                        venv_dir=venv_dir,
-                        package_specs=[generate_package_spec(inject_package)],
-                        requirement_files=[],
-                        pip_args=pip_args,
-                        verbose=verbose,
-                        include_apps=inject_package.include_apps,
-                        include_dependencies=inject_package.include_dependencies,
-                        force=force,
-                        suffix=inject_package.suffix == main_package.suffix,
-                    )
-        except PipxError as e:
-            print(e, file=sys.stderr)
-            failed.append(venv_dir.name)
-        else:
-            installed.append(venv_dir.name)
-    if len(installed) == 0:
-        print(f"No packages installed after running 'pipx install-all {spec_metadata_file}' {sleep}")
-    if len(failed) > 0:
-        raise PipxError(f"The following package(s) failed to install: {', '.join(failed)}")
-    # Any failure to install will raise PipxError, otherwise success
-    return EXIT_CODE_OK
 
 
 __all__ = [

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -140,6 +140,7 @@ def reinstall(
             reinstall=True,
             include_dependencies=venv.pipx_metadata.main_package.include_dependencies,
             preinstall_packages=[],
+            expected_apps=venv.pipx_metadata.main_package.expected_apps,
             suffix=venv.pipx_metadata.main_package.suffix,
             python_flag_passed=python_flag_passed,
             backend=backend or venv.pipx_metadata.backend,

--- a/src/pipx/commands/transaction.py
+++ b/src/pipx/commands/transaction.py
@@ -1,0 +1,37 @@
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from shutil import Error, copytree
+from tempfile import mkdtemp
+from typing import Final
+
+from pipx.util import PipxError, rmdir
+
+
+@contextmanager
+def preserve_venv(venv_dir: Path, *, enabled: bool) -> Iterator[None]:
+    if not enabled:
+        yield
+        return
+
+    backup_dir: Final[Path] = Path(mkdtemp(prefix=f".{venv_dir.name}-", suffix="-pipx-backup", dir=venv_dir.parent))
+    backup_dir.rmdir()
+    try:
+        copytree(venv_dir, backup_dir, symlinks=True)
+    except (Error, OSError) as error:
+        rmdir(backup_dir)
+        raise PipxError(f"pipx could not back up environment {venv_dir.name}: {error}") from error
+
+    try:
+        yield
+    except (Exception, KeyboardInterrupt):
+        rmdir(venv_dir)
+        backup_dir.rename(venv_dir)
+        raise
+    else:
+        rmdir(backup_dir)
+
+
+__all__ = [
+    "preserve_venv",
+]

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -10,7 +10,8 @@ from filelock import BaseFileLock
 
 from pipx import commands, paths
 from pipx.colors import bold, red
-from pipx.commands.common import expose_package_resources
+from pipx.commands.common import expose_package_resources, validate_expected_apps
+from pipx.commands.transaction import preserve_venv
 from pipx.constants import EXIT_CODE_OK, ExitCode
 from pipx.emojis import sleep
 from pipx.package_specifier import parse_specifier_for_upgrade
@@ -94,6 +95,7 @@ def _upgrade_package(
     )
 
     package_metadata = venv.package_metadata[package_name]
+    validate_expected_apps(venv, package_name, package_metadata.expected_apps)
 
     display_name = f"{package_metadata.package}{package_metadata.suffix}"
     new_version = package_metadata.package_version
@@ -232,31 +234,41 @@ def _upgrade_venv(
             wrap_message=False,
         )
 
+    with preserve_venv(
+        venv_dir,
+        enabled=any(package.expected_apps for package in venv.package_metadata.values()),
+    ):
+        return _upgrade_packages(venv, main_pip_args, pip_args, include_injected=include_injected, force=force)
+
+
+def _upgrade_packages(
+    venv: Venv,
+    main_pip_args: list[str],
+    pip_args: list[str],
+    *,
+    include_injected: bool,
+    force: bool,
+) -> tuple[PackageUpgradeResult, ...]:
     venv.upgrade_packaging_libraries(main_pip_args)
-
-    results: list[PackageUpgradeResult] = []
-
-    package_name = venv.main_package_name
-    results.append(
+    results: Final[list[PackageUpgradeResult]] = [
         _upgrade_package(
             venv,
-            package_name,
+            venv.main_package_name,
             main_pip_args,
             is_main_package=True,
             force=force,
         )
-    )
+    ]
 
     if include_injected:
         for package_name in venv.package_metadata:
             if package_name == venv.main_package_name:
                 continue
-            injected_pip_args = pip_args or venv.package_metadata[package_name].pip_args
             results.append(
                 _upgrade_package(
                     venv,
                     package_name,
-                    injected_pip_args,
+                    pip_args or venv.package_metadata[package_name].pip_args,
                     is_main_package=False,
                     force=force,
                 )

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -478,6 +478,11 @@ def _add_install(subparsers: argparse._SubParsersAction, shared_parser: argparse
             "installing the main package. Use this flag multiple times if you want to preinstall multiple packages."
         ),
     )
+    p.add_argument(
+        "--app",
+        action="append",
+        help="Require this application entry point after installation. Repeat to require multiple entry points.",
+    )
     add_pip_venv_args(p)
     add_backend_arg(p)
     p.set_defaults(func=_cmd_install)
@@ -499,6 +504,7 @@ def _cmd_install(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
         reinstall=False,
         include_dependencies=args.include_deps,
         preinstall_packages=args.preinstall,
+        expected_apps=args.app or (),
         suffix=args.suffix,
         python_flag_passed=ctx.python_flag_passed,
         backend=ctx.backend,

--- a/src/pipx/pipx_metadata_file.py
+++ b/src/pipx/pipx_metadata_file.py
@@ -33,6 +33,7 @@ class _RawPackageInfo(TypedDict, total=False):
     apps_of_dependencies: list[str]
     app_paths_of_dependencies: dict[str, list[Path]]
     package_version: str
+    expected_apps: list[str]
     man_pages: list[str]
     man_paths: list[Path]
     man_pages_of_dependencies: list[str]
@@ -90,6 +91,7 @@ class PackageInfo:
     apps_of_dependencies: list[str]
     app_paths_of_dependencies: dict[str, list[Path]]
     package_version: str
+    expected_apps: list[str] = field(default_factory=list)
     man_pages: list[str] = field(default_factory=list)
     man_paths: list[Path] = field(default_factory=list)
     man_pages_of_dependencies: list[str] = field(default_factory=list)
@@ -106,7 +108,7 @@ class PipxMetadata:
     # V0.4 -> Add source interpreter
     # V0.5 -> Add pinned
     # V0.6 -> Add backend (pip|uv)
-    __METADATA_VERSION__: str = "0.7"
+    __METADATA_VERSION__: Final[str] = "0.8"
 
     def __init__(self, venv_dir: Path, read: bool = True):
         self.venv_dir = venv_dir
@@ -122,6 +124,7 @@ class PipxMetadata:
             app_paths=[],
             apps_of_dependencies=[],
             app_paths_of_dependencies={},
+            expected_apps=[],
             man_pages=[],
             man_paths=[],
             man_pages_of_dependencies=[],
@@ -157,7 +160,7 @@ class PipxMetadata:
 
     def _convert_legacy_metadata(self, metadata_dict: _RawMetadata) -> _RawMetadata:
         version = metadata_dict["pipx_metadata_version"]
-        if version in (self.__METADATA_VERSION__, "0.6", "0.5"):
+        if version in (self.__METADATA_VERSION__, "0.7", "0.6", "0.5"):
             pass
         elif version == "0.4":
             metadata_dict["pinned"] = False

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -1,7 +1,7 @@
 import logging
 import shutil
 import time
-from collections.abc import Generator, Iterable
+from collections.abc import Generator, Iterable, Sequence
 from importlib.metadata import Distribution, EntryPoint
 from pathlib import Path
 from typing import TYPE_CHECKING, Final, NoReturn
@@ -344,6 +344,7 @@ class Venv:
         is_main_package: bool,
         suffix: str = "",
         install_only_pip_args: list[str] | None = None,
+        expected_apps: Sequence[str] | None = None,
     ) -> None:
         # package_name in package specifier can mismatch URL due to user error
         package_or_url = fix_package_name(package_or_url, package_name)
@@ -372,6 +373,7 @@ class Venv:
             include_apps=include_apps,
             is_main_package=is_main_package,
             suffix=suffix,
+            expected_apps=expected_apps,
         )
 
         # Verify package installed ok
@@ -453,8 +455,13 @@ class Venv:
         is_main_package: bool,
         suffix: str = "",
         pinned: bool = False,
+        expected_apps: Sequence[str] | None = None,
     ) -> None:
         venv_package_metadata = self.get_venv_metadata_for_package(package_name, get_extras(package_or_url))
+        if expected_apps is None:
+            expected_apps = (
+                self.package_metadata[package_name].expected_apps if package_name in self.package_metadata else ()
+            )
         package_info = PackageInfo(
             package=package_name,
             package_or_url=parse_specifier_for_metadata(package_or_url),
@@ -470,6 +477,7 @@ class Venv:
             man_pages_of_dependencies=venv_package_metadata.man_pages_of_dependencies,
             man_paths_of_dependencies=venv_package_metadata.man_paths_of_dependencies,
             package_version=venv_package_metadata.package_version,
+            expected_apps=list(dict.fromkeys(expected_apps)),
             suffix=suffix,
             pinned=pinned,
         )
@@ -563,6 +571,7 @@ class Venv:
         is_main_package: bool,
         suffix: str = "",
         upgrade_only_pip_args: list[str] | None = None,
+        expected_apps: Sequence[str] | None = None,
     ) -> None:
         _LOGGER.info("Upgrading %s", package_descr := full_package_description(package_name, package_or_url))
         with animate(f"upgrading {package_descr}", self.do_animation):
@@ -585,6 +594,7 @@ class Venv:
             include_apps=include_apps,
             is_main_package=is_main_package,
             suffix=suffix,
+            expected_apps=expected_apps,
         )
 
     def _run_pip(self, cmd: list[str]) -> "CompletedProcess[str]":

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -4,7 +4,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 from unittest import mock
 
 import pytest
@@ -184,6 +184,198 @@ def test_install_no_apps_guidance(
         f"--preinstall {package_name}" in error,
         "Try again with '--include-deps'" in error,
     ) == (1, True, True, True, has_dependency_apps)
+
+
+def test_install_records_expected_app(pipx_temp_env: None) -> None:
+    assert not run_pipx_cli(["install", "--app", "pycowsay", PKG["pycowsay"]["spec"]])
+
+    assert PipxMetadata(paths.ctx.venvs / "pycowsay").main_package.expected_apps == ["pycowsay"]
+
+
+@pytest.mark.parametrize(
+    ("app_args", "expected_error"),
+    [
+        pytest.param(["--app", "missing"], "expected app missing", id="one"),
+        pytest.param(
+            ["--app", "missing", "--app", "absent"],
+            "expected apps absent, missing",
+            id="multiple",
+        ),
+    ],
+)
+def test_install_missing_expected_app_rolls_back(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    app_args: list[str],
+    expected_error: str,
+) -> None:
+    return_code = run_pipx_cli(["install", *app_args, PKG["pycowsay"]["spec"]])
+
+    captured = capsys.readouterr()
+    error = " ".join(captured.err.split())
+    assert (
+        return_code,
+        f"Package pycowsay does not provide {expected_error}. Available apps: pycowsay." in error,
+        (paths.ctx.venvs / "pycowsay").exists(),
+        (paths.ctx.bin_dir / app_name("pycowsay")).exists(),
+    ) == (1, True, False, False)
+
+
+@pytest.mark.parametrize(
+    ("package_spec", "pin"),
+    [
+        pytest.param("pycowsay>=0", False, id="satisfied"),
+        pytest.param("pycowsay==999", True, id="pinned"),
+    ],
+)
+def test_install_upgrade_records_expected_app_without_package_change(
+    pipx_temp_env: None,
+    package_spec: str,
+    pin: bool,
+) -> None:
+    assert not run_pipx_cli(["install", PKG["pycowsay"]["spec"]])
+    if pin:
+        assert not run_pipx_cli(["pin", "pycowsay"])
+
+    assert not run_pipx_cli(["install", "--upgrade", "--app", "pycowsay", package_spec])
+
+    assert PipxMetadata(paths.ctx.venvs / "pycowsay").main_package.expected_apps == ["pycowsay"]
+
+
+def test_install_accepts_expected_dependency_app(pipx_temp_env: None, root: Path) -> None:
+    package = f"{root / TEST_DATA_PATH / 'local_extras'}[cow]"
+
+    assert not run_pipx_cli(["install", "--include-deps", "--app", "pycowsay", package])
+
+    assert PipxMetadata(paths.ctx.venvs / "repeatme").main_package.expected_apps == ["pycowsay"]
+
+
+def test_install_upgrade_reexposes_expected_dependency_resources(
+    pipx_temp_env: None,
+    root: Path,
+    tmp_path: Path,
+) -> None:
+    dependency: Final[Path] = root / TEST_DATA_PATH / "local_manpage"
+    project: Final[Path] = tmp_path / "expected-dependency-app"
+    shutil.copytree(root / "testdata/empty_project", project)
+    pyproject: Final[Path] = project / "pyproject.toml"
+    pyproject.write_text(
+        pyproject.read_text(encoding="utf-8").replace(
+            'requires-python = ">=3.10"\n',
+            f'dependencies = [\n  "local-manpage @ {dependency.as_uri()}",\n]\nrequires-python = ">=3.10"\n',
+        ),
+        encoding="utf-8",
+    )
+    assert not run_pipx_cli(["install", "--include-deps", "--app", "local-manpage", str(project)])
+    app_path: Final[Path] = paths.ctx.bin_dir / app_name("local-manpage")
+    man_path: Final[Path] = paths.ctx.man_dir / "man1/local-manpage.1"
+    app_path.unlink()
+    man_path.unlink()
+    pyproject.write_text(
+        pyproject.read_text(encoding="utf-8").replace('version = "0.1.0"', 'version = "0.2.0"'),
+        encoding="utf-8",
+    )
+
+    assert not run_pipx_cli(["install", "--upgrade", str(project)])
+
+    assert (app_path.exists(), man_path.exists()) == (True, True)
+
+
+def test_install_expected_app_rejects_multiple_specs(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert run_pipx_cli(["install", "--app", "pycowsay", "pycowsay", PKG["black"]["spec"]])
+
+    assert (
+        "--app accepts one package spec" in capsys.readouterr().err,
+        (paths.ctx.venvs / "pycowsay").exists(),
+        (paths.ctx.venvs / "black").exists(),
+    ) == (True, False, False)
+
+
+def test_install_force_preserves_expected_app(pipx_temp_env: None) -> None:
+    assert not run_pipx_cli(["install", "--app", "pycowsay", PKG["pycowsay"]["spec"]])
+
+    assert not run_pipx_cli(["install", "--force", PKG["pycowsay"]["spec"]])
+
+    assert (
+        PipxMetadata(paths.ctx.venvs / "pycowsay").main_package.expected_apps,
+        tuple(paths.ctx.venvs.glob(".pycowsay-*-pipx-backup")),
+    ) == (["pycowsay"], ())
+
+
+def test_install_backup_failure_preserves_existing_environment(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    mocker: "MockerFixture",
+) -> None:
+    assert not run_pipx_cli(["install", "--app", "pycowsay", PKG["pycowsay"]["spec"]])
+    mocker.patch("pipx.commands.transaction.copytree", autospec=True, side_effect=OSError("disk full"))
+
+    assert run_pipx_cli(["install", "--force", PKG["pycowsay"]["spec"]])
+
+    assert (
+        "pipx could not back up environment pycowsay: disk full" in capsys.readouterr().err,
+        PipxMetadata(paths.ctx.venvs / "pycowsay").main_package.expected_apps,
+        (paths.ctx.bin_dir / app_name("pycowsay")).exists(),
+    ) == (True, ["pycowsay"], True)
+
+
+@pytest.mark.parametrize(
+    "reconciliation",
+    [
+        pytest.param("force", id="install-force"),
+        pytest.param("install-upgrade", id="install-upgrade"),
+        pytest.param("upgrade", id="upgrade"),
+        pytest.param("reinstall", id="reinstall"),
+    ],
+)
+def test_install_missing_recorded_app_restores_existing_environment(
+    missing_expected_app_project: Path,
+    capsys: pytest.CaptureFixture[str],
+    reconciliation: str,
+) -> None:
+    commands = {
+        "force": ["install", "--force", str(missing_expected_app_project)],
+        "install-upgrade": ["install", "--upgrade", str(missing_expected_app_project)],
+        "upgrade": ["upgrade", "empty-project"],
+        "reinstall": ["reinstall", "empty-project"],
+    }
+    assert run_pipx_cli(commands[reconciliation])
+
+    captured = capsys.readouterr()
+    metadata = PipxMetadata(paths.ctx.venvs / "empty-project").main_package
+    error = " ".join(captured.err.split())
+    assert (
+        "Package empty-project does not provide expected app empty-project. Available apps: none." in error,
+        metadata.package_version,
+        metadata.expected_apps,
+        metadata.apps,
+        (paths.ctx.bin_dir / app_name("empty-project")).exists(),
+    ) == (True, "0.1.0", ["empty-project"], [app_name("empty-project")], True)
+
+
+@pytest.fixture
+def missing_expected_app_project(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    root: Path,
+    tmp_path: Path,
+) -> Path:
+    project = tmp_path / "expected-app-project"
+    shutil.copytree(root / "testdata/empty_project", project)
+    assert not run_pipx_cli(["install", "--app", "empty-project", str(project)])
+    capsys.readouterr()
+
+    pyproject = project / "pyproject.toml"
+    pyproject.write_text(
+        pyproject.read_text()
+        .replace('version = "0.1.0"', 'version = "0.2.0"')
+        .replace('scripts.empty-project = "empty_project.main:cli"\n', "")
+        .replace('entry-points."pipx.run".empty-project = "empty_project.main:cli"\n', "")
+    )
+    return project
 
 
 def test_install_same_package_twice_no_force(pipx_temp_env, capsys):

--- a/tests/test_install_all.py
+++ b/tests/test_install_all.py
@@ -8,7 +8,7 @@ from pipx import paths
 
 
 def test_install_all(pipx_temp_env: None, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-    assert not run_pipx_cli(["install", "pycowsay"])
+    assert not run_pipx_cli(["install", "--app", "pycowsay", "pycowsay"])
     assert not run_pipx_cli(["install", "black"])
     assert not run_pipx_cli(["inject", "black", "pycowsay"])
     capsys.readouterr()
@@ -23,8 +23,13 @@ def test_install_all(pipx_temp_env: None, tmp_path: Path, capsys: pytest.Capture
     assert not run_pipx_cli(["list", "--json"])
 
     installed = json.loads(capsys.readouterr().out)["venvs"]
-    assert (sorted(installed), sorted(installed["black"]["metadata"]["injected_packages"])) == (
+    assert (
+        sorted(installed),
+        sorted(installed["black"]["metadata"]["injected_packages"]),
+        installed["pycowsay"]["metadata"]["main_package"]["expected_apps"],
+    ) == (
         ["black", "pycowsay"],
+        ["pycowsay"],
         ["pycowsay"],
     )
 

--- a/tests/test_pipx_metadata_file.py
+++ b/tests/test_pipx_metadata_file.py
@@ -26,6 +26,7 @@ TEST_PACKAGE1 = PackageInfo(
     man_pages_of_dependencies=[str(Path("man1/dep1.1"))],
     man_paths_of_dependencies={"dep1": [Path("man1/dep1.1")]},
     package_version="0.1.2",
+    expected_apps=["testapp"],
 )
 TEST_PACKAGE2 = PackageInfo(
     package="inj_package",
@@ -90,6 +91,19 @@ def test_pipx_metadata_file_defaults_exposure_for_version_0_6(tmp_path: Path) ->
     )
 
     assert PipxMetadata(venv_dir).exposure_enabled is True
+
+
+def test_pipx_metadata_file_defaults_expected_apps_from_version_0_7(tmp_path: Path) -> None:
+    venv_dir = tmp_path / "venv"
+    venv_dir.mkdir()
+    metadata = PipxMetadata(venv_dir, read=False)
+    metadata.main_package = TEST_PACKAGE1
+    payload = metadata.to_dict()
+    payload["pipx_metadata_version"] = "0.7"
+    payload["main_package"].pop("expected_apps")
+    (venv_dir / PIPX_INFO_FILENAME).write_text(json.dumps(payload, cls=JsonEncoderHandlesPath))
+
+    assert PipxMetadata(venv_dir).main_package.expected_apps == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
[#1908](https://github.com/pypa/pipx/issues/1908) asks automation to verify that a package provides a required command. `pipx install --app APP PACKAGE` checks exact entry-point names before exposing resources and lists the available apps when validation fails.

pipx records required names in environment metadata. Force installs, upgrades, reinstalls, repairs, and `install-all` preserve the contract. Failed reconciliation restores the prior environment. Installs without `--app` avoid the backup path.

Closes #1908.
