### PR TITLE
🐛 fix(uv): allow forced reinstalls

### DIFF
--- a/changelog.d/1924.bugfix.md
+++ b/changelog.d/1924.bugfix.md
@@ -1,0 +1,1 @@
+Allow forced installs in existing uv environments.

--- a/src/pipx/backends/uv.py
+++ b/src/pipx/backends/uv.py
@@ -80,7 +80,7 @@ class UvBackend(Backend):
                 "The uv backend cannot create a virtual environment with pip preinstalled.\n"
                 "Reinstall the package with `--backend pip` (or unset PIPX_DEFAULT_BACKEND)."
             )
-        cmd: list[str | Path] = [self._binary, "venv", "--python", python, *venv_args]
+        cmd: list[str | Path] = [self._binary, "venv", "--python", python, "--allow-existing", *venv_args]
         cmd.append("--verbose" if verbose else "--quiet")
         cmd.append(str(root))
         with animate("creating virtual environment", not verbose):

--- a/tests/test_backends_install.py
+++ b/tests/test_backends_install.py
@@ -36,3 +36,10 @@ def test_uv_backend_install_uninstall_smoke(pipx_temp_env, capsys: pytest.Captur
     uninstall_rc = run_pipx_cli(["uninstall", "pycowsay"])
     assert uninstall_rc == 0
     assert not metadata_file.exists()
+
+
+@pytest.mark.skipif(shutil.which("uv") is None, reason="uv binary not on PATH; skipping uv integration smoke")
+def test_uv_backend_force_install_existing(pipx_temp_env: None) -> None:
+    command = ["install", "pycowsay", "--backend", "uv"]
+    assert run_pipx_cli(command) == 0
+    assert run_pipx_cli([*command, "--force"]) == 0


### PR DESCRIPTION
Closes #1924.

`pipx install --force` reruns virtual environment creation before reinstalling the package. Python's `venv` accepts an existing environment, but `uv venv` rejects one unless pipx passes `--allow-existing`.

Pass `--allow-existing` when pipx creates uv environments so forced installs reach the package reinstall. This option exists in uv 0.4.0, pipx's minimum supported version.
