### PR TITLE
✨ feat(install): support PEP 751 lock files

### DIFF
--- a/changelog.d/1807.feature.md
+++ b/changelog.d/1807.feature.md
@@ -1,0 +1,1 @@
+Install from PEP 751 lock files.

--- a/docs/explanation/scope.md
+++ b/docs/explanation/scope.md
@@ -7,13 +7,13 @@ exposes their entry points on `PATH`.
 
 - Persistent application environments for `pipx install` and disposable environments for `pipx run`.
 - User installations by default and system installations when the caller passes `--global`.
-- Application dependencies inside a managed environment. `inject` and `--preinstall` extend an application environment;
-    they do not create standalone library environments.
+- Application dependencies inside a managed environment. For unlocked environments, `inject` and `--preinstall` extend
+    an application environment; they do not create standalone library environments.
 - Entry points from the main package, or from dependencies when the caller passes `--include-deps`.
 
-An install fails when neither the package nor its selected dependencies expose an application. pipx removes the new
-environment and reports the missing entry point. A future option may let the caller name the expected application so
-pipx can validate that entry point and apply the same rollback.
+An install fails when neither the package nor its selected dependencies expose an application. The caller can pass
+`--app NAME` to require an exact entry point. pipx removes a new environment or restores an existing one when the check
+fails.
 
 ## Boundaries
 
@@ -35,10 +35,10 @@ Ordinary pipx commands must not search the current directory or its parents for 
 state, the caller must supply a path, for example to a future `pipx apply tools.toml` command. The manifest must contain
 desired application state and reject arbitrary command defaults.
 
-Resolved dependency state must use the PyPA
+Resolved dependency state uses the PyPA
 [`pylock.toml` specification](https://packaging.python.org/en/latest/specifications/pylock-toml/). The standard permits
-`pylock.toml` and named files such as `pylock.black.toml` when a manifest needs more than one lock. pipx must not use
-`requirements.txt` as a state or lock format.
+`pylock.toml` and named files such as `pylock.black.toml` when a manifest needs more than one lock.
+`pipx install --lock` accepts an explicit path. pipx does not use `requirements.txt` as a state or lock format.
 
 Top-level pipx options describe policy that pip and uv can both honor. A control supported by one backend stays in the
 arguments for that backend until both backends can provide the same contract.

--- a/docs/reference/examples.md
+++ b/docs/reference/examples.md
@@ -22,6 +22,7 @@ pipx install --pip-args='--pre' poetry
 pipx install --pip-args='--index-url=<private-repo-host>:<private-repo-port> --trusted-host=<private-repo-host>:<private-repo-port>' private-repo-package
 pipx install --index-url https://test.pypi.org/simple/ --pip-args='--extra-index-url https://pypi.org/simple/' some-package
 pipx install --global pycowsay
+pipx install --lock pylock.toml .
 pipx install .
 pipx install path/to/some-project
 ```

--- a/docs/tutorial/install-applications.md
+++ b/docs/tutorial/install-applications.md
@@ -71,6 +71,28 @@ entry point, pipx restores the existing environment.
 Use one package spec with `--app`. Repeat the option to require more than one entry point. Dependency entry points
 qualify when you also pass `--include-deps`.
 
+### Installing from a lock file
+
+Use a [PEP 751 lock file](https://packaging.python.org/en/latest/specifications/pylock-toml/) when a resolver must
+choose the application versions and artifacts. Pass the path; pipx does not search the current directory for a lock.
+
+```
+uvx nab lock pyproject.toml
+pipx install --lock pylock.toml .
+```
+
+[nab](https://pypi.org/project/nab/) resolves the dependencies in `pyproject.toml` and writes `pylock.toml`. pipx runs
+the selected backend against the lock. A named package must appear in the lock. For a local project or direct URL, pipx
+installs the target without resolving its dependencies. pipx checks the environment before it exposes the application.
+
+pipx records the absolute lock path. `--force` and `reinstall` reuse it; `install-all` imports it. pipx skips the
+environment during `upgrade` and `upgrade-all`; update the lock and run `pipx reinstall PACKAGE` to apply it. pipx
+rejects `inject` because the added package would fall outside the lock.
+
+`--lock` accepts one package spec. Do not combine it with `--preinstall` or `--upgrade`. Pass `--force --lock` to
+replace an installed environment with a new lock. The pip backend requires pip 26.1 or newer; the uv backend requires uv
+0.6.15 or newer.
+
 ### Keeping an installation within a version range
 
 Use `--upgrade` when you want an installed app to match a package spec:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
   "userpath>=1.6,!=1.9",
 ]
 optional-dependencies.uv = [
-  "uv>=0.4",
+  "uv>=0.6.15",
 ]
 urls."Issue Tracker" = "https://github.com/pypa/pipx/issues"
 urls."Release Notes" = "https://pipx.pypa.io/latest/changelog/"

--- a/src/pipx/backends/_base.py
+++ b/src/pipx/backends/_base.py
@@ -46,6 +46,23 @@ class Backend(ABC):
         verbose: bool = False,
     ) -> CompletedProcess[str]: ...
 
+    def install_lock(
+        self,
+        *,
+        venv_root: Path,
+        venv_python: Path,
+        lock_file: Path,
+        pip_args: list[str],
+        verbose: bool = False,
+    ) -> CompletedProcess[str]:
+        return self.install(
+            venv_root=venv_root,
+            venv_python=venv_python,
+            requirements=["--requirement", str(lock_file)],
+            pip_args=pip_args,
+            verbose=verbose,
+        )
+
     @abstractmethod
     def uninstall(
         self,

--- a/src/pipx/backends/uv.py
+++ b/src/pipx/backends/uv.py
@@ -36,7 +36,7 @@ except ImportError:
     _uv_bin_from_extra = None
 _FIND_UV_BIN_FROM_EXTRA: Final[Callable[[], str] | None] = _uv_bin_from_extra
 del _uv_bin_from_extra
-_MIN_UV_VERSION: Final[Version] = Version("0.4.0")
+_MIN_UV_VERSION: Final[Version] = Version("0.6.15")
 _VERSION_RE: Final[re.Pattern[str]] = re.compile(
     r"""
     uv \s+        # the literal "uv " prefix from `uv --version`

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -576,6 +576,10 @@ def add_suffix(name: str, suffix: str) -> str:
     return f"{app.stem}{suffix}{app.suffix}"
 
 
+def locked_package_message(package_name: str) -> str:
+    return f"Not upgrading locked package {package_name}. Update its lock file and run `pipx reinstall {package_name}`."
+
+
 __all__ = [
     "VenvProblems",
     "add_suffix",
@@ -585,6 +589,7 @@ __all__ = [
     "get_exposed_man_paths_for_package",
     "get_exposed_paths_for_package",
     "get_venv_summary",
+    "locked_package_message",
     "package_name_from_spec",
     "run_post_install_actions",
     "validate_expected_apps",

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -48,8 +48,6 @@ def inject_dep(
         )
 
     venv = Venv(venv_dir, verbose=verbose, backend=backend, env_backend=env_backend)
-    venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
-
     if not venv.package_metadata:
         raise PipxError(
             f"""
@@ -59,6 +57,12 @@ def inject_dep(
             uninstall and install {venv.name!r}, or reinstall-all to fix.
             """
         )
+    if (lock_file := venv.pipx_metadata.main_package.lock_file) is not None:
+        raise PipxError(
+            f"Cannot inject into locked environment {venv.name}. "
+            f"Update {lock_file} and run `pipx reinstall {venv.name}`."
+        )
+    venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
 
     # package_spec is anything pip-installable, including package_name, vcs spec,
     #   zip file, or tar.gz file.

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -1,4 +1,5 @@
 import json
+import re
 import sys
 from collections.abc import Iterator, Sequence
 from dataclasses import replace
@@ -12,6 +13,7 @@ from pipx import commands, paths
 from pipx.backends import PIP
 from pipx.commands.common import (
     expose_package_resources,
+    locked_package_message,
     package_name_from_spec,
     run_post_install_actions,
     validate_expected_apps,
@@ -26,8 +28,10 @@ from pipx.emojis import sleep
 from pipx.interpreter import get_default_python
 from pipx.package_specifier import package_spec_satisfied
 from pipx.pipx_metadata_file import PackageInfo, PipxMetadata, load_spec_file
-from pipx.util import PipxError, pipx_wrap
+from pipx.util import PipxError, pipx_wrap, rmdir
 from pipx.venv import Venv, VenvContainer
+
+_PYLOCK_NAME_RE: Final[re.Pattern[str]] = re.compile(r"pylock(?:\.[^.]+)?\.toml")
 
 
 def install(
@@ -46,6 +50,7 @@ def install(
     include_dependencies: bool,
     preinstall_packages: list[str] | None,
     expected_apps: Sequence[str] = (),
+    lock_file: Path | None = None,
     suffix: str = "",
     python_flag_passed: bool = False,
     backend: str | None = None,
@@ -59,7 +64,14 @@ def install(
     # package_spec is anything pip-installable, including package_name, vcs spec,
     #   zip file, or tar.gz file.
 
-    _validate_install_options(package_specs, expected_apps, upgrade=upgrade, upgrade_strategy=upgrade_strategy)
+    lock_file = _validate_install_options(
+        package_specs,
+        expected_apps,
+        preinstall_packages,
+        lock_file,
+        upgrade=upgrade,
+        upgrade_strategy=upgrade_strategy,
+    )
 
     python = python or get_default_python()
 
@@ -104,6 +116,8 @@ def install(
                 env_backend=install_env_backend,
             )
             required_apps = tuple(dict.fromkeys(expected_apps or venv.pipx_metadata.main_package.expected_apps))
+            required_lock = lock_file or venv.pipx_metadata.main_package.lock_file
+            required_exposure = venv.pipx_metadata.exposure_enabled if exposure_enabled is None else exposure_enabled
             if exists:
                 if not reinstall and force and python_flag_passed:
                     print(
@@ -151,14 +165,24 @@ def install(
                     venv_dir = None
                     continue
 
-            with preserve_venv(venv_dir, enabled=exists and bool(required_apps)):
+            with preserve_venv(
+                venv_dir,
+                enabled=exists and (bool(required_apps) or required_lock is not None),
+            ):
                 venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
                 try:
+                    if exists and required_lock is not None:
+                        recorded_backend = venv.pipx_metadata.backend
+                        rmdir(venv_dir)
+                        venv = Venv(
+                            venv_dir,
+                            python=python,
+                            verbose=verbose,
+                            backend=install_backend or recorded_backend,
+                        )
                     override_shared = canonicalize_name(package_name) == "pip"
                     venv.create_venv(venv_args, pip_args, override_shared)
-                    venv.pipx_metadata.exposure_enabled = (
-                        venv.pipx_metadata.exposure_enabled if exposure_enabled is None else exposure_enabled
-                    )
+                    venv.pipx_metadata.exposure_enabled = required_exposure
                     for dependency in preinstall_packages or []:
                         venv.upgrade_package_no_metadata(dependency, [])
                     venv.install_package(
@@ -171,6 +195,7 @@ def install(
                         is_main_package=True,
                         suffix=suffix,
                         expected_apps=required_apps,
+                        lock_file=required_lock,
                     )
                     validate_expected_apps(venv, package_name, required_apps)
                     run_post_install_actions(
@@ -194,14 +219,30 @@ def install(
 def _validate_install_options(
     package_specs: Sequence[str],
     expected_apps: Sequence[str],
+    preinstall_packages: Sequence[str] | None,
+    lock_file: Path | None,
     *,
     upgrade: bool,
     upgrade_strategy: str | None,
-) -> None:
+) -> Path | None:
     if upgrade_strategy is not None and not upgrade:
         raise PipxError("--upgrade-strategy requires --upgrade")
     if expected_apps and len(package_specs) != 1:
         raise PipxError("--app accepts one package spec")
+    if lock_file is None:
+        return None
+    if len(package_specs) != 1:
+        raise PipxError("--lock accepts one package spec")
+    if preinstall_packages:
+        raise PipxError("--lock cannot be combined with --preinstall")
+    if upgrade:
+        raise PipxError("--lock cannot be combined with --upgrade; use --force to apply a new lock")
+    lock_file = lock_file.expanduser().resolve()
+    if not _PYLOCK_NAME_RE.fullmatch(lock_file.name):
+        raise PipxError("Lock files must be named pylock.toml or pylock.<name>.toml")
+    if not lock_file.is_file():
+        raise PipxError(f"Lock file does not exist: {lock_file}")
+    return lock_file
 
 
 def _upgrade_existing_venv(
@@ -217,6 +258,11 @@ def _upgrade_existing_venv(
 ) -> None:
     package_metadata = venv.pipx_metadata.main_package
     installed_version: Final[str] = package_metadata.package_version
+    if package_metadata.lock_file is not None:
+        validate_expected_apps(venv, package_name, expected_apps)
+        _record_expected_apps(venv, expected_apps)
+        print(locked_package_message(venv.name))
+        return
     if package_spec_satisfied(
         package_spec,
         package_name,
@@ -307,6 +353,7 @@ def install_all(
                     include_dependencies=main_package.include_dependencies,
                     preinstall_packages=[],
                     expected_apps=main_package.expected_apps,
+                    lock_file=main_package.lock_file,
                     suffix=main_package.suffix,
                     backend=backend or venv_metadata.backend,
                     env_backend=env_backend,

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -141,6 +141,7 @@ def reinstall(
             include_dependencies=venv.pipx_metadata.main_package.include_dependencies,
             preinstall_packages=[],
             expected_apps=venv.pipx_metadata.main_package.expected_apps,
+            lock_file=venv.pipx_metadata.main_package.lock_file,
             suffix=venv.pipx_metadata.main_package.suffix,
             python_flag_passed=python_flag_passed,
             backend=backend or venv.pipx_metadata.backend,

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -10,7 +10,7 @@ from filelock import BaseFileLock
 
 from pipx import commands, paths
 from pipx.colors import bold, red
-from pipx.commands.common import expose_package_resources, validate_expected_apps
+from pipx.commands.common import expose_package_resources, locked_package_message, validate_expected_apps
 from pipx.commands.transaction import preserve_venv
 from pipx.constants import EXIT_CODE_OK, ExitCode
 from pipx.emojis import sleep
@@ -24,6 +24,7 @@ _LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
 
 class UpgradeStatus(str, Enum):
+    LOCKED = "locked"
     PINNED = "pinned"
     UNCHANGED = "unchanged"
     UPGRADED = "upgraded"
@@ -115,6 +116,8 @@ def _upgrade_package(
 
 
 def _package_messages(result: PackageUpgradeResult, *, upgrading_all: bool) -> tuple[OutputMessage, ...]:
+    if result.status is UpgradeStatus.LOCKED:
+        return (OutputMessage(locked_package_message(result.environment)),)
     if result.status is UpgradeStatus.PINNED:
         subject = (
             f"package {result.package} in venv {result.environment}"
@@ -232,6 +235,20 @@ def _upgrade_venv(
             f"It was likely installed using a pipx version before 0.15.0.0.\n"
             f"Please uninstall and install this package to fix.",
             wrap_message=False,
+        )
+
+    main_package = venv.pipx_metadata.main_package
+    if main_package.lock_file is not None:
+        return (
+            PackageUpgradeResult(
+                environment=venv.name,
+                package=venv.name,
+                previous_version=main_package.package_version,
+                version=main_package.package_version,
+                status=UpgradeStatus.LOCKED,
+                injected=False,
+                location=str(venv.root),
+            ),
         )
 
     with preserve_venv(

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -483,6 +483,11 @@ def _add_install(subparsers: argparse._SubParsersAction, shared_parser: argparse
         action="append",
         help="Require this application entry point after installation. Repeat to require multiple entry points.",
     )
+    p.add_argument(
+        "--lock",
+        type=Path,
+        help="Install the environment from an explicit pylock.toml file.",
+    )
     add_pip_venv_args(p)
     add_backend_arg(p)
     p.set_defaults(func=_cmd_install)
@@ -505,6 +510,7 @@ def _cmd_install(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
         include_dependencies=args.include_deps,
         preinstall_packages=args.preinstall,
         expected_apps=args.app or (),
+        lock_file=args.lock,
         suffix=args.suffix,
         python_flag_passed=ctx.python_flag_passed,
         backend=ctx.backend,

--- a/src/pipx/pipx_metadata_file.py
+++ b/src/pipx/pipx_metadata_file.py
@@ -34,6 +34,7 @@ class _RawPackageInfo(TypedDict, total=False):
     app_paths_of_dependencies: dict[str, list[Path]]
     package_version: str
     expected_apps: list[str]
+    lock_file: Path | None
     man_pages: list[str]
     man_paths: list[Path]
     man_pages_of_dependencies: list[str]
@@ -92,6 +93,7 @@ class PackageInfo:
     app_paths_of_dependencies: dict[str, list[Path]]
     package_version: str
     expected_apps: list[str] = field(default_factory=list)
+    lock_file: Path | None = None
     man_pages: list[str] = field(default_factory=list)
     man_paths: list[Path] = field(default_factory=list)
     man_pages_of_dependencies: list[str] = field(default_factory=list)
@@ -108,7 +110,7 @@ class PipxMetadata:
     # V0.4 -> Add source interpreter
     # V0.5 -> Add pinned
     # V0.6 -> Add backend (pip|uv)
-    __METADATA_VERSION__: Final[str] = "0.8"
+    __METADATA_VERSION__: Final[str] = "0.9"
 
     def __init__(self, venv_dir: Path, read: bool = True):
         self.venv_dir = venv_dir
@@ -125,6 +127,7 @@ class PipxMetadata:
             apps_of_dependencies=[],
             app_paths_of_dependencies={},
             expected_apps=[],
+            lock_file=None,
             man_pages=[],
             man_paths=[],
             man_pages_of_dependencies=[],
@@ -160,7 +163,7 @@ class PipxMetadata:
 
     def _convert_legacy_metadata(self, metadata_dict: _RawMetadata) -> _RawMetadata:
         version = metadata_dict["pipx_metadata_version"]
-        if version in (self.__METADATA_VERSION__, "0.7", "0.6", "0.5"):
+        if version in (self.__METADATA_VERSION__, "0.8", "0.7", "0.6", "0.5"):
             pass
         elif version == "0.4":
             metadata_dict["pinned"] = False

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -212,7 +212,7 @@ class _SharedLibs:
                         "install",
                         "--upgrade",
                         *filtered_pip_args,
-                        "pip >= 23.1",
+                        "pip >= 26.1",
                     ]
                 )
             subprocess_post_check(upgrade_process)

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -29,8 +29,10 @@ from pipx.interpreter import get_default_python
 from pipx.package_specifier import (
     fix_package_name,
     get_extras,
+    package_spec_satisfied,
     parse_specifier_for_install,
     parse_specifier_for_metadata,
+    valid_pypi_name,
 )
 from pipx.pipx_metadata_file import PackageInfo, PipxMetadata
 from pipx.shared_libs import (
@@ -345,6 +347,7 @@ class Venv:
         suffix: str = "",
         install_only_pip_args: list[str] | None = None,
         expected_apps: Sequence[str] | None = None,
+        lock_file: Path | None = None,
     ) -> None:
         # package_name in package specifier can mismatch URL due to user error
         package_or_url = fix_package_name(package_or_url, package_name)
@@ -353,17 +356,20 @@ class Venv:
         (package_or_url, pip_args) = parse_specifier_for_install(package_or_url, pip_args)
         install_pip_args = [*(install_only_pip_args or []), *pip_args]
 
-        _LOGGER.info("Installing %s", package_descr := full_package_description(package_name, package_or_url))
-        with animate(f"installing {package_descr}", self.do_animation):
-            process = self.backend.install(
-                venv_root=self.root,
-                venv_python=self.python_path,
-                requirements=[package_or_url],
-                pip_args=install_pip_args,
-                verbose=self.verbose,
-            )
-        if process.returncode:
-            raise PipxError(f"Error installing {full_package_description(package_name, package_or_url)}.")
+        if lock_file is None:
+            _LOGGER.info("Installing %s", package_descr := full_package_description(package_name, package_or_url))
+            with animate(f"installing {package_descr}", self.do_animation):
+                process = self.backend.install(
+                    venv_root=self.root,
+                    venv_python=self.python_path,
+                    requirements=[package_or_url],
+                    pip_args=install_pip_args,
+                    verbose=self.verbose,
+                )
+            if process.returncode:
+                raise PipxError(f"Error installing {full_package_description(package_name, package_or_url)}.")
+        else:
+            self._install_locked_package(package_name, package_or_url, lock_file, install_pip_args)
 
         self.update_package_metadata(
             package_name=package_name,
@@ -374,6 +380,7 @@ class Venv:
             is_main_package=is_main_package,
             suffix=suffix,
             expected_apps=expected_apps,
+            lock_file=lock_file,
         )
 
         # Verify package installed ok
@@ -385,6 +392,60 @@ class Venv:
                 f"be installed with pip.",
                 wrap_message=False,
             )
+
+    def _install_locked_package(
+        self,
+        package_name: str,
+        package_or_url: str,
+        lock_file: Path,
+        pip_args: list[str],
+    ) -> None:
+        _LOGGER.info("Installing packages from %s", lock_file)
+        with animate(f"installing packages from {lock_file.name}", self.do_animation):
+            process = self.backend.install_lock(
+                venv_root=self.root,
+                venv_python=self.python_path,
+                lock_file=lock_file,
+                pip_args=[argument for argument in pip_args if argument != "--editable"],
+                verbose=self.verbose,
+            )
+        if process.returncode:
+            raise PipxError(f"Error installing packages from {lock_file}.")
+
+        if valid_pypi_name(package_or_url) is None:
+            with animate(f"installing {full_package_description(package_name, package_or_url)}", self.do_animation):
+                process = self.backend.install(
+                    venv_root=self.root,
+                    venv_python=self.python_path,
+                    requirements=[package_or_url],
+                    pip_args=pip_args,
+                    no_deps=True,
+                    verbose=self.verbose,
+                )
+            if process.returncode:
+                raise PipxError(f"Error installing {full_package_description(package_name, package_or_url)}.")
+        elif (
+            distribution := next(
+                iter(Distribution.discover(name=package_name, path=[str(self.site_packages)])),
+                None,
+            )
+        ) is None:
+            raise PipxError(f"Lock file {lock_file} does not contain {package_name}.")
+        elif not package_spec_satisfied(package_or_url, package_name, distribution.version, package_or_url):
+            raise PipxError(
+                f"Lock file {lock_file} provides {package_name} {distribution.version}, "
+                f"which does not satisfy {package_or_url}."
+            )
+
+        process = self.backend.run_raw_pip(
+            venv_root=self.root,
+            venv_python=self.python_path,
+            args=["check"],
+            verbose=self.verbose,
+        )
+        if process.returncode:
+            error = (process.stdout or process.stderr or "dependency check failed").strip()
+            raise PipxError(f"Lock file {lock_file} does not satisfy {package_name}: {error}", wrap_message=False)
 
     def install_unmanaged_packages(self, requirements: list[str], pip_args: list[str]) -> None:
         """Install packages in the venv, but do not record them in the metadata."""
@@ -456,12 +517,15 @@ class Venv:
         suffix: str = "",
         pinned: bool = False,
         expected_apps: Sequence[str] | None = None,
+        lock_file: Path | None = None,
     ) -> None:
         venv_package_metadata = self.get_venv_metadata_for_package(package_name, get_extras(package_or_url))
         if expected_apps is None:
             expected_apps = (
                 self.package_metadata[package_name].expected_apps if package_name in self.package_metadata else ()
             )
+        if lock_file is None:
+            lock_file = self.package_metadata[package_name].lock_file if package_name in self.package_metadata else None
         package_info = PackageInfo(
             package=package_name,
             package_or_url=parse_specifier_for_metadata(package_or_url),
@@ -478,6 +542,7 @@ class Venv:
             man_paths_of_dependencies=venv_package_metadata.man_paths_of_dependencies,
             package_version=venv_package_metadata.package_version,
             expected_apps=list(dict.fromkeys(expected_apps)),
+            lock_file=lock_file,
             suffix=suffix,
             pinned=pinned,
         )

--- a/testdata/tests_packages/macos24-python3.13.txt
+++ b/testdata/tests_packages/macos24-python3.13.txt
@@ -116,7 +116,7 @@ pexpect==4.9.0
 pickleshare==0.7.5
 pip==23.3.2
 pip==24.0
-pip==25.2
+pip==26.1.2
 platformdirs==4.4.0
 pluggy==1.6.0
 prometheus_client==0.23.1

--- a/testdata/tests_packages/unix-python3.10.txt
+++ b/testdata/tests_packages/unix-python3.10.txt
@@ -120,7 +120,7 @@ pexpect==4.9.0
 pickleshare==0.7.5
 pip==23.3.2
 pip==24.0
-pip==25.2
+pip==26.1.2
 platformdirs==4.4.0
 pluggy==1.6.0
 prometheus_client==0.23.1

--- a/testdata/tests_packages/unix-python3.11.txt
+++ b/testdata/tests_packages/unix-python3.11.txt
@@ -119,7 +119,7 @@ pexpect==4.9.0
 pickleshare==0.7.5
 pip==23.3.2
 pip==24.0
-pip==25.2
+pip==26.1.2
 platformdirs==4.4.0
 pluggy==1.6.0
 prometheus_client==0.23.1

--- a/testdata/tests_packages/unix-python3.12.txt
+++ b/testdata/tests_packages/unix-python3.12.txt
@@ -116,7 +116,7 @@ pexpect==4.9.0
 pickleshare==0.7.5
 pip==23.3.2
 pip==24.0
-pip==25.2
+pip==26.1.2
 platformdirs==4.4.0
 pluggy==1.6.0
 prometheus_client==0.23.1

--- a/testdata/tests_packages/unix-python3.13.txt
+++ b/testdata/tests_packages/unix-python3.13.txt
@@ -116,7 +116,7 @@ pexpect==4.9.0
 pickleshare==0.7.5
 pip==23.3.2
 pip==24.0
-pip==25.2
+pip==26.1.2
 platformdirs==4.4.0
 pluggy==1.6.0
 prometheus_client==0.23.1

--- a/testdata/tests_packages/win-python3.13.txt
+++ b/testdata/tests_packages/win-python3.13.txt
@@ -122,7 +122,7 @@ pbr==5.6.0
 pickleshare==0.7.5
 pip==23.3.2
 pip==24.0
-pip==25.2
+pip==26.1.2
 platformdirs==4.4.0
 pluggy==1.6.0
 prometheus_client==0.23.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import hashlib
 import importlib
 import json
 import os
@@ -5,7 +6,7 @@ import shutil
 import socket
 import subprocess
 import sys
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import closing
 from http import HTTPStatus
 from pathlib import Path
@@ -34,6 +35,55 @@ PIPX_TESTS_PACKAGE_LIST_DIR = Path("testdata/tests_packages")
 @pytest.fixture(scope="session")
 def root() -> Path:
     return Path(__file__).parents[1]
+
+
+@pytest.fixture
+def make_pylock(root: Path, tmp_path: Path) -> Callable[[str, str], Path]:
+    def create(package: str, version: str) -> Path:
+        wheel = next(
+            (root / PIPX_TESTS_DIR / "package_cache" / f"{sys.version_info.major}.{sys.version_info.minor}").glob(
+                f"{package}-{version}-*.whl"
+            )
+        )
+        lock_file = tmp_path / "pylock.test.toml"
+        lock_file.write_text(
+            f'''lock-version = "1.0"
+created-by = "pipx tests"
+
+[[packages]]
+name = "{package}"
+version = "{version}"
+
+[[packages.wheels]]
+name = "{wheel.name}"
+url = "{wheel.as_uri()}"
+
+[packages.wheels.hashes]
+sha256 = "{hashlib.sha256(wheel.read_bytes()).hexdigest()}"
+''',
+            encoding="utf-8",
+        )
+        return lock_file
+
+    return create
+
+
+@pytest.fixture
+def make_project_with_dependency(root: Path, tmp_path: Path) -> Callable[[str], Path]:
+    def create(dependency: str) -> Path:
+        project = tmp_path / "locked-project"
+        shutil.copytree(root / "testdata/empty_project", project)
+        pyproject = project / "pyproject.toml"
+        pyproject.write_text(
+            pyproject.read_text(encoding="utf-8").replace(
+                'requires-python = ">=3.10"\n',
+                f'dependencies = ["{dependency}"]\nrequires-python = ">=3.10"\n',
+            ),
+            encoding="utf-8",
+        )
+        return project
+
+    return create
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli, skip_if_windows, unwrap_log_text
+from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli, skip_if_windows
 from package_info import PKG
 from pipx import paths
 from pipx.pipx_metadata_file import PipxMetadata
@@ -23,7 +23,7 @@ def test_inject_rejects_pylock(
 
     assert run_pipx_cli(["inject", "pycowsay", "black"])
 
-    error = unwrap_log_text(capsys.readouterr().err)
+    error = " ".join(capsys.readouterr().err.split())
     assert (
         "Cannot inject into locked environment pycowsay" in error and "`pipx reinstall pycowsay`" in error,
         PipxMetadata(paths.ctx.venvs / "pycowsay").injected_packages,

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -1,13 +1,33 @@
 import logging
 import re
 import textwrap
+from collections.abc import Callable
+from pathlib import Path
 
 import pytest
 
-from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli, skip_if_windows
+from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli, skip_if_windows, unwrap_log_text
 from package_info import PKG
 from pipx import paths
 from pipx.pipx_metadata_file import PipxMetadata
+
+
+def test_inject_rejects_pylock(
+    pipx_temp_env: None,
+    make_pylock: Callable[[str, str], Path],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    lock_file = make_pylock("pycowsay", "0.0.0.2")
+    assert not run_pipx_cli(["install", "--lock", str(lock_file), "pycowsay"])
+    capsys.readouterr()
+
+    assert run_pipx_cli(["inject", "pycowsay", "black"])
+
+    error = unwrap_log_text(capsys.readouterr().err)
+    assert (
+        "Cannot inject into locked environment pycowsay" in error and "`pipx reinstall pycowsay`" in error,
+        PipxMetadata(paths.ctx.venvs / "pycowsay").injected_packages,
+    ) == (True, {})
 
 
 # Note that this also checks that packages used in other tests can be injected individually

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -3,6 +3,7 @@ import re
 import shutil
 import subprocess
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
 from unittest import mock
@@ -190,6 +191,213 @@ def test_install_records_expected_app(pipx_temp_env: None) -> None:
     assert not run_pipx_cli(["install", "--app", "pycowsay", PKG["pycowsay"]["spec"]])
 
     assert PipxMetadata(paths.ctx.venvs / "pycowsay").main_package.expected_apps == ["pycowsay"]
+
+
+@pytest.mark.parametrize("backend", [pytest.param("pip", id="pip"), pytest.param("uv", id="uv")])
+def test_install_from_pylock(
+    pipx_temp_env: None,
+    make_pylock: Callable[[str, str], Path],
+    backend: str,
+) -> None:
+    if backend == "uv" and shutil.which("uv") is None:
+        pytest.skip("uv is not installed")
+    lock_file = make_pylock("pycowsay", "0.0.0.2")
+
+    assert not run_pipx_cli(["install", "--backend", backend, "--lock", str(lock_file), "pycowsay>=0"])
+
+    metadata = PipxMetadata(paths.ctx.venvs / "pycowsay").main_package
+    assert (
+        metadata.package_version,
+        metadata.lock_file,
+        (paths.ctx.bin_dir / app_name("pycowsay")).exists(),
+    ) == ("0.0.0.2", lock_file.resolve(), True)
+
+
+@pytest.mark.parametrize("editable", [pytest.param(False, id="wheel"), pytest.param(True, id="editable")])
+def test_install_source_from_pylock(
+    pipx_temp_env: None,
+    make_pylock: Callable[[str, str], Path],
+    make_project_with_dependency: Callable[[str], Path],
+    editable: bool,
+) -> None:
+    project = make_project_with_dependency("pycowsay==0.0.0.2")
+    lock_file = make_pylock("pycowsay", "0.0.0.2")
+
+    assert not run_pipx_cli(["install", *(["--editable"] if editable else []), "--lock", str(lock_file), str(project)])
+
+    metadata = PipxMetadata(paths.ctx.venvs / "empty-project").main_package
+    assert (metadata.package_version, metadata.lock_file, metadata.apps, metadata.pip_args) == (
+        "0.1.0",
+        lock_file.resolve(),
+        [app_name("empty-project")],
+        ["--editable"] if editable else [],
+    )
+
+
+def test_install_rejects_incomplete_pylock(
+    pipx_temp_env: None,
+    make_pylock: Callable[[str, str], Path],
+    make_project_with_dependency: Callable[[str], Path],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    project = make_project_with_dependency("black==22.8.0")
+    lock_file = make_pylock("pycowsay", "0.0.0.2")
+
+    assert run_pipx_cli(["install", "--lock", str(lock_file), str(project)])
+
+    assert (
+        "does not satisfy empty-project" in capsys.readouterr().err,
+        (paths.ctx.venvs / "empty-project").exists(),
+    ) == (True, False)
+
+
+@pytest.mark.parametrize(
+    ("package_spec", "environment", "expected_error"),
+    [
+        pytest.param("pycowsay==999", "pycowsay", "does not satisfy pycowsay==999", id="version"),
+        pytest.param("black", "black", r"does\s+not\s+contain\s+black", id="package"),
+    ],
+)
+def test_install_rejects_target_outside_pylock(
+    pipx_temp_env: None,
+    make_pylock: Callable[[str, str], Path],
+    capsys: pytest.CaptureFixture[str],
+    package_spec: str,
+    environment: str,
+    expected_error: str,
+) -> None:
+    lock_file = make_pylock("pycowsay", "0.0.0.2")
+
+    assert run_pipx_cli(["install", "--lock", str(lock_file), package_spec])
+
+    error = unwrap_log_text(capsys.readouterr().err)
+    assert (
+        re.search(expected_error, error) is not None,
+        (paths.ctx.venvs / environment).exists(),
+    ) == (True, False)
+
+
+def test_install_rejects_invalid_pylock(
+    pipx_temp_env: None,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    lock_file = tmp_path / "pylock.toml"
+    lock_file.write_text("invalid = true\n", encoding="utf-8")
+
+    assert run_pipx_cli(["install", "--lock", str(lock_file), "pycowsay"])
+
+    assert (
+        "Error installing packages from" in unwrap_log_text(capsys.readouterr().err),
+        (paths.ctx.venvs / "pycowsay").exists(),
+    ) == (True, False)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        pytest.param(["install", "--force", "pycowsay"], id="force"),
+        pytest.param(["reinstall", "pycowsay"], id="reinstall"),
+    ],
+)
+def test_install_reapplies_recorded_pylock(
+    pipx_temp_env: None,
+    make_pylock: Callable[[str, str], Path],
+    command: list[str],
+) -> None:
+    lock_file = make_pylock("pycowsay", "0.0.0.2")
+    assert not run_pipx_cli(["install", "--lock", str(lock_file), "pycowsay"])
+    marker = paths.ctx.venvs / "pycowsay" / "marker"
+    marker.touch()
+
+    assert not run_pipx_cli(command)
+
+    metadata = PipxMetadata(paths.ctx.venvs / "pycowsay").main_package
+    assert (marker.exists(), metadata.package_version, metadata.lock_file) == (
+        False,
+        "0.0.0.2",
+        lock_file.resolve(),
+    )
+
+
+def test_install_restores_environment_after_pylock_mismatch(
+    pipx_temp_env: None,
+    make_pylock: Callable[[str, str], Path],
+) -> None:
+    lock_file = make_pylock("pycowsay", "0.0.0.2")
+    assert not run_pipx_cli(["install", "--lock", str(lock_file), "pycowsay"])
+    marker = paths.ctx.venvs / "pycowsay" / "marker"
+    marker.touch()
+
+    assert run_pipx_cli(["install", "--force", "--lock", str(lock_file), "pycowsay==999"])
+
+    metadata = PipxMetadata(paths.ctx.venvs / "pycowsay").main_package
+    assert (marker.exists(), metadata.package_version, metadata.lock_file) == (
+        True,
+        "0.0.0.2",
+        lock_file.resolve(),
+    )
+
+
+def test_install_upgrade_skips_pylock(
+    pipx_temp_env: None,
+    make_pylock: Callable[[str, str], Path],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    lock_file = make_pylock("pycowsay", "0.0.0.2")
+    assert not run_pipx_cli(["install", "--lock", str(lock_file), "pycowsay"])
+    capsys.readouterr()
+
+    assert not run_pipx_cli(["install", "--upgrade", "pycowsay==999"])
+
+    metadata = PipxMetadata(paths.ctx.venvs / "pycowsay").main_package
+    assert (
+        "Not upgrading locked package pycowsay. Update its lock file and run `pipx reinstall pycowsay`."
+        in unwrap_log_text(capsys.readouterr().out),
+        metadata.package_version,
+        metadata.lock_file,
+    ) == (True, "0.0.0.2", lock_file.resolve())
+
+
+@pytest.mark.parametrize(
+    ("package_args", "lock_name", "lock_exists", "expected_error"),
+    [
+        pytest.param(["pycowsay", "black"], "pylock.test.toml", True, "--lock accepts one package spec", id="packages"),
+        pytest.param(
+            ["--preinstall", "black", "pycowsay"],
+            "pylock.test.toml",
+            True,
+            "--lock cannot be combined with --preinstall",
+            id="preinstall",
+        ),
+        pytest.param(
+            ["--upgrade", "pycowsay"],
+            "pylock.test.toml",
+            True,
+            "--lock cannot be combined with --upgrade",
+            id="upgrade",
+        ),
+        pytest.param(["pycowsay"], "lock.toml", True, "Lock files must be named", id="name"),
+        pytest.param(["pycowsay"], "pylock.missing.toml", False, "Lock file does not exist", id="missing"),
+    ],
+)
+def test_install_rejects_invalid_pylock_options(
+    pipx_temp_env: None,
+    make_pylock: Callable[[str, str], Path],
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    package_args: list[str],
+    lock_name: str,
+    lock_exists: bool,
+    expected_error: str,
+) -> None:
+    lock_file = tmp_path / lock_name
+    if lock_exists:
+        make_pylock("pycowsay", "0.0.0.2").rename(lock_file)
+
+    assert run_pipx_cli(["install", "--lock", str(lock_file), *package_args])
+
+    assert expected_error in unwrap_log_text(capsys.readouterr().err)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -254,7 +254,7 @@ def test_install_rejects_incomplete_pylock(
 @pytest.mark.parametrize(
     ("package_spec", "environment", "expected_error"),
     [
-        pytest.param("pycowsay==999", "pycowsay", "does not satisfy pycowsay==999", id="version"),
+        pytest.param("pycowsay==999", "pycowsay", r"does\s+not\s+satisfy\s+pycowsay==999", id="version"),
         pytest.param("black", "black", r"does\s+not\s+contain\s+black", id="package"),
     ],
 )

--- a/tests/test_install_all.py
+++ b/tests/test_install_all.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -7,8 +8,14 @@ from helpers import run_pipx_cli
 from pipx import paths
 
 
-def test_install_all(pipx_temp_env: None, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-    assert not run_pipx_cli(["install", "--app", "pycowsay", "pycowsay"])
+def test_install_all(
+    pipx_temp_env: None,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    make_pylock: Callable[[str, str], Path],
+) -> None:
+    lock_file = make_pylock("pycowsay", "0.0.0.2")
+    assert not run_pipx_cli(["install", "--app", "pycowsay", "--lock", str(lock_file), "pycowsay"])
     assert not run_pipx_cli(["install", "black"])
     assert not run_pipx_cli(["inject", "black", "pycowsay"])
     capsys.readouterr()
@@ -27,10 +34,12 @@ def test_install_all(pipx_temp_env: None, tmp_path: Path, capsys: pytest.Capture
         sorted(installed),
         sorted(installed["black"]["metadata"]["injected_packages"]),
         installed["pycowsay"]["metadata"]["main_package"]["expected_apps"],
+        installed["pycowsay"]["metadata"]["main_package"]["lock_file"],
     ) == (
         ["black", "pycowsay"],
         ["pycowsay"],
         ["pycowsay"],
+        {"__Path__": str(lock_file.resolve()), "__type__": "Path"},
     )
 
 

--- a/tests/test_pipx_metadata_file.py
+++ b/tests/test_pipx_metadata_file.py
@@ -106,6 +106,19 @@ def test_pipx_metadata_file_defaults_expected_apps_from_version_0_7(tmp_path: Pa
     assert PipxMetadata(venv_dir).main_package.expected_apps == []
 
 
+def test_pipx_metadata_file_defaults_lock_file_from_version_0_8(tmp_path: Path) -> None:
+    venv_dir = tmp_path / "venv"
+    venv_dir.mkdir()
+    metadata = PipxMetadata(venv_dir, read=False)
+    metadata.main_package = TEST_PACKAGE1
+    payload = metadata.to_dict()
+    payload["pipx_metadata_version"] = "0.8"
+    payload["main_package"].pop("lock_file")
+    (venv_dir / PIPX_INFO_FILENAME).write_text(json.dumps(payload, cls=JsonEncoderHandlesPath))
+
+    assert PipxMetadata(venv_dir).main_package.lock_file is None
+
+
 @pytest.mark.parametrize(
     "test_package",
     [

--- a/tests/test_reinstall.py
+++ b/tests/test_reinstall.py
@@ -1,5 +1,7 @@
 import sys
+from collections.abc import Callable
 from dataclasses import replace
+from pathlib import Path
 
 import pytest
 from pytest_mock import MockerFixture
@@ -12,6 +14,33 @@ from pipx.pipx_metadata_file import PipxMetadata
 def test_reinstall(pipx_temp_env, capsys):
     assert not run_pipx_cli(["install", "pycowsay"])
     assert not run_pipx_cli(["reinstall", "--python", sys.executable, "pycowsay"])
+
+
+def test_reinstall_pylock_restores_source_after_build_failure(
+    pipx_temp_env: None,
+    make_pylock: Callable[[str, str], Path],
+    make_project_with_dependency: Callable[[str], Path],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    project = make_project_with_dependency("pycowsay==0.0.0.2")
+    lock_file = make_pylock("pycowsay", "0.0.0.2")
+    assert not run_pipx_cli(["install", "--lock", str(lock_file), str(project)])
+    capsys.readouterr()
+    pyproject = project / "pyproject.toml"
+    pyproject.write_text(
+        pyproject.read_text(encoding="utf-8").replace("setuptools.build_meta", "missing"),
+        encoding="utf-8",
+    )
+
+    assert run_pipx_cli(["reinstall", "empty-project"])
+
+    metadata = PipxMetadata(paths.ctx.venvs / "empty-project").main_package
+    assert (
+        "Reinstall failed; restored empty-project" in capsys.readouterr().err,
+        metadata.package_version,
+        metadata.lock_file,
+        (paths.ctx.bin_dir / app_name("empty-project")).exists(),
+    ) == (True, "0.1.0", lock_file.resolve(), True)
 
 
 @skip_if_windows

--- a/tests/test_shared_libs.py
+++ b/tests/test_shared_libs.py
@@ -133,7 +133,7 @@ def test_shared_libs_upgrade_enforces_pip_floor(
     install_command = run_subprocess.call_args.args[0]
     run_subprocess.assert_called_once()
     assert "pip==20" in install_command
-    assert "pip >= 23.1" in install_command
+    assert "pip >= 26.1" in install_command
 
 
 def test_shared_libs_upgrade_serializes_concurrent_calls(

--- a/tests/test_uninject.py
+++ b/tests/test_uninject.py
@@ -1,3 +1,4 @@
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -64,14 +65,21 @@ def test_uninject_running_app(pipx_temp_env: None) -> None:
         process.wait(timeout=10)
 
 
-def test_uninject_with_suffix_removes_apps(pipx_temp_env: None, root: Path) -> None:
+def test_uninject_with_suffix_removes_apps(pipx_temp_env: None, root: Path, tmp_path: Path) -> None:
     suffix = "@1"
-    assert not run_pipx_cli(["install", str(root / "testdata/empty_project"), f"--suffix={suffix}"])
+    ignore_generated = shutil.ignore_patterns("build", "*.egg-info")
+    project = shutil.copytree(root / "testdata/empty_project", tmp_path / "empty_project", ignore=ignore_generated)
+    assert not run_pipx_cli(["install", str(project), f"--suffix={suffix}"])
+    injected_project = shutil.copytree(
+        root / "testdata/test_package_specifier/local_extras",
+        tmp_path / "local_extras",
+        ignore=ignore_generated,
+    )
     assert not run_pipx_cli(
         [
             "inject",
             f"empty-project{suffix}",
-            f"{root / 'testdata/test_package_specifier/local_extras'}[cow]",
+            f"{injected_project}[cow]",
             "--include-deps",
             "--with-suffix",
         ]

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -8,6 +9,7 @@ from helpers import (
     remove_venv_interpreter,
     run_pipx_cli,
     skip_if_windows,
+    unwrap_log_text,
 )
 from package_info import PKG
 from pipx import paths
@@ -26,6 +28,34 @@ def test_upgrade(pipx_temp_env, capsys):
     assert not run_pipx_cli(["upgrade", "pycowsay"])
     captured = capsys.readouterr()
     assert "pycowsay is already at latest version" in captured.out
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        pytest.param(["upgrade", "pycowsay"], id="one"),
+        pytest.param(["upgrade-all"], id="all"),
+    ],
+)
+def test_upgrade_skips_pylock(
+    pipx_temp_env: None,
+    make_pylock: Callable[[str, str], Path],
+    capsys: pytest.CaptureFixture[str],
+    command: list[str],
+) -> None:
+    lock_file = make_pylock("pycowsay", "0.0.0.2")
+    assert not run_pipx_cli(["install", "--lock", str(lock_file), "pycowsay"])
+    capsys.readouterr()
+
+    assert not run_pipx_cli(command)
+
+    metadata = PipxMetadata(paths.ctx.venvs / "pycowsay").main_package
+    assert (
+        "Not upgrading locked package pycowsay. Update its lock file and run `pipx reinstall pycowsay`."
+        in unwrap_log_text(capsys.readouterr().out),
+        metadata.package_version,
+        metadata.lock_file,
+    ) == (True, "0.0.0.2", lock_file.resolve())
 
 
 @skip_if_windows

--- a/tests/test_upgrade_all.py
+++ b/tests/test_upgrade_all.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -59,6 +60,30 @@ def test_upgrade_all_json(pipx_temp_env: None, capsys: pytest.CaptureFixture[str
         "pipx_result_version": "0.1",
         "status": "success",
     }
+
+
+def test_upgrade_all_pylock_json(
+    pipx_temp_env: None,
+    make_pylock: Callable[[str, str], Path],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    lock_file = make_pylock("pycowsay", "0.0.0.2")
+    assert not run_pipx_cli(["install", "--lock", str(lock_file), "pycowsay"])
+    capsys.readouterr()
+
+    assert not run_pipx_cli(["upgrade-all", "--json"])
+
+    assert json.loads(capsys.readouterr().out)["data"]["packages"] == [
+        {
+            "environment": "pycowsay",
+            "injected": False,
+            "location": str(paths.ctx.venvs / "pycowsay"),
+            "package": "pycowsay",
+            "previous_version": "0.0.0.2",
+            "status": "locked",
+            "version": "0.0.0.2",
+        }
+    ]
 
 
 def test_upgrade_all_json_failure(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_upgrade_shared.py
+++ b/tests/test_upgrade_shared.py
@@ -57,10 +57,6 @@ def test_upgrade_shared_pin_pip(shared_libs):
 
     assert shared_libs.has_been_updated_this_run is False
     assert shared_libs.is_valid is False
-    assert run_pipx_cli(["upgrade-shared", "-v", "--pip-args=pip==24.0"]) == 0
+    assert run_pipx_cli(["upgrade-shared", "-v", "--pip-args=pip==26.1.2"]) == 0
     assert shared_libs.is_valid is True
-    assert pip_version() == "24.0"  # type: ignore[unreachable]
-    shared_libs.has_been_updated_this_run = False  # reset for next run
-    assert run_pipx_cli(["upgrade-shared", "-v", "--pip-args=pip==23.3.2"]) == 0
-    assert shared_libs.is_valid is True
-    assert pip_version() == "23.3.2"
+    assert pip_version() == "26.1.2"  # type: ignore[unreachable]


### PR DESCRIPTION
Resolvers record exact Python artifacts in standard [PEP 751 lock files](https://packaging.python.org/en/latest/specifications/pylock-toml/). This adds explicit lock input through `pipx install --lock PATH`. Closes https://github.com/pypa/pipx/issues/1807.

The command reads only the path supplied by the caller. A named target must appear in the lock. For a local project or direct URL, the backend first installs the locked packages, then `pipx` installs the target with dependency resolution disabled. `pipx` validates the resulting environment before exposing its applications, using the same contract for pip and uv.

`pipx` records the absolute lock path and reuses it for `--force`, `reinstall`, and `install-all`. Locked environments skip upgrades and reject injection because either operation would drift from the resolved state. Applying a lock recreates the environment inside the rollback transaction, removing stale distributions and restoring the prior installation when installation or validation fails. The pip backend requires pip 26.1 or newer, and the uv backend requires uv 0.6.15 or newer.
