### PR TITLE
✨ feat(inject): support main-package extras

### DIFF
--- a/changelog.d/1805.feature.md
+++ b/changelog.d/1805.feature.md
@@ -1,0 +1,1 @@
+Support injecting extras into a main package.

--- a/docs/explanation/making-packages-compatible.md
+++ b/docs/explanation/making-packages-compatible.md
@@ -93,6 +93,32 @@ With this declaration, `pipx run my-package` invokes `my_package.cli:main` even 
 exists. The [build](https://github.com/pypa/build) package uses this pattern so that `pipx run build` works even though
 build's console script is named `pyproject-build`.
 
+### Detect a pipx installation
+
+pipx records the environment name in `pipx_metadata.json` for packages installed with `pipx install`. Package code can
+read this name when it needs to give pipx-specific recovery instructions:
+
+```python
+import json
+import sys
+from pathlib import Path
+
+
+def pipx_environment() -> str | None:
+    try:
+        metadata = json.loads((Path(sys.prefix) / "pipx_metadata.json").read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    environment = metadata.get("environment") if isinstance(metadata, dict) else None
+    return environment if isinstance(environment, str) else None
+```
+
+Use the returned name as the target for commands such as `pipx inject ENVIRONMENT 'mytool[feature]'`. pipx records the
+extra on the main package, so reinstalling the environment retains it.
+
+`pipx run` may create internal metadata without setting `environment`, so check the field value. Treat other keys as
+internal pipx state. If the function returns `None`, show the package's usual installer-neutral advice.
+
 ### Manual pages
 
 If you wish to provide documentation via `man` pages on UNIX-like systems then these can be added as data files:

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -14,6 +14,7 @@ from pipx.colors import bold
 from pipx.commands.common import package_name_from_spec, run_post_install_actions
 from pipx.constants import EXIT_CODE_INJECT_ERROR, EXIT_CODE_OK, ExitCode
 from pipx.emojis import hazard, stars
+from pipx.package_specifier import get_extras
 from pipx.util import PipxError, pipx_wrap
 from pipx.venv import Venv
 
@@ -80,12 +81,13 @@ def inject_dep(
     # ``pipx run`` but breaks anyone reaching for the venv's missing pip.
     assert_not_pip_under_uv(canonicalize_name(package_name), venv.backend_name)
 
-    if not force and venv.has_package(package_name):
-        _LOGGER.info("Package %s has already been injected", package_name)
+    is_main_package = canonicalize_name(package_name) == canonicalize_name(venv.main_package_name)
+    if not force and venv.has_package(package_name) and (not is_main_package or not get_extras(package_spec)):
+        _LOGGER.info("Package %s is already installed", package_name)
         print(
             pipx_wrap(
                 f"""
-                {hazard} {package_name} already seems to be injected in {venv.name!r}.
+                {hazard} {package_name} already seems to be installed in {venv.name!r}.
                 Not modifying existing installation in '{venv_dir}'.
                 Pass '--force' to force installation.
                 """
@@ -93,7 +95,15 @@ def inject_dep(
         )
         return True
 
-    if suffix:
+    pinned = False
+    if is_main_package:
+        main_package = venv.pipx_metadata.main_package
+        pip_args = pip_args or main_package.pip_args
+        include_dependencies = main_package.include_dependencies
+        include_apps = main_package.include_apps
+        venv_suffix = main_package.suffix
+        pinned = main_package.pinned
+    elif suffix:
         venv_suffix = venv.package_metadata[venv.main_package_name].suffix
     else:
         venv_suffix = ""
@@ -104,8 +114,9 @@ def inject_dep(
         install_only_pip_args=["--force-reinstall"] if force else None,
         include_dependencies=include_dependencies,
         include_apps=include_apps,
-        is_main_package=False,
+        is_main_package=is_main_package,
         suffix=venv_suffix,
+        pinned=pinned,
     )
     if include_apps:
         run_post_install_actions(
@@ -118,7 +129,10 @@ def inject_dep(
             force=force,
         )
 
-    print(f"  injected package {bold(package_name)} into venv {bold(venv.name)}")
+    if is_main_package:
+        print(f"  updated package {bold(package_name)} in venv {bold(venv.name)}")
+    else:
+        print(f"  injected package {bold(package_name)} into venv {bold(venv.name)}")
     print(f"done! {stars}", file=sys.stderr)
 
     # Any failure to install will raise PipxError, otherwise success

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -183,6 +183,7 @@ def install(
                     override_shared = canonicalize_name(package_name) == "pip"
                     venv.create_venv(venv_args, pip_args, override_shared)
                     venv.pipx_metadata.exposure_enabled = required_exposure
+                    venv.pipx_metadata.environment = venv.root.name
                     for dependency in preinstall_packages or []:
                         venv.upgrade_package_no_metadata(dependency, [])
                     venv.install_package(

--- a/src/pipx/pipx_metadata_file.py
+++ b/src/pipx/pipx_metadata_file.py
@@ -46,6 +46,7 @@ class _RawPackageInfo(TypedDict, total=False):
 class _RawMetadata(TypedDict, total=False):
     """JSON-on-disk shape for ``pipx_metadata.json``."""
 
+    environment: str | None
     main_package: _RawPackageInfo
     python_version: str | None
     source_interpreter: Path | None
@@ -134,6 +135,7 @@ class PipxMetadata:
             man_paths_of_dependencies={},
             package_version="",
         )
+        self.environment: str | None = None
         self.python_version: str | None = None
         self.source_interpreter: Path | None = None
         self.venv_args: list[str] = []
@@ -151,6 +153,7 @@ class PipxMetadata:
         # Plain dict over _RawMetadata: asdict() returns dict[str, Any] and
         # consumers serialise straight to JSON.
         return {
+            "environment": self.environment,
             "main_package": asdict(self.main_package),
             "python_version": self.python_version,
             "source_interpreter": self.source_interpreter,
@@ -190,6 +193,7 @@ class PipxMetadata:
 
     def from_dict(self, input_dict: _RawMetadata) -> None:
         input_dict = self._convert_legacy_metadata(input_dict)
+        self.environment = input_dict.get("environment")
         self.main_package = PackageInfo(**input_dict["main_package"])
         self.python_version = input_dict.get("python_version")
         source_interpreter_raw = input_dict.get("source_interpreter")

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -348,6 +348,7 @@ class Venv:
         install_only_pip_args: list[str] | None = None,
         expected_apps: Sequence[str] | None = None,
         lock_file: Path | None = None,
+        pinned: bool = False,
     ) -> None:
         # package_name in package specifier can mismatch URL due to user error
         package_or_url = fix_package_name(package_or_url, package_name)
@@ -381,6 +382,7 @@ class Venv:
             suffix=suffix,
             expected_apps=expected_apps,
             lock_file=lock_file,
+            pinned=pinned,
         )
 
         # Verify package installed ok

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -1,12 +1,15 @@
 import logging
 import re
+import shutil
+import subprocess
 import textwrap
 from collections.abc import Callable
 from pathlib import Path
 
 import pytest
+from packaging.utils import canonicalize_name
 
-from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli, skip_if_windows
+from helpers import PIPX_METADATA_LEGACY_VERSIONS, app_name, mock_legacy_venv, run_pipx_cli, skip_if_windows
 from package_info import PKG
 from pipx import paths
 from pipx.pipx_metadata_file import PipxMetadata
@@ -53,6 +56,49 @@ def test_inject_single_package(pipx_temp_env, capsys, caplog, pkg_spec):
     injected = re.findall(r"injected package (.+?) into venv pycowsay", captured.out)
     pkg_name = pkg_spec.split("=", 1)[0].replace(".", "-")  # assuming spec is always of the form <name>==<version>
     assert set(injected) == {pkg_name}
+
+
+@pytest.mark.parametrize(
+    ("backend", "suffix"),
+    [
+        pytest.param("pip", "", id="pip"),
+        pytest.param(
+            "uv",
+            "_x",
+            id="uv",
+            marks=pytest.mark.skipif(shutil.which("uv") is None, reason="uv binary not on PATH"),
+        ),
+    ],
+)
+def test_inject_main_package_extra(
+    pipx_temp_env: None,
+    root: Path,
+    capsys: pytest.CaptureFixture[str],
+    backend: str,
+    suffix: str,
+) -> None:
+    package = root / "testdata/test_package_specifier/local_extras"
+    assert not run_pipx_cli(["install", str(package), "--backend", backend, f"--suffix={suffix}"])
+    venv_dir = paths.ctx.venvs / canonicalize_name(f"repeatme{suffix}")
+    environment = PipxMetadata(venv_dir).environment
+    assert environment is not None
+    assert not run_pipx_cli(["inject", environment, f"{package}[cow]", "--backend", backend])
+    assert not run_pipx_cli(["reinstall", environment])
+
+    output = subprocess.run(
+        [paths.ctx.bin_dir / app_name(f"repeatme{suffix}"), "hello"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    capsys.readouterr()
+    assert not run_pipx_cli(["list", "--include-injected"])
+    list_output = capsys.readouterr().out
+    assert (
+        "In cow, you said:" in output,
+        "injected in venv" in list_output,
+        environment,
+    ) == (True, False, venv_dir.name)
 
 
 @skip_if_windows

--- a/tests/test_pin.py
+++ b/tests/test_pin.py
@@ -1,10 +1,12 @@
 import json
+from pathlib import Path
 
 import pytest
 
 from helpers import run_pipx_cli
 from package_info import PKG
 from pipx import paths
+from pipx.pipx_metadata_file import PipxMetadata
 
 
 def test_pin(pipx_temp_env: None, caplog: pytest.LogCaptureFixture) -> None:
@@ -13,6 +15,16 @@ def test_pin(pipx_temp_env: None, caplog: pytest.LogCaptureFixture) -> None:
     assert not run_pipx_cli(["upgrade", "pycowsay"])
 
     assert "Not upgrading pinned package pycowsay" in caplog.text
+
+
+def test_pin_survives_main_package_extra_injection(pipx_temp_env: None, root: Path) -> None:
+    package = root / "testdata/test_package_specifier/local_extras"
+    assert not run_pipx_cli(["install", str(package)])
+    assert not run_pipx_cli(["pin", "repeatme"])
+
+    assert not run_pipx_cli(["inject", "repeatme", f"{package}[cow]"])
+
+    assert PipxMetadata(paths.ctx.venvs / "repeatme").main_package.pinned
 
 
 def test_pin_json(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_pipx_metadata_file.py
+++ b/tests/test_pipx_metadata_file.py
@@ -57,6 +57,7 @@ def test_pipx_metadata_file_create(tmp_path: Path) -> None:
 
     pipx_metadata = PipxMetadata(venv_dir)
     pipx_metadata.main_package = TEST_PACKAGE1
+    pipx_metadata.environment = "test-package"
     pipx_metadata.python_version = "3.4.5"
     pipx_metadata.source_interpreter = Path(sys.executable)
     pipx_metadata.venv_args = ["--system-site-packages"]
@@ -68,6 +69,7 @@ def test_pipx_metadata_file_create(tmp_path: Path) -> None:
 
     for attribute in [
         "venv_dir",
+        "environment",
         "main_package",
         "python_version",
         "venv_args",
@@ -117,6 +119,19 @@ def test_pipx_metadata_file_defaults_lock_file_from_version_0_8(tmp_path: Path) 
     (venv_dir / PIPX_INFO_FILENAME).write_text(json.dumps(payload, cls=JsonEncoderHandlesPath))
 
     assert PipxMetadata(venv_dir).main_package.lock_file is None
+
+
+def test_pipx_metadata_file_defaults_environment_from_version_0_8(tmp_path: Path) -> None:
+    venv_dir = tmp_path / "venv"
+    venv_dir.mkdir()
+    metadata = PipxMetadata(venv_dir, read=False)
+    metadata.main_package = TEST_PACKAGE1
+    payload = metadata.to_dict()
+    payload["pipx_metadata_version"] = "0.8"
+    payload.pop("environment")
+    (venv_dir / PIPX_INFO_FILENAME).write_text(json.dumps(payload, cls=JsonEncoderHandlesPath))
+
+    assert PipxMetadata(venv_dir).environment is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -10,12 +10,14 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
+from pytest_mock import MockerFixture
 
 import pipx.main
 import pipx.util
 from helpers import run_pipx_cli
 from package_info import PKG
 from pipx import paths, shared_libs
+from pipx.pipx_metadata_file import PipxMetadata
 
 
 def test_help_text(pipx_temp_env, monkeypatch, capsys):
@@ -63,6 +65,15 @@ def test_cache(pipx_temp_env, monkeypatch, capsys, caplog):
 
     run_pipx_cli_exit(["run", "--no-cache", "pycowsay", "cowsay", "args"])
     assert "Removing cached venv" in caplog.text
+
+
+def test_run_does_not_mark_cache_as_installation(pipx_temp_env: None, mocker: MockerFixture) -> None:
+    mocker.patch("os.execvpe", new=execvpe_mock)
+
+    run_pipx_cli_exit(["run", "pycowsay", "cowsay", "args"])
+
+    venv_dir = next(path for path in paths.ctx.venv_cache.iterdir() if path.is_dir())
+    assert PipxMetadata(venv_dir).environment is None
 
 
 @mock.patch("os.execvpe", new=execvpe_mock)


### PR DESCRIPTION
Closes #1805.

Packages installed by pipx need their environment name when package code offers a command that enables an extra. Metadata-file presence cannot distinguish persistent installs because `pipx run` creates internal metadata too.

pipx records the environment name for persistent installs; it leaves the field unset for `pipx run`. Package authors can pass that name to `pipx inject`.

Injecting main-package extras updates the main package record. Reinstall keeps the extras alongside the pin state and install settings.
