### PR TITLE
✨ feat(manifest): sync managed tools

### DIFF
--- a/changelog.d/1506.feature.md
+++ b/changelog.d/1506.feature.md
@@ -1,0 +1,1 @@
+Add explicit tool manifests with separate PEP 751 locks.

--- a/docs/explanation/comparisons.md
+++ b/docs/explanation/comparisons.md
@@ -69,6 +69,8 @@ managers writes the same filename. Each manager refuses to overwrite a binary th
 - `--suffix` keeps two copies of the same tool side-by-side.
 - `--global` and the `PIPX_GLOBAL_*` variables drive a system-wide install.
 - Manual pages get symlinked under `$PIPX_MAN_DIR`.
+- `pipx sync <manifest>` applies an explicit desired set; `pipx lock <manifest>` writes one PEP 751 lock per selected
+    tool.
 - `pipx install-all <spec.json>` rebuilds every venv from a `pipx list --json` snapshot for cross-machine migration.
 - `[project.entry-points."pipx.run"]` declares pipx-specific runtime extras in the package metadata.
 - `pipx environment` prints every variable and its resolved value in one place.

--- a/docs/explanation/scope.md
+++ b/docs/explanation/scope.md
@@ -31,17 +31,18 @@ may package pipx for their users, but each ecosystem owns its build, release, up
 
 ## Configuration and state
 
-Ordinary pipx commands must not search the current directory or its parents for configuration. If pipx gains declarative
-state, the caller must supply a path, for example to a future `pipx apply tools.toml` command. The manifest must contain
-desired application state and reject arbitrary command defaults.
+Ordinary pipx commands do not search the current directory or its parents for configuration. `pipx sync PATH` applies
+the desired application state from the manifest at `PATH`; pipx does not infer that path. The manifest accepts tool
+state instead of arbitrary command defaults.
 
-Resolved dependency state uses the PyPA
-[`pylock.toml` specification](https://packaging.python.org/en/latest/specifications/pylock-toml/). The standard permits
-`pylock.toml` and named files such as `pylock.black.toml` when a manifest needs more than one lock.
-`pipx install --lock` accepts an explicit path. pipx does not use `requirements.txt` as a state or lock format.
+pipx records resolved dependencies with the PyPA
+[`pylock.toml` specification](https://packaging.python.org/en/latest/specifications/pylock-toml/). PEP 751 defines
+`pylock.toml` and named files such as `pylock.black.toml` when a manifest needs more than one lock. `pipx lock PATH`
+uses nab to resolve each locked tool in isolation. `pipx install --lock` accepts one explicit lock path. pipx does not
+use `requirements.txt` as a state or lock format.
 
-Top-level pipx options describe policy that pip and uv can both honor. A control supported by one backend stays in the
-arguments for that backend until both backends can provide the same contract.
+pipx exposes top-level policy when pip and uv honor the same contract. Backend arguments carry controls specific to pip
+or uv.
 
 Application launchers start the installed application without downloading packages or changing its environment. Health
 checks and repairs belong in commands that the user invokes for those purposes.

--- a/docs/man/pipx.1.rst
+++ b/docs/man/pipx.1.rst
@@ -14,10 +14,10 @@ install and run Python applications in isolated environments
 SYNOPSIS
 --------
 
-**pipx** [*global-options*] [**install** | **install-all** | **uninject** | **inject** | **expose** | **unexpose** |
-**pin** | **unpin** | **upgrade** | **upgrade-all** | **upgrade-shared** | **uninstall** | **uninstall-all** |
-**reinstall** | **reinstall-all** | **health** | **repair** | **list** | **interpreter** | **run** | **runpip** |
-**ensurepath** | **environment** | **completions** | **help**] [*command-options*]
+**pipx** [*global-options*] [**install** | **install-all** | **lock** | **sync** | **uninject** | **inject** |
+**expose** | **unexpose** | **pin** | **unpin** | **upgrade** | **upgrade-all** | **upgrade-shared** | **uninstall** |
+**uninstall-all** | **reinstall** | **reinstall-all** | **health** | **repair** | **list** | **interpreter** | **run** |
+**runpip** | **ensurepath** | **environment** | **completions** | **help**] [*command-options*]
 
 DESCRIPTION
 -----------
@@ -33,6 +33,12 @@ COMMANDS
 
 **install-all**
     Install all packages
+
+**lock**
+    Resolve a tool manifest with nab
+
+**sync**
+    Apply a tool manifest
 
 **uninject**
     Uninstall injected packages from an existing Virtual Environment

--- a/docs/tutorial/install-applications.md
+++ b/docs/tutorial/install-applications.md
@@ -93,6 +93,70 @@ rejects `inject` because the added package would fall outside the lock.
 replace an installed environment with a new lock. The pip backend requires pip 26.1 or newer; the uv backend requires uv
 0.6.15 or newer.
 
+### Applying a tool manifest
+
+Use an explicit manifest to manage a set of pipx tools:
+
+```toml
+[project]
+name = "pipx-tools"
+version = "1"
+dependencies = []
+requires-python = ">=3.10"
+
+[dependency-groups]
+black = ["black>=25,<26"]
+httpie = ["httpie"]
+
+[tool.pipx]
+version = "1.0"
+
+[tool.pipx.tools.black]
+apps = ["black"]
+lock = "pylock.black.toml"
+
+[tool.pipx.tools.httpie]
+apps = ["http", "https"]
+```
+
+Each dependency group contains one package requirement and names its pipx environment. Keep `project.dependencies` empty
+so each group resolves independently. Add a matching `tool.pipx.tools` table only when the tool needs policy beyond its
+package requirement.
+
+Use the normalized package name plus its suffix as the environment name:
+
+```toml
+[dependency-groups]
+black-24 = ["black==24.10.0"]
+
+[tool.pipx.tools.black-24]
+suffix = "-24"
+apps = ["black"]
+```
+
+Package requirements use PEP 508 syntax without environment markers. A tool table may set `suffix`, `apps`,
+`include-dependencies`, `expose`, or `lock`. Relative lock paths start from the manifest directory. Put nab settings in
+`tool.nab`.
+
+Install [nab](https://pypi.org/project/nab/), generate the declared locks, and apply the manifest:
+
+```console
+pipx install nab
+pipx lock ./pipx.toml
+pipx sync ./pipx.toml
+```
+
+`pipx lock` passes the manifest to nab once per locked dependency group. Existing locks seed their replacements, and
+pipx replaces the declared files only after every resolution succeeds. Entries without `lock` remain unlocked.
+
+`pipx sync` installs, upgrades, or downgrades each declared tool. The backend resolves unlocked package specs on each
+run; pipx installs locked entries from the artifacts in their named PEP 751 files. pipx restores an existing environment
+and its exposed resources when a tool fails to install or lacks a required app.
+
+Pass `--prune` to uninstall environments absent from the manifest. Without it, sync leaves other pipx environments
+alone. Pass `--global` or `--backend` after `sync` to select the pipx store or installation backend. pipx reads only the
+manifest path supplied on the command line.
+
 ### Keeping an installation within a version range
 
 Use `--upgrade` when you want an installed app to match a package spec:

--- a/src/pipx/commands/__init__.py
+++ b/src/pipx/commands/__init__.py
@@ -6,6 +6,7 @@ from pipx.commands.inject import inject
 from pipx.commands.install import install, install_all
 from pipx.commands.interpreter import list_interpreters, prune_interpreters, upgrade_interpreters
 from pipx.commands.list_packages import list_packages
+from pipx.commands.manifest import lock_manifest, sync_manifest
 from pipx.commands.outdated import OutdatedData, list_outdated
 from pipx.commands.pin import PinData, pin, unpin
 from pipx.commands.reinstall import reinstall, reinstall_all
@@ -32,6 +33,7 @@ __all__ = [
     "list_interpreters",
     "list_outdated",
     "list_packages",
+    "lock_manifest",
     "pin",
     "prune_interpreters",
     "reinstall",
@@ -39,6 +41,7 @@ __all__ = [
     "repair",
     "run",
     "run_pip",
+    "sync_manifest",
     "unexpose",
     "uninject",
     "uninstall",

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -59,6 +59,9 @@ def install(
     upgrade: bool = False,
     upgrade_strategy: str | None = None,
     venv_lock: BaseFileLock | None = None,
+    preserve_existing: bool = False,
+    replace_expected_apps: bool = False,
+    replace_lock: bool = False,
 ) -> ExitCode:
     """Returns pipx exit code."""
     # package_spec is anything pip-installable, including package_name, vcs spec,
@@ -115,8 +118,15 @@ def install(
                 backend=install_backend,
                 env_backend=install_env_backend,
             )
-            required_apps = tuple(dict.fromkeys(expected_apps or venv.pipx_metadata.main_package.expected_apps))
-            required_lock = lock_file or venv.pipx_metadata.main_package.lock_file
+            required_apps = tuple(
+                dict.fromkeys(
+                    expected_apps
+                    if replace_expected_apps
+                    else expected_apps or venv.pipx_metadata.main_package.expected_apps
+                )
+            )
+            recorded_lock = venv.pipx_metadata.main_package.lock_file
+            required_lock = lock_file if replace_lock else lock_file or recorded_lock
             required_exposure = venv.pipx_metadata.exposure_enabled if exposure_enabled is None else exposure_enabled
             if exists:
                 if not reinstall and force and python_flag_passed:
@@ -167,11 +177,11 @@ def install(
 
             with preserve_venv(
                 venv_dir,
-                enabled=exists and (bool(required_apps) or required_lock is not None),
+                enabled=exists and (preserve_existing or bool(required_apps) or required_lock is not None),
             ):
                 venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
                 try:
-                    if exists and required_lock is not None:
+                    if exists and (required_lock is not None or (replace_lock and recorded_lock is not None)):
                         recorded_backend = venv.pipx_metadata.backend
                         rmdir(venv_dir)
                         venv = Venv(
@@ -358,6 +368,8 @@ def install_all(
                     backend=backend or venv_metadata.backend,
                     env_backend=env_backend,
                     exposure_enabled=venv_metadata.exposure_enabled,
+                    replace_expected_apps=True,
+                    replace_lock=True,
                     venv_lock=venv_lock,
                 )
                 for inject_package in venv_metadata.injected_packages.values():

--- a/src/pipx/commands/manifest.py
+++ b/src/pipx/commands/manifest.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import date, datetime, time
+from importlib import import_module
+from pathlib import Path
+from shutil import copy2, which
+from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING, Final, TypeAlias, cast
+
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
+
+from pipx.commands.expose import expose, unexpose
+from pipx.commands.install import install
+from pipx.commands.uninstall import uninstall
+from pipx.constants import EXIT_CODE_OK, ExitCode
+from pipx.pipx_metadata_file import PipxMetadata
+from pipx.result import render_result
+from pipx.util import PipxError
+
+if TYPE_CHECKING:
+    if sys.version_info < (3, 11):
+        import tomli as tomllib
+    else:
+        import tomllib
+
+    from pipx.venv import VenvContainer
+else:
+    tomllib = import_module("tomli" if sys.version_info < (3, 11) else "tomllib")
+
+
+def sync_manifest(
+    manifest_file: Path,
+    venv_container: VenvContainer,
+    local_bin_dir: Path,
+    local_man_dir: Path,
+    python: str,
+    verbose: bool,
+    *,
+    prune: bool,
+    backend: str | None,
+    env_backend: str | None,
+) -> ExitCode:
+    manifest = _load_manifest(manifest_file, require_locks=True)
+    failures: list[str] = []
+    for tool in manifest.tools:
+        venv_dir = venv_container.get_venv_dir(tool.environment)
+        with venv_container.venv_lock(venv_dir) as venv_lock:
+            existed = venv_dir.is_dir()
+            was_exposed = existed and PipxMetadata(venv_dir).exposure_enabled
+            if was_exposed:
+                unexpose(venv_dir, local_bin_dir, local_man_dir, verbose)
+            try:
+                install(
+                    venv_dir,
+                    [tool.package_name],
+                    [tool.package],
+                    local_bin_dir,
+                    local_man_dir,
+                    python,
+                    [],
+                    [],
+                    verbose,
+                    force=existed,
+                    reinstall=False,
+                    include_dependencies=tool.include_dependencies,
+                    preinstall_packages=None,
+                    expected_apps=tool.apps,
+                    lock_file=tool.lock_file,
+                    suffix=tool.suffix,
+                    backend=backend,
+                    env_backend=env_backend,
+                    exposure_enabled=tool.expose,
+                    preserve_existing=True,
+                    replace_expected_apps=True,
+                    replace_lock=True,
+                    venv_lock=venv_lock,
+                )
+            except PipxError as error:
+                print(error, file=sys.stderr)
+                failures.append(tool.environment)
+                if was_exposed:
+                    expose(venv_dir, local_bin_dir, local_man_dir, verbose)
+
+    if failures:
+        raise PipxError(f"The following manifest tools failed to sync: {', '.join(failures)}")
+    if prune:
+        _prune_environments(manifest, venv_container, local_bin_dir, local_man_dir, verbose)
+    return EXIT_CODE_OK
+
+
+def lock_manifest(manifest_file: Path) -> ExitCode:
+    manifest = _load_manifest(manifest_file, require_locks=False)
+    if not any(tool.lock_file is not None for tool in manifest.tools):
+        raise PipxError("The manifest does not declare any lock files.")
+    if not (nab := which("nab")):
+        raise PipxError("The nab command is required. Install it with `pipx install nab`.")
+    try:
+        _generate_locks(manifest, nab)
+    except OSError as error:
+        raise PipxError(f"Cannot write manifest locks: {error}") from error
+    return EXIT_CODE_OK
+
+
+def _load_manifest(manifest_file: Path, *, require_locks: bool) -> _Manifest:
+    path = manifest_file.expanduser().resolve()
+    try:
+        with path.open("rb") as file:
+            data = cast("dict[str, _TomlValue]", tomllib.load(file))
+    except FileNotFoundError as error:
+        raise PipxError(f"Manifest does not exist: {path}") from error
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise PipxError(f"Cannot read manifest {path}: {error}") from error
+
+    groups, tool_data = _parse_manifest_tables(data)
+
+    tools: list[_ManifestTool] = []
+    for environment, group in groups.items():
+        if not isinstance(group, list) or len(group) != 1 or not isinstance(package := group[0], str):
+            raise PipxError(f"Dependency group {environment} must contain one package requirement.")
+        if not isinstance(values := tool_data.get(environment, {}), dict):
+            raise PipxError(f"Manifest tool {environment} must be a table.")
+        tools.append(_parse_tool(environment, package, values, path.parent, require_locks=require_locks))
+    if duplicates := _duplicate_lock_files(tools):
+        raise PipxError(f"Lock files must be unique per tool: {', '.join(map(str, duplicates))}")
+    return _Manifest(path=path, tools=tuple(tools))
+
+
+def _parse_manifest_tables(
+    data: dict[str, _TomlValue],
+) -> tuple[dict[str, _TomlValue], dict[str, _TomlValue]]:
+    if unknown := sorted(set(data) - _ROOT_KEYS):
+        raise PipxError(f"Unknown manifest {'table' if len(unknown) == 1 else 'tables'}: {', '.join(unknown)}")
+    if not isinstance(project := data.get("project"), dict):
+        raise PipxError("Manifest project must be a table.")
+    _validate_project(project)
+    if not isinstance(groups := data.get("dependency-groups"), dict) or not groups:
+        raise PipxError("Manifest dependency-groups must be a non-empty table.")
+    if not isinstance(tool_table := data.get("tool"), dict):
+        raise PipxError("Manifest tool must be a table.")
+    if unknown := sorted(set(tool_table) - _TOOL_TABLE_KEYS):
+        raise PipxError(f"Unknown manifest tool {'table' if len(unknown) == 1 else 'tables'}: {', '.join(unknown)}")
+    if (nab_data := tool_table.get("nab")) is not None and not isinstance(nab_data, dict):
+        raise PipxError("Manifest tool.nab must be a table.")
+    return groups, _parse_pipx_table(tool_table, groups)
+
+
+def _validate_project(data: dict[str, _TomlValue]) -> None:
+    if unknown := sorted(set(data) - _PROJECT_KEYS):
+        raise PipxError(f"Unknown manifest project {'key' if len(unknown) == 1 else 'keys'}: {', '.join(unknown)}")
+    if not isinstance(data.get("name"), str) or not isinstance(data.get("version"), str):
+        raise PipxError("Manifest project requires string name and version values.")
+    if data.get("dependencies") != []:
+        raise PipxError("Manifest project dependencies must be empty; declare tools in dependency-groups.")
+    if (requires_python := data.get("requires-python")) is not None and not isinstance(requires_python, str):
+        raise PipxError("Manifest project requires-python must be a string.")
+
+
+def _parse_pipx_table(
+    tool_table: dict[str, _TomlValue],
+    groups: dict[str, _TomlValue],
+) -> dict[str, _TomlValue]:
+    if not isinstance(pipx_data := tool_table.get("pipx"), dict):
+        raise PipxError("Manifest tool.pipx must be a table.")
+    if unknown := sorted(set(pipx_data) - _PIPX_KEYS):
+        raise PipxError(f"Unknown tool.pipx {'key' if len(unknown) == 1 else 'keys'}: {', '.join(unknown)}")
+    if pipx_data.get("version") != _MANIFEST_VERSION:
+        raise PipxError(f'Manifest version must be "{_MANIFEST_VERSION}".')
+    if not isinstance(tool_data := pipx_data.get("tools", {}), dict):
+        raise PipxError("Manifest tool.pipx.tools must be a table.")
+    if unknown := sorted(set(tool_data) - set(groups)):
+        raise PipxError(f"Missing dependency groups for manifest tools: {', '.join(unknown)}")
+    return tool_data
+
+
+def _parse_tool(
+    environment: str,
+    package: str,
+    data: dict[str, _TomlValue],
+    manifest_dir: Path,
+    *,
+    require_locks: bool,
+) -> _ManifestTool:
+    if environment != canonicalize_name(environment):
+        raise PipxError(f"Manifest tool name must be normalized: {environment}")
+    if unknown := sorted(set(data) - _TOOL_KEYS):
+        raise PipxError(
+            f"Unknown {'key' if len(unknown) == 1 else 'keys'} for manifest tool {environment}: {', '.join(unknown)}"
+        )
+    package_name = _parse_package(environment, package)
+    if not isinstance(suffix := data.get("suffix", ""), str):
+        raise PipxError(f"Manifest tool {environment} suffix must be a string.")
+    if environment != canonicalize_name(f"{package_name}{suffix}"):
+        raise PipxError(f"Manifest tool {environment} must match package {package_name} and suffix {suffix!r}.")
+    if not isinstance(include_dependencies := data.get("include-dependencies", False), bool):
+        raise PipxError(f"Manifest tool {environment} include-dependencies must be a boolean.")
+    if not isinstance(expose_resources := data.get("expose", True), bool):
+        raise PipxError(f"Manifest tool {environment} expose must be a boolean.")
+
+    return _ManifestTool(
+        environment=environment,
+        package=package,
+        package_name=package_name,
+        suffix=suffix,
+        apps=_parse_apps(environment, data),
+        include_dependencies=include_dependencies,
+        expose=expose_resources,
+        lock_file=_parse_lock_file(environment, data, manifest_dir, require_locks=require_locks),
+    )
+
+
+def _parse_package(environment: str, package: str) -> str:
+    try:
+        requirement = Requirement(package)
+    except InvalidRequirement as error:
+        raise PipxError(f"Manifest tool {environment} has an invalid package requirement: {package}") from error
+    if requirement.marker is not None:
+        raise PipxError(f"Manifest tool {environment} cannot use an environment marker.")
+    return canonicalize_name(requirement.name)
+
+
+def _parse_apps(environment: str, data: dict[str, _TomlValue]) -> tuple[str, ...]:
+    if not isinstance(apps := data.get("apps", []), list) or any(not isinstance(app, str) or not app for app in apps):
+        raise PipxError(f"Manifest tool {environment} apps must be non-empty strings.")
+    if len(apps) != len(set(apps)):
+        raise PipxError(f"Manifest tool {environment} apps must be unique.")
+    return tuple(cast("list[str]", apps))
+
+
+def _parse_lock_file(
+    environment: str,
+    data: dict[str, _TomlValue],
+    manifest_dir: Path,
+    *,
+    require_locks: bool,
+) -> Path | None:
+    if (lock_value := data.get("lock")) is None:
+        return None
+    if not isinstance(lock_value, str):
+        raise PipxError(f"Manifest tool {environment} lock must be a path string.")
+    lock_file = Path(lock_value).expanduser()
+    if not lock_file.is_absolute():
+        lock_file = manifest_dir / lock_file
+    lock_file = lock_file.resolve()
+    if not _is_pylock_name(lock_file.name):
+        raise PipxError(f"Manifest tool {environment} lock must be named pylock.toml or pylock.<name>.toml.")
+    if require_locks and not lock_file.is_file():
+        raise PipxError(f"Lock file does not exist for manifest tool {environment}: {lock_file}")
+    return lock_file
+
+
+def _duplicate_lock_files(tools: list[_ManifestTool]) -> tuple[Path, ...]:
+    counts = Counter(tool.lock_file for tool in tools if tool.lock_file is not None)
+    return tuple(sorted(lock_file for lock_file, count in counts.items() if count > 1))
+
+
+def _is_pylock_name(name: str) -> bool:
+    if name == "pylock.toml":
+        return True
+    return (
+        name.startswith("pylock.")
+        and name.endswith(".toml")
+        and bool(lock_name := name.removeprefix("pylock.").removesuffix(".toml"))
+        and "." not in lock_name
+    )
+
+
+def _generate_locks(manifest: _Manifest, nab: str) -> None:
+    with TemporaryDirectory(prefix=".pipx-lock-", dir=manifest.path.parent) as temporary_dir:
+        generated: list[tuple[Path, Path]] = []
+        for tool in manifest.tools:
+            if tool.lock_file is None:
+                continue
+            tool_dir = Path(temporary_dir) / tool.environment
+            tool_dir.mkdir()
+            generated_lock = tool_dir / tool.lock_file.name
+            if tool.lock_file.is_file():
+                copy2(tool.lock_file, generated_lock)
+            if subprocess.run(
+                [
+                    nab,
+                    "lock",
+                    str(manifest.path),
+                    "--groups",
+                    tool.environment,
+                    "--output",
+                    str(generated_lock),
+                ],
+                check=False,
+                cwd=manifest.path.parent,
+            ).returncode:
+                raise PipxError(f"nab failed to lock {tool.environment}.")
+            if not generated_lock.is_file():
+                raise PipxError(f"nab did not create {generated_lock.name} for {tool.environment}.")
+            generated.append((generated_lock, tool.lock_file))
+
+        for generated_lock, lock_file in generated:
+            lock_file.parent.mkdir(parents=True, exist_ok=True)
+            generated_lock.replace(lock_file)
+            print(f"locked {lock_file}")
+
+
+def _prune_environments(
+    manifest: _Manifest,
+    venv_container: VenvContainer,
+    local_bin_dir: Path,
+    local_man_dir: Path,
+    verbose: bool,
+) -> None:
+    declared = {tool.environment for tool in manifest.tools}
+    for venv_dir in sorted(venv_container.iter_venv_dirs()):
+        if venv_dir.name in declared:
+            continue
+        with venv_container.venv_lock(venv_dir):
+            render_result(
+                uninstall(venv_dir, local_bin_dir, local_man_dir, verbose),
+                json_output=False,
+                quiet=0,
+            )
+
+
+@dataclass(frozen=True)
+class _Manifest:
+    path: Path
+    tools: tuple[_ManifestTool, ...]
+
+
+@dataclass(frozen=True)
+class _ManifestTool:
+    environment: str
+    package: str
+    package_name: str
+    suffix: str
+    apps: tuple[str, ...]
+    include_dependencies: bool
+    expose: bool
+    lock_file: Path | None
+
+
+_TomlValue: TypeAlias = str | int | float | bool | datetime | date | time | list["_TomlValue"] | dict[str, "_TomlValue"]
+
+
+_MANIFEST_VERSION: Final[str] = "1.0"
+_ROOT_KEYS: Final[frozenset[str]] = frozenset({"project", "dependency-groups", "tool"})
+_PROJECT_KEYS: Final[frozenset[str]] = frozenset({"name", "version", "dependencies", "requires-python"})
+_TOOL_TABLE_KEYS: Final[frozenset[str]] = frozenset({"pipx", "nab"})
+_PIPX_KEYS: Final[frozenset[str]] = frozenset({"version", "tools"})
+_TOOL_KEYS: Final[frozenset[str]] = frozenset({"suffix", "apps", "include-dependencies", "expose", "lock"})
+
+
+__all__ = [
+    "lock_manifest",
+    "sync_manifest",
+]

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -555,6 +555,48 @@ def _cmd_install_all(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode
     )
 
 
+def _add_lock(subparsers: argparse._SubParsersAction, shared_parser: argparse.ArgumentParser) -> None:
+    parser = subparsers.add_parser(
+        "lock",
+        help="Resolve a tool manifest with nab",
+        description="Resolve each locked tool in an explicit manifest into a separate PEP 751 lock file.",
+        parents=[shared_parser],
+    )
+    parser.add_argument("manifest", type=Path, help="Path to the tool manifest.")
+    parser.set_defaults(func=_cmd_lock)
+
+
+def _cmd_lock(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
+    return commands.lock_manifest(args.manifest)
+
+
+def _add_sync(subparsers: argparse._SubParsersAction, shared_parser: argparse.ArgumentParser) -> None:
+    parser = subparsers.add_parser(
+        "sync",
+        help="Apply a tool manifest",
+        description="Install, upgrade, or downgrade the tools declared in an explicit manifest.",
+        parents=[shared_parser],
+    )
+    parser.add_argument("manifest", type=Path, help="Path to the tool manifest.")
+    parser.add_argument("--prune", action="store_true", help="Uninstall environments absent from the manifest.")
+    add_backend_arg(parser)
+    parser.set_defaults(func=_cmd_sync)
+
+
+def _cmd_sync(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
+    return commands.sync_manifest(
+        args.manifest,
+        ctx.venv_container,
+        paths.ctx.bin_dir,
+        paths.ctx.man_dir,
+        ctx.python,
+        ctx.verbose,
+        prune=args.prune,
+        backend=ctx.backend,
+        env_backend=ctx.env_backend,
+    )
+
+
 def _add_inject(subparsers, venv_completer: VenvCompleter, shared_parser: argparse.ArgumentParser) -> None:
     p = subparsers.add_parser(
         "inject",
@@ -1386,6 +1428,8 @@ def get_command_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Ar
     subparsers_with_subcommands = {}
     _add_install(subparsers, shared_parser)
     _add_install_all(subparsers, shared_parser)
+    _add_lock(subparsers, shared_parser)
+    _add_sync(subparsers, shared_parser)
     _add_uninject(subparsers, completer_venvs.use, shared_parser)
     _add_inject(subparsers, completer_venvs.use, shared_parser)
     _add_expose(subparsers, completer_venvs.use, shared_parser)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,452 @@
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+from typing import Literal
+
+import pytest
+from pytest_mock import MockerFixture
+
+from helpers import app_name, run_pipx_cli
+from pipx import paths
+from pipx.commands import manifest as manifest_module
+from pipx.pipx_metadata_file import PipxMetadata
+
+
+@pytest.fixture
+def write_manifest(tmp_path: Path) -> Callable[[str], Path]:
+    def write(content: str) -> Path:
+        (manifest := tmp_path / "pipx.toml").write_text(content, encoding="utf-8")
+        return manifest
+
+    return write
+
+
+def _manifest(package: str = "black", environment: str = "black", tool: str = "") -> str:
+    tool_table = f"\n[tool.pipx.tools.{environment}]\n{tool}" if tool else ""
+    return f"""[project]
+name = "pipx-tools"
+version = "1"
+dependencies = []
+requires-python = ">=3.10"
+
+[dependency-groups]
+{environment} = [{package!r}]
+
+[tool.pipx]
+version = "1.0"
+{tool_table}
+"""
+
+
+def test_sync_manifest_installs_declared_tool(
+    pipx_temp_env: None,
+    write_manifest: Callable[[str], Path],
+) -> None:
+    manifest = write_manifest(
+        _manifest(
+            "pycowsay==0.0.0.2",
+            "pycowsay-managed",
+            'suffix = "-managed"\napps = ["pycowsay"]\ninclude-dependencies = false\nexpose = true\n',
+        )
+    )
+
+    assert not run_pipx_cli(["sync", str(manifest)])
+
+    metadata = PipxMetadata(paths.ctx.venvs / "pycowsay-managed")
+    assert (
+        metadata.main_package.package_or_url,
+        metadata.main_package.suffix,
+        metadata.main_package.expected_apps,
+        (paths.ctx.bin_dir / app_name("pycowsay-managed")).is_file(),
+    ) == ("pycowsay==0.0.0.2", "-managed", ["pycowsay"], True)
+
+
+def test_sync_manifest_prunes_undeclared_tool(
+    pipx_temp_env: None,
+    write_manifest: Callable[[str], Path],
+) -> None:
+    assert not run_pipx_cli(["install", "black"])
+    manifest = write_manifest(_manifest("pycowsay", "pycowsay"))
+
+    assert not run_pipx_cli(["sync", "--prune", str(manifest)])
+
+    assert not (paths.ctx.venvs / "black").exists()
+
+
+def test_sync_manifest_hides_resources(
+    pipx_temp_env: None,
+    write_manifest: Callable[[str], Path],
+) -> None:
+    manifest = write_manifest(_manifest("pycowsay", "pycowsay", "expose = false\n"))
+
+    assert not run_pipx_cli(["sync", str(manifest)])
+
+    assert (
+        PipxMetadata(paths.ctx.venvs / "pycowsay").exposure_enabled,
+        (paths.ctx.bin_dir / app_name("pycowsay")).exists(),
+    ) == (False, False)
+
+
+def test_sync_manifest_restores_environment_after_missing_app(
+    pipx_temp_env: None,
+    write_manifest: Callable[[str], Path],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    manifest = write_manifest(_manifest("pycowsay", "pycowsay", 'apps = ["pycowsay"]\n'))
+    assert not run_pipx_cli(["sync", str(manifest)])
+    (marker := paths.ctx.venvs / "pycowsay" / "marker").touch()
+    write_manifest(_manifest("pycowsay", "pycowsay", 'apps = ["missing"]\n'))
+    capsys.readouterr()
+
+    assert run_pipx_cli(["sync", str(manifest)])
+
+    metadata = PipxMetadata(paths.ctx.venvs / "pycowsay")
+    assert (
+        "Package pycowsay does not provide expected app missing" in capsys.readouterr().err,
+        marker.exists(),
+        metadata.main_package.expected_apps,
+        metadata.exposure_enabled,
+        (paths.ctx.bin_dir / app_name("pycowsay")).is_file(),
+    ) == (True, True, ["pycowsay"], True, True)
+
+
+def test_sync_manifest_reapplies_lock(
+    pipx_temp_env: None,
+    write_manifest: Callable[[str], Path],
+    make_pylock: Callable[[str, str], Path],
+) -> None:
+    lock_file = make_pylock("pycowsay", "0.0.0.2")
+    manifest = write_manifest(_manifest("pycowsay>=0", "pycowsay", f'apps = ["pycowsay"]\nlock = "{lock_file.name}"\n'))
+    assert not run_pipx_cli(["sync", str(manifest)])
+    (marker := paths.ctx.venvs / "pycowsay" / "marker").touch()
+
+    assert not run_pipx_cli(["sync", str(manifest)])
+
+    metadata = PipxMetadata(paths.ctx.venvs / "pycowsay").main_package
+    assert (metadata.package_version, metadata.lock_file, marker.exists()) == (
+        "0.0.0.2",
+        lock_file.resolve(),
+        False,
+    )
+
+
+def test_sync_manifest_clears_app_and_lock_state(
+    pipx_temp_env: None,
+    write_manifest: Callable[[str], Path],
+    make_pylock: Callable[[str, str], Path],
+) -> None:
+    lock_file = make_pylock("pycowsay", "0.0.0.2")
+    manifest = write_manifest(_manifest("pycowsay", "pycowsay", f'apps = ["pycowsay"]\nlock = "{lock_file.name}"\n'))
+    assert not run_pipx_cli(["sync", str(manifest)])
+    (marker := paths.ctx.venvs / "pycowsay" / "marker").touch()
+    write_manifest(_manifest("pycowsay", "pycowsay"))
+
+    assert not run_pipx_cli(["sync", str(manifest)])
+
+    metadata = PipxMetadata(paths.ctx.venvs / "pycowsay").main_package
+    assert (metadata.expected_apps, metadata.lock_file, marker.exists()) == ([], None, False)
+
+
+@pytest.mark.parametrize(
+    ("content", "expected_error"),
+    [
+        pytest.param("invalid", "Cannot read manifest", id="toml"),
+        pytest.param(_manifest() + "\n[extra]\n", "Unknown manifest table", id="root"),
+        pytest.param("project = []\n", "Manifest project must be a table", id="project-type"),
+        pytest.param(
+            _manifest().replace("dependencies = []", "dependencies = []\nextra = true"),
+            "Unknown manifest project key",
+            id="project-key",
+        ),
+        pytest.param(
+            _manifest().replace('name = "pipx-tools"', "name = 1"),
+            "requires string name and version",
+            id="project-name",
+        ),
+        pytest.param(
+            _manifest().replace("dependencies = []", 'dependencies = ["black"]'),
+            "project dependencies must be empty",
+            id="project-dependencies",
+        ),
+        pytest.param(
+            _manifest().replace('requires-python = ">=3.10"', "requires-python = true"),
+            "requires-python must be a string",
+            id="requires-python",
+        ),
+        pytest.param(
+            _manifest().replace("black = ['black']", ""),
+            "dependency-groups must be a non-empty table",
+            id="groups-empty",
+        ),
+        pytest.param(
+            _manifest().replace("black = ['black']", 'black = "black"'),
+            "must contain one package requirement",
+            id="group-type",
+        ),
+        pytest.param(
+            _manifest().replace("black = ['black']", "black = ['black', 'ruff']"),
+            "must contain one package requirement",
+            id="group-size",
+        ),
+        pytest.param(
+            _manifest().replace("black = ['black']", "black = [1]"),
+            "must contain one package requirement",
+            id="group-package",
+        ),
+        pytest.param(
+            _manifest().replace('[tool.pipx]\nversion = "1.0"', "tool = []"),
+            "Manifest tool must be a table",
+            id="tool-type",
+        ),
+        pytest.param(_manifest() + "\n[tool.other]\n", "Unknown manifest tool table", id="tool-table"),
+        pytest.param(_manifest() + "\n[tool]\nnab = true\n", "tool.nab must be a table", id="nab"),
+        pytest.param(
+            _manifest().replace('[tool.pipx]\nversion = "1.0"', "[tool.nab]"),
+            "tool.pipx must be a table",
+            id="pipx-missing",
+        ),
+        pytest.param(
+            _manifest().replace('[tool.pipx]\nversion = "1.0"', "[tool]\npipx = true"),
+            "tool.pipx must be a table",
+            id="pipx-type",
+        ),
+        pytest.param(_manifest() + "unknown = true\n", "Unknown tool.pipx key", id="pipx-key"),
+        pytest.param(_manifest().replace('version = "1.0"', 'version = "2.0"'), "Manifest version", id="version"),
+        pytest.param(_manifest() + "tools = []\n", "tool.pipx.tools must be a table", id="tools-type"),
+        pytest.param(
+            _manifest() + "\n[tool.pipx.tools.ruff]\n",
+            "Missing dependency groups for manifest tools",
+            id="tool-group",
+        ),
+        pytest.param(
+            _manifest() + '\n[tool.pipx.tools]\nblack = "black"\n',
+            "Manifest tool black must be a table",
+            id="tool-value",
+        ),
+        pytest.param(_manifest("black", "Black"), "must be normalized", id="name"),
+        pytest.param(
+            _manifest("black", "black", "unknown = true\n"),
+            "Unknown key for manifest tool black",
+            id="tool-key",
+        ),
+        pytest.param(_manifest("["), "invalid package requirement", id="package"),
+        pytest.param(
+            _manifest('black; python_version > "3.10"'),
+            "cannot use an environment marker",
+            id="marker",
+        ),
+        pytest.param(
+            _manifest("black", "black-other", 'suffix = "-one"\n'),
+            "must match package black",
+            id="environment",
+        ),
+        pytest.param(_manifest("black", "black", "suffix = true\n"), "suffix must be a string", id="suffix"),
+        pytest.param(
+            _manifest("black", "black", 'apps = "black"\n'),
+            "apps must be non-empty strings",
+            id="apps-type",
+        ),
+        pytest.param(
+            _manifest("black", "black", 'apps = [""]\n'),
+            "apps must be non-empty strings",
+            id="app-empty",
+        ),
+        pytest.param(
+            _manifest("black", "black", 'apps = ["black", "black"]\n'),
+            "apps must be unique",
+            id="apps-duplicate",
+        ),
+        pytest.param(
+            _manifest("black", "black", 'include-dependencies = "yes"\n'),
+            "include-dependencies must be a boolean",
+            id="include-dependencies",
+        ),
+        pytest.param(
+            _manifest("black", "black", 'expose = "yes"\n'),
+            "expose must be a boolean",
+            id="expose",
+        ),
+        pytest.param(_manifest("black", "black", "lock = 1\n"), "lock must be a path string", id="lock-type"),
+        pytest.param(
+            _manifest("black", "black", 'lock = "black.lock"\n'),
+            "lock must be named",
+            id="lock-name",
+        ),
+        pytest.param(
+            _manifest("black", "black", 'lock = "pylock.black.toml"\n'),
+            "Lock file does not exist",
+            id="lock-missing",
+        ),
+    ],
+)
+def test_sync_manifest_rejects_invalid_input(
+    pipx_temp_env: None,
+    write_manifest: Callable[[str], Path],
+    capsys: pytest.CaptureFixture[str],
+    content: str,
+    expected_error: str,
+) -> None:
+    assert run_pipx_cli(["sync", str(write_manifest(content))])
+    assert expected_error in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("path_kind", [pytest.param("missing", id="missing"), pytest.param("directory", id="directory")])
+def test_sync_manifest_rejects_unreadable_path(
+    pipx_temp_env: None,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    path_kind: Literal["missing", "directory"],
+) -> None:
+    manifest = tmp_path / "missing.toml"
+    if path_kind == "directory":
+        manifest.mkdir()
+
+    assert run_pipx_cli(["sync", str(manifest)])
+
+    assert ("does not exist" if path_kind == "missing" else "Cannot read manifest") in capsys.readouterr().err
+
+
+def test_sync_manifest_rejects_duplicate_locks(
+    pipx_temp_env: None,
+    write_manifest: Callable[[str], Path],
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    (tmp_path / "pylock.tools.toml").touch()
+    manifest = write_manifest(
+        """[project]
+name = "pipx-tools"
+version = "1"
+dependencies = []
+
+[dependency-groups]
+black = ["black"]
+pycowsay = ["pycowsay"]
+
+[tool.pipx]
+version = "1.0"
+
+[tool.pipx.tools.black]
+lock = "pylock.tools.toml"
+
+[tool.pipx.tools.pycowsay]
+lock = "pylock.tools.toml"
+"""
+    )
+
+    assert run_pipx_cli(["sync", str(manifest)])
+    assert "Lock files must be unique per tool" in capsys.readouterr().err
+
+
+def test_lock_manifest_generates_named_locks(
+    pipx_temp_env: None,
+    write_manifest: Callable[[str], Path],
+    tmp_path: Path,
+    mocker: MockerFixture,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    manifest = write_manifest(
+        """[project]
+name = "pipx-tools"
+version = "1"
+dependencies = []
+
+[dependency-groups]
+black = ["black>=22,<23"]
+pycowsay = ["pycowsay"]
+
+[tool.pipx]
+version = "1.0"
+
+[tool.pipx.tools.black]
+lock = "locks/pylock.toml"
+
+[tool.nab]
+offline = false
+"""
+    )
+    (lock_file := tmp_path / "locks" / "pylock.toml").parent.mkdir()
+    lock_file.write_text("old\n", encoding="utf-8")
+    observed: list[tuple[str, str, str]] = []
+
+    def run_nab(command: list[str], *, check: bool, cwd: Path) -> subprocess.CompletedProcess[str]:
+        generated_lock = Path(command[6])
+        observed.append((Path(command[2]).read_text(encoding="utf-8"), command[4], generated_lock.read_text()))
+        generated_lock.write_text('lock-version = "1.0"\ncreated-by = "nab"\n', encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0)
+
+    mocker.patch.object(manifest_module, "which", autospec=True, return_value="/usr/bin/nab")
+    run = mocker.patch.object(manifest_module.subprocess, "run", autospec=True, side_effect=run_nab)
+
+    assert not run_pipx_cli(["lock", str(manifest)])
+
+    assert (
+        run.call_count,
+        observed,
+        lock_file.read_text(encoding="utf-8"),
+        "locked" in capsys.readouterr().out,
+    ) == (
+        1,
+        [(manifest.read_text(encoding="utf-8"), "black", "old\n")],
+        'lock-version = "1.0"\ncreated-by = "nab"\n',
+        True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_error"),
+    [
+        pytest.param("failure", "nab failed to lock black", id="failure"),
+        pytest.param("missing", "nab did not create pylock.toml", id="missing-output"),
+        pytest.param("os-error", "Cannot write manifest locks: unavailable", id="os-error"),
+    ],
+)
+def test_lock_manifest_preserves_existing_lock_after_failure(
+    pipx_temp_env: None,
+    write_manifest: Callable[[str], Path],
+    tmp_path: Path,
+    mocker: MockerFixture,
+    capsys: pytest.CaptureFixture[str],
+    mode: Literal["failure", "missing", "os-error"],
+    expected_error: str,
+) -> None:
+    manifest = write_manifest(_manifest("black", "black", 'lock = "pylock.toml"\n'))
+    (lock_file := tmp_path / "pylock.toml").write_text("old\n", encoding="utf-8")
+
+    def run_nab(command: list[str], *, check: bool, cwd: Path) -> subprocess.CompletedProcess[str]:
+        if mode == "failure":
+            return subprocess.CompletedProcess(command, 1)
+        if mode == "os-error":
+            raise OSError("unavailable")
+        Path(command[6]).unlink()
+        return subprocess.CompletedProcess(command, 0)
+
+    mocker.patch.object(manifest_module, "which", autospec=True, return_value="/usr/bin/nab")
+    mocker.patch.object(manifest_module.subprocess, "run", autospec=True, side_effect=run_nab)
+
+    assert run_pipx_cli(["lock", str(manifest)])
+
+    assert (expected_error in capsys.readouterr().err, lock_file.read_text(encoding="utf-8")) == (True, "old\n")
+
+
+@pytest.mark.parametrize(
+    ("nab", "lock", "expected_error"),
+    [
+        pytest.param(None, 'lock = "pylock.toml"\n', "nab command is required", id="nab"),
+        pytest.param("/usr/bin/nab", "", "does not declare any lock files", id="lock"),
+    ],
+)
+def test_lock_manifest_requires_nab_and_lock(
+    pipx_temp_env: None,
+    write_manifest: Callable[[str], Path],
+    mocker: MockerFixture,
+    capsys: pytest.CaptureFixture[str],
+    nab: str | None,
+    lock: str,
+    expected_error: str,
+) -> None:
+    manifest = write_manifest(_manifest("black", "black", lock))
+    mocker.patch.object(manifest_module, "which", autospec=True, return_value=nab)
+
+    assert run_pipx_cli(["lock", str(manifest)])
+    assert expected_error in capsys.readouterr().err


### PR DESCRIPTION
Adds an explicit `pipx sync MANIFEST` workflow for managed tools. The manifest is a PEP 621 project with one PEP 735 dependency group per environment, optional pipx policy, no directory discovery, and opt-in pruning.

Adds `pipx lock MANIFEST`, which invokes nab once per locked group and writes named PEP 751 locks only after every resolution succeeds. Sync applies locked or unlocked state under per-environment locks and restores the existing environment and exposed resources on failure.

Closes #1506
