### PR TITLE
✨ feat(policy): add dependency cooldowns

### DIFF
--- a/changelog.d/1811.feature.md
+++ b/changelog.d/1811.feature.md
@@ -1,0 +1,1 @@
+Add dependency cooldowns.

--- a/docs/explanation/comparisons.md
+++ b/docs/explanation/comparisons.md
@@ -74,6 +74,7 @@ managers writes the same filename. Each manager refuses to overwrite a binary th
 - `pipx install-all <spec.json>` rebuilds every venv from a `pipx list --json` snapshot for cross-machine migration.
 - `[project.entry-points."pipx.run"]` declares pipx-specific runtime extras in the package metadata.
 - `pipx environment` prints every variable and its resolved value in one place.
+- `--cooldown DAYS` provides the same release-age policy through pip and uv.
 
 ### Only in uv tool
 
@@ -83,8 +84,7 @@ managers writes the same filename. Each manager refuses to overwrite a binary th
 - `uv tool upgrade --all -p 3.13` re-pins every tool to a different Python in one shot.
 - `uv python install/list/find/pin/upgrade/uninstall` integrates managed Python; uv auto-fetches when the requested
     Python isn't installed.
-- `--exclude-newer`, `--torch-backend`, and `--isolated` add reproducibility knobs that pipx forwards but doesn't add on
-    its own.
+- `--torch-backend` and `--isolated` add controls that pipx does not expose.
 - The content-addressed cache spans `uv pip`, `uv tool`, `uv run`, and `uv venv`. Wheels downloaded once get reused
     everywhere.
 

--- a/docs/explanation/scope.md
+++ b/docs/explanation/scope.md
@@ -42,7 +42,7 @@ uses nab to resolve each locked tool in isolation. `pipx install --lock` accepts
 use `requirements.txt` as a state or lock format.
 
 pipx exposes top-level policy when pip and uv honor the same contract. Backend arguments carry controls specific to pip
-or uv.
+or uv. `--cooldown DAYS` maps one pipx release-age policy to both backends.
 
 Application launchers start the installed application without downloading packages or changing its environment. Health
 checks and repairs belong in commands that the user invokes for those purposes.

--- a/docs/how-to/use-uv-backend.md
+++ b/docs/how-to/use-uv-backend.md
@@ -49,6 +49,7 @@ pipx environment --value PIPX_RESOLVED_BACKEND  # see what pipx will use right n
     silently dropping them.
 - `pipx run` execs `uv tool run`; the cache lives in uv's cache directory. Pass `--no-cache` to skip it.
 - `pipx run script.py` execs `uv run --script script.py` for PEP 723 inline scripts.
+- `--cooldown DAYS` maps to uv's `--exclude-newer P{DAYS}D`. Relative cooldowns require uv 0.9.17 or newer.
 
 ## Limitations
 

--- a/docs/tutorial/install-applications.md
+++ b/docs/tutorial/install-applications.md
@@ -103,7 +103,27 @@ rejects `inject` because the added package would fall outside the lock.
 
 `--lock` accepts one package spec. Do not combine it with `--preinstall` or `--upgrade`. Pass `--force --lock` to
 replace an installed environment with a new lock. The pip backend requires pip 26.1 or newer; the uv backend requires uv
-0.6.15 or newer.
+0.9.17 or newer.
+
+### Delaying new releases
+
+Use a cooldown when you want time to review a release before installing it:
+
+```
+pipx install --cooldown 7 PACKAGE
+```
+
+`--cooldown DAYS` excludes remote-index artifacts uploaded within that many days. pipx stores the value for each
+installed or injected package; upgrades and rebuilds reuse it. A command-line value overrides the stored value. Pass
+`--cooldown 0` to clear the restriction. An `install-all` override does not alter a locked environment.
+
+`pipx run --cooldown DAYS` applies the same policy to temporary environments and keeps caches for different cooldowns
+separate. The pip backend uses `--uploaded-prior-to`; the uv backend uses `--exclude-newer`. Relative cooldowns require
+pip 26.1 or uv 0.9.17. The package index must publish artifact upload times. The cooldown does not apply to local paths,
+VCS URLs, or `--find-links` artifacts.
+
+A cooldown delays security releases. Use vulnerability scanning and pass `--cooldown 0` to install an urgent fix without
+delay.
 
 ### Applying a tool manifest
 

--- a/docs/tutorial/run-applications.md
+++ b/docs/tutorial/run-applications.md
@@ -54,6 +54,7 @@ pipx can consume arguments meant for the application:
 
 usage: pipx run [-h] [--no-cache] [--pypackages] [--spec SPEC] [--verbose] [--python PYTHON]
                 [--system-site-packages] [--index-url INDEX_URL] [--editable] [--pip-args PIP_ARGS]
+                [--cooldown DAYS]
                 app ...
 pipx run: error: ambiguous option: --py could match --pypackages, --python
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
   "userpath>=1.6,!=1.9",
 ]
 optional-dependencies.uv = [
-  "uv>=0.6.15",
+  "uv>=0.9.17",
 ]
 urls."Issue Tracker" = "https://github.com/pypa/pipx/issues"
 urls."Release Notes" = "https://pipx.pypa.io/latest/changelog/"

--- a/src/pipx/backends/_base.py
+++ b/src/pipx/backends/_base.py
@@ -63,6 +63,10 @@ class Backend(ABC):
             verbose=verbose,
         )
 
+    @staticmethod
+    @abstractmethod
+    def cooldown_args(cooldown_days: int | None) -> list[str]: ...
+
     @abstractmethod
     def uninstall(
         self,

--- a/src/pipx/backends/pip.py
+++ b/src/pipx/backends/pip.py
@@ -98,6 +98,10 @@ class PipBackend(Backend):
             subprocess_post_check_handle_pip_error(process)
         return process
 
+    @staticmethod
+    def cooldown_args(cooldown_days: int | None) -> list[str]:
+        return [] if not cooldown_days else ["--uploaded-prior-to", f"P{cooldown_days}D"]
+
     def uninstall(
         self,
         *,

--- a/src/pipx/backends/uv.py
+++ b/src/pipx/backends/uv.py
@@ -6,8 +6,9 @@ import re
 import shutil
 import subprocess
 from functools import cache
+from importlib import import_module
 from pathlib import Path
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING, Final, cast
 
 from packaging.version import InvalidVersion, Version
 
@@ -28,15 +29,15 @@ if TYPE_CHECKING:
 _LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
 
-# Imported into a temporary, then assigned through Final and deleted so mypy
-# sees one Final binding (it rejects redefinition across try/except branches).
-try:
-    from uv import find_uv_bin as _uv_bin_from_extra  # type: ignore[import-not-found]
-except ImportError:
-    _uv_bin_from_extra = None
-_FIND_UV_BIN_FROM_EXTRA: Final[Callable[[], str] | None] = _uv_bin_from_extra
-del _uv_bin_from_extra
-_MIN_UV_VERSION: Final[Version] = Version("0.6.15")
+def _load_uv_bin_finder() -> Callable[[], str] | None:
+    try:
+        return cast("Callable[[], str]", import_module("uv").find_uv_bin)
+    except (AttributeError, ImportError):
+        return None
+
+
+_FIND_UV_BIN_FROM_EXTRA: Final[Callable[[], str] | None] = _load_uv_bin_finder()
+_MIN_UV_VERSION: Final[Version] = Version("0.9.17")
 _VERSION_RE: Final[re.Pattern[str]] = re.compile(
     r"""
     uv \s+        # the literal "uv " prefix from `uv --version`
@@ -115,6 +116,10 @@ class UvBackend(Backend):
         if log_pip_errors:
             subprocess_post_check_handle_pip_error(process, tool_name="uv")
         return process
+
+    @staticmethod
+    def cooldown_args(cooldown_days: int | None) -> list[str]:
+        return [] if not cooldown_days else ["--exclude-newer", f"P{cooldown_days}D"]
 
     def uninstall(
         self,

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -428,6 +428,7 @@ def package_name_from_spec(
     verbose: bool,
     backend: str | None = None,
     env_backend: str | None = None,
+    cooldown_days: int | None = None,
 ) -> str:
     start_time = time.time()
 
@@ -447,7 +448,11 @@ def package_name_from_spec(
     with tempfile.TemporaryDirectory() as temp_venv_dir:
         venv = Venv(Path(temp_venv_dir), python=python, verbose=verbose, backend=backend, env_backend=env_backend)
         venv.create_venv(venv_args=[], pip_args=[])
-        package_name = venv.install_package_no_deps(package_or_url=package_spec, pip_args=pip_args)
+        package_name = venv.install_package_no_deps(
+            package_or_url=package_spec,
+            pip_args=pip_args,
+            cooldown_days=cooldown_days,
+        )
 
     _LOGGER.info(f"Package name determined in {time.time() - start_time:.1f}s")
     return package_name

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -42,6 +42,7 @@ def inject_dep(
     suffix: bool = False,
     backend: str | None = None,
     env_backend: str | None = None,
+    cooldown_days: int | None = None,
 ) -> bool:
     _LOGGER.debug("Injecting package %s", package_spec)
 
@@ -69,6 +70,8 @@ def inject_dep(
             f"Cannot inject into locked environment {venv.name}. "
             f"Update {lock_file} and run `pipx reinstall {venv.name}`."
         )
+    if cooldown_days is None:
+        cooldown_days = venv.pipx_metadata.main_package.cooldown_days
     venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
 
     # package_spec is anything pip-installable, including package_name, vcs spec,
@@ -81,6 +84,7 @@ def inject_dep(
             verbose=verbose,
             backend=venv.backend_name,
             env_backend=env_backend,
+            cooldown_days=cooldown_days,
         )
 
     # Mirrors the install-side guard: dropping pip into a uv venv works for
@@ -129,6 +133,7 @@ def inject_dep(
             is_main_package=is_main_package,
             suffix=venv_suffix,
             pinned=pinned,
+            cooldown_days=cooldown_days,
         )
         if include_apps:
             run_post_install_actions(
@@ -165,6 +170,7 @@ def inject(
     suffix: bool = False,
     backend: str | None = None,
     env_backend: str | None = None,
+    cooldown_days: int | None = None,
 ) -> ExitCode:
     """Returns pipx exit code."""
     # Combined collection of package specifications
@@ -197,6 +203,7 @@ def inject(
             suffix=suffix,
             backend=backend,
             env_backend=env_backend,
+            cooldown_days=cooldown_days,
         )
 
     # Any failure to install will raise PipxError, otherwise success

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -60,6 +60,7 @@ def install(
     exposure_enabled: bool | None = None,
     upgrade: bool = False,
     upgrade_strategy: str | None = None,
+    cooldown_days: int | None = None,
     venv_lock: BaseFileLock | None = None,
     preserve_existing: bool = False,
     replace_expected_apps: bool = False,
@@ -74,6 +75,7 @@ def install(
         expected_apps,
         preinstall_packages,
         lock_file,
+        cooldown_days,
         upgrade=upgrade,
         upgrade_strategy=upgrade_strategy,
     )
@@ -90,6 +92,7 @@ def install(
                 verbose=verbose,
                 backend=backend,
                 env_backend=env_backend,
+                cooldown_days=cooldown_days,
             )
             for package_spec in package_specs
         ]
@@ -129,6 +132,12 @@ def install(
             )
             recorded_lock = venv.pipx_metadata.main_package.lock_file
             required_lock = lock_file if replace_lock else lock_file or recorded_lock
+            required_cooldown = _resolve_cooldown(
+                required_lock,
+                cooldown_days,
+                venv.pipx_metadata.main_package.cooldown_days,
+                modifies_existing=exists and force,
+            )
             required_exposure = venv.pipx_metadata.exposure_enabled if exposure_enabled is None else exposure_enabled
             if exists:
                 if not reinstall and force and python_flag_passed:
@@ -154,6 +163,7 @@ def install(
                         verbose,
                         upgrade_strategy,
                         required_apps,
+                        required_cooldown,
                     )
                     if len(package_specs) == 1:
                         return EXIT_CODE_OK
@@ -199,7 +209,7 @@ def install(
                     venv.pipx_metadata.exposure_enabled = required_exposure
                     venv.pipx_metadata.environment = venv.root.name
                     for dependency in preinstall_packages or []:
-                        venv.upgrade_package_no_metadata(dependency, [])
+                        venv.upgrade_package_no_metadata(dependency, pip_args, cooldown_days=required_cooldown)
                     venv.install_package(
                         package_name=package_name,
                         package_or_url=package_spec,
@@ -212,6 +222,7 @@ def install(
                         suffix=suffix,
                         expected_apps=required_apps,
                         lock_file=required_lock,
+                        cooldown_days=required_cooldown,
                     )
                     validate_expected_apps(venv, package_name, required_apps)
                     run_post_install_actions(
@@ -237,6 +248,7 @@ def _validate_install_options(
     expected_apps: Sequence[str],
     preinstall_packages: Sequence[str] | None,
     lock_file: Path | None,
+    cooldown_days: int | None,
     *,
     upgrade: bool,
     upgrade_strategy: str | None,
@@ -253,12 +265,28 @@ def _validate_install_options(
         raise PipxError("--lock cannot be combined with --preinstall")
     if upgrade:
         raise PipxError("--lock cannot be combined with --upgrade; use --force to apply a new lock")
+    if cooldown_days is not None:
+        raise PipxError("--lock cannot be combined with --cooldown")
     lock_file = lock_file.expanduser().resolve()
     if not _PYLOCK_NAME_RE.fullmatch(lock_file.name):
         raise PipxError("Lock files must be named pylock.toml or pylock.<name>.toml")
     if not lock_file.is_file():
         raise PipxError(f"Lock file does not exist: {lock_file}")
     return lock_file
+
+
+def _resolve_cooldown(
+    lock_file: Path | None,
+    requested: int | None,
+    stored: int | None,
+    *,
+    modifies_existing: bool,
+) -> int | None:
+    if modifies_existing and lock_file is not None and requested is not None:
+        raise PipxError("--cooldown cannot modify a locked environment")
+    if lock_file is not None:
+        return None
+    return requested if requested is not None else stored
 
 
 def _upgrade_existing_venv(
@@ -271,6 +299,7 @@ def _upgrade_existing_venv(
     verbose: bool,
     upgrade_strategy: str | None,
     expected_apps: Sequence[str],
+    cooldown_days: int | None,
 ) -> None:
     package_metadata = venv.pipx_metadata.main_package
     installed_version: Final[str] = package_metadata.package_version
@@ -310,6 +339,7 @@ def _upgrade_existing_venv(
             suffix=package_metadata.suffix,
             upgrade_only_pip_args=([f"--upgrade-strategy={upgrade_strategy}"] if upgrade_strategy is not None else None),
             expected_apps=expected_apps,
+            cooldown_days=cooldown_days,
         )
         validate_expected_apps(venv, package_name, expected_apps)
         package_metadata = venv.pipx_metadata.main_package
@@ -345,6 +375,7 @@ def install_all(
     force: bool,
     backend: str | None = None,
     env_backend: str | None = None,
+    cooldown_days: int | None = None,
 ) -> ExitCode:
     venv_container: Final[VenvContainer] = VenvContainer(paths.ctx.venvs)
     failed: Final[list[str]] = []
@@ -355,6 +386,12 @@ def install_all(
         venv_dir = venv_container.get_venv_dir(f"{main_package.package}{main_package.suffix}")
         try:
             with venv_container.venv_lock(venv_dir) as venv_lock:
+                package_cooldown = _resolve_cooldown(
+                    main_package.lock_file,
+                    cooldown_days,
+                    main_package.cooldown_days,
+                    modifies_existing=False,
+                )
                 install(
                     venv_dir,
                     None,
@@ -379,6 +416,7 @@ def install_all(
                     replace_expected_apps=True,
                     replace_lock=True,
                     venv_lock=venv_lock,
+                    cooldown_days=package_cooldown,
                 )
                 for inject_package in venv_metadata.injected_packages.values():
                     commands.inject(
@@ -392,6 +430,7 @@ def install_all(
                         include_apps_from=inject_package.include_apps_from,
                         force=force,
                         suffix=inject_package.suffix == main_package.suffix,
+                        cooldown_days=(cooldown_days if cooldown_days is not None else inject_package.cooldown_days),
                     )
         except PipxError as error:
             print(error, file=sys.stderr)

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -135,6 +135,7 @@ def reinstall(
             preinstall_packages=[],
             expected_apps=venv.pipx_metadata.main_package.expected_apps,
             lock_file=venv.pipx_metadata.main_package.lock_file,
+            cooldown_days=venv.pipx_metadata.main_package.cooldown_days,
             suffix=venv.pipx_metadata.main_package.suffix,
             python_flag_passed=python_flag_passed,
             backend=backend or venv.pipx_metadata.backend,
@@ -161,6 +162,7 @@ def reinstall(
                 force=True,
                 backend=backend or venv.pipx_metadata.backend,
                 env_backend=env_backend,
+                cooldown_days=injected_package.cooldown_days,
             )
 
         new_resource_paths = _get_expected_reinstall_resource_paths(

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -94,6 +94,7 @@ def run_script(
     resolved_backend: str | None = None,
     script_source: Path | None = None,
     dependencies: list[str] | None = None,
+    cooldown_days: int | None = None,
 ) -> NoReturn:
     requirements = _get_requirements_from_script(content)
 
@@ -119,6 +120,7 @@ def run_script(
                 use_cache=use_cache,
                 verbose=verbose,
                 dependencies=dependencies,
+                cooldown_days=cooldown_days,
             )
         # URL / named-pipe content has no on-disk path for ``uv run --script``;
         # warn so users on ``--backend uv`` notice they lose uv's cache and
@@ -145,7 +147,14 @@ def run_script(
         # managed. The requirements are normalised (in
         # _get_requirements_from_script), so that irrelevant differences in
         # whitespace, and similar, don't prevent environment sharing.
-        venv_dir = _get_temporary_venv_path(requirements, python, pip_args, venv_args, resolved_backend or "pip")
+        venv_dir = _get_temporary_venv_path(
+            requirements,
+            python,
+            pip_args,
+            venv_args,
+            resolved_backend or "pip",
+            cooldown_days,
+        )
         venv = Venv(venv_dir, backend=backend, env_backend=env_backend)
         _prepare_venv_cache(venv, None, use_cache)
         if venv_dir.exists():
@@ -155,8 +164,8 @@ def run_script(
             venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
             venv.create_venv(venv_args, pip_args)
             try:
-                venv.install_unmanaged_packages(requirements, pip_args)
-            except:
+                venv.install_unmanaged_packages(requirements, pip_args, cooldown_days=cooldown_days)
+            except (OSError, PipxError, KeyboardInterrupt):
                 # Package installation failed, so mark the cache as expired.
                 # This ensures an attempt is made to re-install requirements
                 # when `pipx run` is next executed, rather than just failing.
@@ -187,6 +196,7 @@ def run_package(
     env_backend: str | None = None,
     resolved_backend: str | None = None,
     no_path_check: bool = False,
+    cooldown_days: int | None = None,
 ) -> NoReturn:
     if not no_path_check and (app_path := which(app)):
         _LOGGER.warning(
@@ -218,7 +228,14 @@ def run_package(
             """
         )
 
-    venv_dir = _get_temporary_venv_path([package_or_url], python, pip_args, venv_args, resolved_backend or "pip")
+    venv_dir = _get_temporary_venv_path(
+        [package_or_url],
+        python,
+        pip_args,
+        venv_args,
+        resolved_backend or "pip",
+        cooldown_days,
+    )
 
     venv = Venv(venv_dir, backend=backend, env_backend=env_backend)
     if infer_app_name and venv.pipx_metadata.main_package.package is not None:
@@ -244,6 +261,7 @@ def run_package(
             infer_app_name=infer_app_name,
             backend=backend,
             env_backend=env_backend,
+            cooldown_days=cooldown_days,
         )
 
     for dependency in dependencies:
@@ -259,6 +277,7 @@ def run_package(
             force=False,
             backend=backend,
             env_backend=env_backend,
+            cooldown_days=cooldown_days,
         )
     venv.run_app(app, app_filename, app_args)
 
@@ -279,6 +298,7 @@ def run(
     no_path_check: bool = False,
     backend: str | None = None,
     env_backend: str | None = None,
+    cooldown_days: int | None = None,
 ) -> NoReturn:
     """Installs venv to temporary dir (or reuses cache), then runs app from
     package
@@ -310,6 +330,7 @@ def run(
             resolved_backend=resolved_backend,
             script_source=Path(app) if isinstance(content, Path) else None,
             dependencies=dependencies,
+            cooldown_days=cooldown_days,
         )
 
     elif use_uvx:
@@ -324,6 +345,7 @@ def run(
             use_cache=use_cache,
             verbose=verbose,
             no_path_check=no_path_check,
+            cooldown_days=cooldown_days,
         )
     else:
         package_or_url = spec if spec is not None else app
@@ -343,6 +365,7 @@ def run(
             env_backend=env_backend,
             resolved_backend=resolved_backend,
             no_path_check=no_path_check,
+            cooldown_days=cooldown_days,
         )
 
 
@@ -360,6 +383,7 @@ def _prepare_venv(
     infer_app_name: bool = False,
     backend: str | None = None,
     env_backend: str | None = None,
+    cooldown_days: int | None = None,
 ) -> tuple[Venv, str, str]:
     venv = Venv(venv_dir, python=python, verbose=verbose, backend=backend, env_backend=env_backend)
     venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
@@ -367,7 +391,13 @@ def _prepare_venv(
     if venv.pipx_metadata.main_package.package is not None:
         package_name = venv.pipx_metadata.main_package.package
     else:
-        package_name = package_name_from_spec(package_or_url, python, pip_args=pip_args, verbose=verbose)
+        package_name = package_name_from_spec(
+            package_or_url,
+            python,
+            pip_args=pip_args,
+            verbose=verbose,
+            cooldown_days=cooldown_days,
+        )
 
     if infer_app_name:
         app = package_name
@@ -384,6 +414,7 @@ def _prepare_venv(
         include_apps_from=(),
         include_apps=True,
         is_main_package=True,
+        cooldown_days=cooldown_days,
     )
 
     if not venv.has_app(app, app_filename):
@@ -428,6 +459,7 @@ def _get_temporary_venv_path(
     pip_args: list[str],
     venv_args: list[str],
     backend: str,
+    cooldown_days: int | None,
 ) -> Path:
     """Hash venv-affecting inputs to a deterministic cache path.
 
@@ -440,6 +472,7 @@ def _get_temporary_venv_path(
     digest.update("".join(pip_args).encode())
     digest.update("".join(venv_args).encode())
     digest.update(backend.encode())
+    digest.update(f"{cooldown_days=}".encode())
     venv_folder_name = digest.hexdigest()[:15]  # 15 chosen arbitrarily
     return Path(paths.ctx.venv_cache) / venv_folder_name
 

--- a/src/pipx/commands/run_uv.py
+++ b/src/pipx/commands/run_uv.py
@@ -4,7 +4,7 @@ import logging
 from shutil import which
 from typing import TYPE_CHECKING, Final, NoReturn
 
-from pipx.backends.uv import resolve_uv_binary
+from pipx.backends.uv import UvBackend, resolve_uv_binary
 from pipx.emojis import hazard
 from pipx.util import PipxError, exec_app, pipx_wrap
 
@@ -46,6 +46,7 @@ def run_via_uv_tool_run(
     use_cache: bool,
     verbose: bool,
     no_path_check: bool = False,
+    cooldown_days: int | None = None,
 ) -> NoReturn:
     _reject_venv_args(venv_args)
     if not no_path_check and (existing_app_path := which(app)):
@@ -71,6 +72,7 @@ def run_via_uv_tool_run(
     if verbose:
         cmd.append("--verbose")
     cmd += translate_pip_args_for_uv(pip_args)
+    cmd += UvBackend.cooldown_args(cooldown_days)
     cmd.append(app)
     cmd += app_args
     exec_app(cmd)
@@ -86,6 +88,7 @@ def run_script_via_uv_run(
     use_cache: bool,
     verbose: bool,
     dependencies: list[str] | None = None,
+    cooldown_days: int | None = None,
 ) -> NoReturn:
     _reject_venv_args(venv_args)
     cmd: list[str] = [str(resolve_uv_binary()), "run", "--script"]
@@ -98,6 +101,7 @@ def run_script_via_uv_run(
     for dependency in dependencies or []:
         cmd += ["--with", dependency]
     cmd += translate_pip_args_for_uv(pip_args)
+    cmd += UvBackend.cooldown_args(cooldown_days)
     cmd += [str(script_path), *app_args]
     exec_app(cmd)
 

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -66,6 +66,7 @@ def _upgrade_package(
     pip_args: list[str],
     is_main_package: bool,
     force: bool,
+    cooldown_days: int | None,
 ) -> PackageUpgradeResult:
     package_metadata = venv.package_metadata[package_name]
 
@@ -94,6 +95,7 @@ def _upgrade_package(
         include_apps=package_metadata.include_apps,
         is_main_package=is_main_package,
         suffix=package_metadata.suffix,
+        cooldown_days=cooldown_days if cooldown_days is not None else package_metadata.cooldown_days,
     )
 
     package_metadata = venv.package_metadata[package_name]
@@ -172,6 +174,7 @@ def _upgrade_venv(
     venv: Venv | None = None,
     shared_libs_already_checked: bool = False,
     venv_lock: BaseFileLock | None = None,
+    cooldown_days: int | None = None,
 ) -> tuple[PackageUpgradeResult, ...]:
     """Return package upgrade results.
 
@@ -201,6 +204,7 @@ def _upgrade_venv(
                 backend=backend,
                 env_backend=env_backend,
                 venv_lock=venv_lock,
+                cooldown_days=cooldown_days,
             )
             return ()
         else:
@@ -257,7 +261,14 @@ def _upgrade_venv(
         venv_dir,
         enabled=any(package.expected_apps for package in venv.package_metadata.values()),
     ):
-        return _upgrade_packages(venv, main_pip_args, pip_args, include_injected=include_injected, force=force)
+        return _upgrade_packages(
+            venv,
+            main_pip_args,
+            pip_args,
+            include_injected=include_injected,
+            force=force,
+            cooldown_days=cooldown_days,
+        )
 
 
 def _upgrade_packages(
@@ -267,6 +278,7 @@ def _upgrade_packages(
     *,
     include_injected: bool,
     force: bool,
+    cooldown_days: int | None,
 ) -> tuple[PackageUpgradeResult, ...]:
     venv.upgrade_packaging_libraries(main_pip_args)
     results: Final[list[PackageUpgradeResult]] = [
@@ -276,6 +288,7 @@ def _upgrade_packages(
             main_pip_args,
             is_main_package=True,
             force=force,
+            cooldown_days=cooldown_days,
         )
     ]
 
@@ -290,6 +303,7 @@ def _upgrade_packages(
                     pip_args or venv.package_metadata[package_name].pip_args,
                     is_main_package=False,
                     force=force,
+                    cooldown_days=cooldown_days,
                 )
             )
 
@@ -309,6 +323,7 @@ def upgrade(
     python_flag_passed: bool = False,
     backend: str | None = None,
     env_backend: str | None = None,
+    cooldown_days: int | None = None,
 ) -> OperationResult[UpgradeData]:
     results: list[PackageUpgradeResult] = []
 
@@ -328,6 +343,7 @@ def upgrade(
                     backend=backend,
                     env_backend=env_backend,
                     venv_lock=venv_lock,
+                    cooldown_days=cooldown_days,
                 )
             )
 
@@ -352,6 +368,7 @@ def upgrade_all(
     python_flag_passed: bool = False,
     backend: str | None = None,
     env_backend: str | None = None,
+    cooldown_days: int | None = None,
 ) -> OperationResult[UpgradeData]:
     failures: list[FailedUpgrade] = []
     messages: list[OutputMessage] = []
@@ -383,6 +400,7 @@ def upgrade_all(
                     venv=venv,
                     shared_libs_already_checked=True,
                     venv_lock=venv_lock,
+                    cooldown_days=cooldown_days,
                 )
                 results.extend(package_results)
                 for result in package_results:

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -205,6 +205,16 @@ def get_pip_args(parsed_args: dict[str, str]) -> list[str]:
     return pip_args
 
 
+def _non_negative_int(value: str) -> int:
+    try:
+        result: Final[int] = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("--cooldown must be a non-negative integer") from exc
+    if result < 0:
+        raise argparse.ArgumentTypeError("--cooldown must be a non-negative integer")
+    return result
+
+
 def get_runpip_args(pip_args: list[str]) -> list[str]:
     if len(pip_args) != 1:
         return pip_args
@@ -304,6 +314,7 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:
         spec=spec,
         backend=cli_backend,
         env_backend=env_backend,
+        cooldown_days=getattr(args, "cooldown", None),
     )
     with skip_shared_libs_maintenance(getattr(args, "skip_maintenance", False)):
         result = args.func(args, ctx)
@@ -337,6 +348,7 @@ class DispatchContext:
     spec: str | None
     backend: str | None = None
     env_backend: str | None = None
+    cooldown_days: int | None = None
 
     @property
     def effective_backend(self) -> str | None:
@@ -366,6 +378,12 @@ def add_pip_venv_args(parser: argparse.ArgumentParser) -> None:
             "Under the uv backend a small subset is translated (--index-url, --extra-index-url, "
             "--find-links, --pre); other flags raise an error so behaviour stays explicit."
         ),
+    )
+    parser.add_argument(
+        "--cooldown",
+        type=_non_negative_int,
+        metavar="DAYS",
+        help="Ignore index artifacts uploaded fewer than DAYS days ago.",
     )
 
 
@@ -529,6 +547,7 @@ def _cmd_install(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
         backend=ctx.backend,
         env_backend=ctx.env_backend,
         upgrade_strategy=args.upgrade_strategy,
+        cooldown_days=ctx.cooldown_days,
     )
 
 
@@ -565,6 +584,7 @@ def _cmd_install_all(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode
         force=args.force,
         backend=ctx.backend,
         env_backend=ctx.env_backend,
+        cooldown_days=ctx.cooldown_days,
     )
 
 
@@ -677,6 +697,7 @@ def _cmd_inject(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
             suffix=args.with_suffix,
             backend=ctx.backend,
             env_backend=ctx.env_backend,
+            cooldown_days=ctx.cooldown_days,
         )
 
 
@@ -862,6 +883,7 @@ def _cmd_upgrade(args: argparse.Namespace, ctx: DispatchContext) -> OperationRes
         python_flag_passed=ctx.python_flag_passed,
         backend=ctx.backend,
         env_backend=ctx.env_backend,
+        cooldown_days=ctx.cooldown_days,
     )
 
 
@@ -901,6 +923,7 @@ def _cmd_upgrade_all(args: argparse.Namespace, ctx: DispatchContext) -> Operatio
         python_flag_passed=ctx.python_flag_passed,
         backend=ctx.backend,
         env_backend=ctx.env_backend,
+        cooldown_days=ctx.cooldown_days,
     )
 
 
@@ -1243,6 +1266,7 @@ def _cmd_run(args: argparse.Namespace, ctx: DispatchContext) -> NoReturn:
         no_path_check=args.no_path_check,
         backend=ctx.backend,
         env_backend=ctx.env_backend,
+        cooldown_days=ctx.cooldown_days,
     )
 
 

--- a/src/pipx/pipx_metadata_file.py
+++ b/src/pipx/pipx_metadata_file.py
@@ -36,6 +36,7 @@ class _RawPackageInfo(TypedDict, total=False):
     expected_apps: list[str]
     lock_file: Path | None
     include_apps_from: list[str]
+    cooldown_days: int | None
     man_pages: list[str]
     man_paths: list[Path]
     man_pages_of_dependencies: list[str]
@@ -97,6 +98,7 @@ class PackageInfo:
     expected_apps: list[str] = field(default_factory=list)
     lock_file: Path | None = None
     include_apps_from: list[str] = field(default_factory=list)
+    cooldown_days: int | None = None
     man_pages: list[str] = field(default_factory=list)
     man_paths: list[Path] = field(default_factory=list)
     man_pages_of_dependencies: list[str] = field(default_factory=list)
@@ -161,7 +163,7 @@ class PipxMetadata:
     # V0.4 -> Add source interpreter
     # V0.5 -> Add pinned
     # V0.6 -> Add backend (pip|uv)
-    __METADATA_VERSION__: Final[str] = "0.10"
+    __METADATA_VERSION__: Final[str] = "0.11"
 
     def __init__(self, venv_dir: Path, read: bool = True):
         self.venv_dir = venv_dir
@@ -180,6 +182,7 @@ class PipxMetadata:
             expected_apps=[],
             lock_file=None,
             include_apps_from=[],
+            cooldown_days=None,
             man_pages=[],
             man_paths=[],
             man_pages_of_dependencies=[],
@@ -217,7 +220,7 @@ class PipxMetadata:
 
     def _convert_legacy_metadata(self, metadata_dict: _RawMetadata) -> _RawMetadata:
         version = metadata_dict["pipx_metadata_version"]
-        if version in (self.__METADATA_VERSION__, "0.9", "0.8", "0.7", "0.6", "0.5"):
+        if version in (self.__METADATA_VERSION__, "0.10", "0.9", "0.8", "0.7", "0.6", "0.5"):
             pass
         elif version == "0.4":
             metadata_dict["pinned"] = False

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -350,13 +350,16 @@ class Venv:
         expected_apps: Sequence[str] | None = None,
         lock_file: Path | None = None,
         pinned: bool = False,
+        cooldown_days: int | None = None,
     ) -> None:
         # package_name in package specifier can mismatch URL due to user error
         package_or_url = fix_package_name(package_or_url, package_name)
 
         # check syntax and clean up spec and pip_args
         (package_or_url, pip_args) = parse_specifier_for_install(package_or_url, pip_args)
-        install_pip_args = [*(install_only_pip_args or []), *pip_args]
+        install_pip_args: Final[list[str]] = self._with_cooldown(
+            [*(install_only_pip_args or []), *pip_args], cooldown_days
+        )
 
         if lock_file is None:
             _LOGGER.info("Installing %s", package_descr := full_package_description(package_name, package_or_url))
@@ -385,6 +388,7 @@ class Venv:
             expected_apps=expected_apps,
             lock_file=lock_file,
             pinned=pinned,
+            cooldown_days=cooldown_days,
         )
 
         # Verify package installed ok
@@ -451,7 +455,12 @@ class Venv:
             error = (process.stdout or process.stderr or "dependency check failed").strip()
             raise PipxError(f"Lock file {lock_file} does not satisfy {package_name}: {error}", wrap_message=False)
 
-    def install_unmanaged_packages(self, requirements: list[str], pip_args: list[str]) -> None:
+    def install_unmanaged_packages(
+        self,
+        requirements: list[str],
+        pip_args: list[str],
+        cooldown_days: int | None = None,
+    ) -> None:
         """Install packages in the venv, but do not record them in the metadata."""
         _LOGGER.info("Installing %s", package_descr := ", ".join(requirements))
         with animate(f"installing {package_descr}", self.do_animation):
@@ -459,20 +468,25 @@ class Venv:
                 venv_root=self.root,
                 venv_python=self.python_path,
                 requirements=list(requirements),
-                pip_args=pip_args,
+                pip_args=self._with_cooldown(pip_args, cooldown_days),
                 verbose=self.verbose,
             )
         if process.returncode:
             raise PipxError(f"Error installing {', '.join(requirements)}.")
 
-    def install_package_no_deps(self, package_or_url: str, pip_args: list[str]) -> str:
+    def install_package_no_deps(
+        self,
+        package_or_url: str,
+        pip_args: list[str],
+        cooldown_days: int | None = None,
+    ) -> str:
         with animate(f"determining package name from {package_or_url!r}", self.do_animation):
             old_package_set = self.list_installed_packages()
             process = self.backend.install(
                 venv_root=self.root,
                 venv_python=self.python_path,
                 requirements=[package_or_url],
-                pip_args=pip_args,
+                pip_args=self._with_cooldown(pip_args, cooldown_days),
                 no_deps=True,
                 log_pip_errors=False,
                 verbose=self.verbose,
@@ -523,6 +537,7 @@ class Venv:
         pinned: bool = False,
         expected_apps: Sequence[str] | None = None,
         lock_file: Path | None = None,
+        cooldown_days: int | None = None,
     ) -> None:
         venv_package_metadata = self.get_venv_metadata_for_package(package_name, get_extras(package_or_url))
         if expected_apps is None:
@@ -545,6 +560,10 @@ class Venv:
                 "Dependencies with apps or manual pages: "
                 f"{', '.join(sorted(available_dependencies)) or 'none'}."
             )
+        if cooldown_days is None:
+            cooldown_days = (
+                self.package_metadata[package_name].cooldown_days if package_name in self.package_metadata else None
+            )
         package_info = PackageInfo(
             package=package_name,
             package_or_url=parse_specifier_for_metadata(package_or_url),
@@ -563,6 +582,7 @@ class Venv:
             package_version=venv_package_metadata.package_version,
             expected_apps=list(dict.fromkeys(expected_apps)),
             lock_file=lock_file,
+            cooldown_days=cooldown_days,
             suffix=suffix,
             pinned=pinned,
         )
@@ -632,14 +652,19 @@ class Venv:
     def has_package(self, package_name: str) -> bool:
         return bool(list(Distribution.discover(name=package_name, path=[str(self.site_packages)])))
 
-    def upgrade_package_no_metadata(self, package_name: str, pip_args: list[str]) -> None:
+    def upgrade_package_no_metadata(
+        self,
+        package_name: str,
+        pip_args: list[str],
+        cooldown_days: int | None = None,
+    ) -> None:
         _LOGGER.info("Upgrading %s", package_descr := full_package_description(package_name, package_name))
         with animate(f"upgrading {package_descr}", self.do_animation):
             process = self.backend.install(
                 venv_root=self.root,
                 venv_python=self.python_path,
                 requirements=[package_name],
-                pip_args=pip_args,
+                pip_args=self._with_cooldown(pip_args, cooldown_days),
                 upgrade=True,
                 log_pip_errors=False,
                 verbose=self.verbose,
@@ -658,6 +683,7 @@ class Venv:
         suffix: str = "",
         upgrade_only_pip_args: list[str] | None = None,
         expected_apps: Sequence[str] | None = None,
+        cooldown_days: int | None = None,
     ) -> None:
         _LOGGER.info("Upgrading %s", package_descr := full_package_description(package_name, package_or_url))
         with animate(f"upgrading {package_descr}", self.do_animation):
@@ -665,7 +691,7 @@ class Venv:
                 venv_root=self.root,
                 venv_python=self.python_path,
                 requirements=[package_or_url],
-                pip_args=[*(upgrade_only_pip_args or []), *pip_args],
+                pip_args=self._with_cooldown([*(upgrade_only_pip_args or []), *pip_args], cooldown_days),
                 upgrade=True,
                 log_pip_errors=False,
                 verbose=self.verbose,
@@ -682,7 +708,11 @@ class Venv:
             is_main_package=is_main_package,
             suffix=suffix,
             expected_apps=expected_apps,
+            cooldown_days=cooldown_days,
         )
+
+    def _with_cooldown(self, pip_args: list[str], cooldown_days: int | None) -> list[str]:
+        return [*pip_args, *self.backend.cooldown_args(cooldown_days)]
 
     def _run_pip(self, cmd: list[str]) -> "CompletedProcess[str]":
         return self.backend.run_raw_pip(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,7 @@ _upgrade_module = importlib.import_module("pipx.commands.upgrade")
 
 PIPX_TESTS_DIR = Path(".pipx_tests")
 PIPX_TESTS_PACKAGE_LIST_DIR = Path("testdata/tests_packages")
+_IGNORE_PROJECT_OUTPUT: Final[Callable[[str, list[str]], set[str]]] = shutil.ignore_patterns("build", "*.egg-info")
 
 
 @pytest.fixture(scope="session")
@@ -73,7 +74,7 @@ sha256 = "{hashlib.sha256(wheel.read_bytes()).hexdigest()}"
 def make_project_with_dependency(root: Path, tmp_path: Path) -> Callable[[str], Path]:
     def create(dependency: str) -> Path:
         project = tmp_path / "locked-project"
-        shutil.copytree(root / "testdata/empty_project", project)
+        shutil.copytree(root / "testdata/empty_project", project, ignore=_IGNORE_PROJECT_OUTPUT)
         pyproject = project / "pyproject.toml"
         pyproject.write_text(
             pyproject.read_text(encoding="utf-8").replace(
@@ -90,14 +91,14 @@ def make_project_with_dependency(root: Path, tmp_path: Path) -> Callable[[str], 
 @pytest.fixture()
 def local_extras_project(root: Path, tmp_path: Path) -> Path:
     project: Final[Path] = tmp_path / "local_extras"
-    shutil.copytree(root / "testdata/test_package_specifier/local_extras", project)
+    shutil.copytree(root / "testdata/test_package_specifier/local_extras", project, ignore=_IGNORE_PROJECT_OUTPUT)
     return project
 
 
 @pytest.fixture()
 def empty_project(root: Path, tmp_path: Path) -> Path:
     project: Final[Path] = tmp_path / "empty_project"
-    shutil.copytree(root / "testdata/empty_project", project)
+    shutil.copytree(root / "testdata/empty_project", project, ignore=_IGNORE_PROJECT_OUTPUT)
     return project
 
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import subprocess
 from pathlib import Path
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, Final, TypedDict
 
 import pytest
 
@@ -203,6 +203,19 @@ def test_find_uv_binary_is_cached(mocker: MockerFixture) -> None:
     assert which_mock.call_count == 1
 
 
+def test_uv_backend_rejects_pre_cooldown_version(mocker: MockerFixture) -> None:
+    binary: Final[Path] = Path("/usr/local/bin/uv")
+    mocker.patch("pipx.backends.uv.resolve_uv_binary", return_value=binary)
+    mocker.patch("pipx.backends.uv.find_uv_binary", return_value=(binary, "path"))
+    mocker.patch(
+        "pipx.backends.uv.subprocess.run",
+        return_value=subprocess.CompletedProcess([str(binary), "--version"], 0, stdout="uv 0.9.16", stderr=""),
+    )
+
+    with pytest.raises(PipxError, match=r"uv>=0\.9\.17"):
+        UvBackend()
+
+
 @pytest.mark.parametrize(
     ("pip_args", "expected"),
     [
@@ -328,7 +341,11 @@ def test_backend_list_outdated_forwards_index_settings(backend_name: str, tmp_pa
             "https://index.example/simple",
         ]
     else:
-        mocker.patch("pipx.backends.uv.shutil.which", autospec=True, return_value=str(tmp_path / "uv"))
+        mocker.patch(
+            "pipx.backends.uv.find_uv_binary",
+            autospec=True,
+            return_value=(tmp_path / "uv", "path"),
+        )
         mocker.patch(
             "pipx.backends.uv.subprocess.run",
             autospec=True,
@@ -368,6 +385,24 @@ def test_backend_list_outdated_forwards_index_settings(backend_name: str, tmp_pa
         (OutdatedPackage(name="demo", version="1", latest_version="2"),),
         expected_command,
     )
+
+
+@pytest.mark.parametrize(
+    ("backend_type", "expected"),
+    [
+        pytest.param(PipBackend, "--uploaded-prior-to", id="pip"),
+        pytest.param(UvBackend, "--exclude-newer", id="uv"),
+    ],
+)
+def test_backend_cooldown_args(
+    backend_type: type[PipBackend] | type[UvBackend],
+    expected: str,
+) -> None:
+    assert (
+        backend_type.cooldown_args(None),
+        backend_type.cooldown_args(0),
+        backend_type.cooldown_args(7),
+    ) == ([], [], [expected, "P7D"])
 
 
 def test_list_not_required_packages_treats_extra_dependencies_as_required(

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -2,6 +2,7 @@ import logging
 import re
 import shutil
 import subprocess
+import sys
 import textwrap
 from collections.abc import Callable
 from pathlib import Path
@@ -277,3 +278,25 @@ def test_force_inject_reinstalls_without_storing_force(pipx_temp_env, caplog):
 
     metadata = PipxMetadata(paths.ctx.venvs / "pycowsay")
     assert metadata.injected_packages["black"].pip_args == ["--no-cache-dir"]
+
+
+def test_inject_inherits_cooldown(
+    pipx_temp_env: None,
+    root: Path,
+    empty_project: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    find_links: Final[Path] = (
+        root / ".pipx_tests" / "package_cache" / f"{sys.version_info.major}.{sys.version_info.minor}"
+    )
+    pip_args: Final[str] = f"--pip-args=--no-index --find-links={find_links}"
+    assert not run_pipx_cli(["install", "--cooldown", "7", pip_args, PKG["pycowsay"]["spec"]])
+    caplog.clear()
+
+    assert not run_pipx_cli(["inject", "pycowsay", pip_args, str(empty_project)])
+
+    metadata: Final[PipxMetadata] = PipxMetadata(paths.ctx.venvs / "pycowsay")
+    assert (
+        "--uploaded-prior-to P7D" in caplog.text,
+        metadata.injected_packages["empty-project"].cooldown_days,
+    ) == (True, 7)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -9,17 +9,19 @@ from typing import TYPE_CHECKING, Final
 from unittest import mock
 
 import pytest
+from pytest_mock import MockerFixture
 
 from helpers import app_name, run_pipx_cli, skip_if_windows, unwrap_log_text
 from package_info import PKG
 from pipx import paths, shared_libs
+from pipx.backends import Backend
 from pipx.constants import EXIT_CODE_OK
 from pipx.pipx_metadata_file import PackageInfo, PipxMetadata
 from pipx.util import PipxError
 from pipx.venv import Venv
 
 if TYPE_CHECKING:
-    from pytest_mock import MockerFixture
+    from unittest.mock import MagicMock
 
 TEST_DATA_PATH = "./testdata/test_package_specifier"
 
@@ -201,16 +203,60 @@ def test_install_from_pylock(
 ) -> None:
     if backend == "uv" and shutil.which("uv") is None:
         pytest.skip("uv is not installed")
-    lock_file = make_pylock("pycowsay", "0.0.0.2")
+    lock_file: Final[Path] = make_pylock("pycowsay", "0.0.0.2")
 
     assert not run_pipx_cli(["install", "--backend", backend, "--lock", str(lock_file), "pycowsay>=0"])
 
-    metadata = PipxMetadata(paths.ctx.venvs / "pycowsay").main_package
+    metadata: Final[PackageInfo] = PipxMetadata(paths.ctx.venvs / "pycowsay").main_package
     assert (
         metadata.package_version,
         metadata.lock_file,
         (paths.ctx.bin_dir / app_name("pycowsay")).exists(),
     ) == ("0.0.0.2", lock_file.resolve(), True)
+
+
+@pytest.mark.parametrize(
+    ("backend", "backend_option"),
+    [
+        pytest.param("pip", "--uploaded-prior-to P7D", id="pip"),
+        pytest.param("uv", "--exclude-newer P7D", id="uv"),
+    ],
+)
+def test_install_cooldown(
+    pipx_temp_env: None,
+    root: Path,
+    caplog: pytest.LogCaptureFixture,
+    backend: str,
+    backend_option: str,
+) -> None:
+    if backend == "uv" and shutil.which("uv") is None:
+        pytest.skip("uv is not installed")
+    find_links: Final[Path] = (
+        root / ".pipx_tests" / "package_cache" / f"{sys.version_info.major}.{sys.version_info.minor}"
+    )
+
+    assert not run_pipx_cli(
+        [
+            "install",
+            "--backend",
+            backend,
+            "--cooldown",
+            "7",
+            f"--pip-args=--no-index --find-links={find_links}",
+            PKG["pycowsay"]["spec"],
+        ]
+    )
+
+    metadata: Final[PackageInfo] = PipxMetadata(paths.ctx.venvs / "pycowsay").main_package
+    assert (backend_option in caplog.text, metadata.cooldown_days) == (True, 7)
+
+
+@pytest.mark.parametrize("value", [pytest.param("-1", id="negative"), pytest.param("invalid", id="not-an-integer")])
+def test_install_rejects_invalid_cooldown(value: str, capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit, match="2"):
+        run_pipx_cli(["install", "--cooldown", value, "pycowsay"])
+
+    assert "--cooldown must be a non-negative integer" in capsys.readouterr().err
 
 
 @pytest.mark.parametrize("editable", [pytest.param(False, id="wheel"), pytest.param(True, id="editable")])
@@ -221,7 +267,7 @@ def test_install_source_from_pylock(
     editable: bool,
 ) -> None:
     project = make_project_with_dependency("pycowsay==0.0.0.2")
-    lock_file = make_pylock("pycowsay", "0.0.0.2")
+    lock_file: Final[Path] = make_pylock("pycowsay", "0.0.0.2")
 
     assert not run_pipx_cli(["install", *(["--editable"] if editable else []), "--lock", str(lock_file), str(project)])
 
@@ -312,7 +358,7 @@ def test_install_reapplies_recorded_pylock(
 
     assert not run_pipx_cli(command)
 
-    metadata = PipxMetadata(paths.ctx.venvs / "pycowsay").main_package
+    metadata: Final[PackageInfo] = PipxMetadata(paths.ctx.venvs / "pycowsay").main_package
     assert (marker.exists(), metadata.package_version, metadata.lock_file) == (
         False,
         "0.0.0.2",
@@ -359,6 +405,25 @@ def test_install_upgrade_skips_pylock(
     ) == (True, "0.0.0.2", lock_file.resolve())
 
 
+def test_install_rejects_cooldown_for_recorded_pylock(
+    pipx_temp_env: None,
+    make_pylock: Callable[[str, str], Path],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    lock_file: Final[Path] = make_pylock("pycowsay", "0.0.0.2")
+    assert not run_pipx_cli(["install", "--lock", str(lock_file), "pycowsay"])
+    capsys.readouterr()
+
+    assert run_pipx_cli(["install", "--force", "--cooldown", "7", "pycowsay"])
+
+    metadata: Final[PackageInfo] = PipxMetadata(paths.ctx.venvs / "pycowsay").main_package
+    assert (
+        "--cooldown cannot modify a locked environment" in unwrap_log_text(capsys.readouterr().err),
+        metadata.package_version,
+        metadata.lock_file,
+    ) == (True, "0.0.0.2", lock_file.resolve())
+
+
 @pytest.mark.parametrize(
     ("package_args", "lock_name", "lock_exists", "expected_error"),
     [
@@ -376,6 +441,13 @@ def test_install_upgrade_skips_pylock(
             True,
             "--lock cannot be combined with --upgrade",
             id="upgrade",
+        ),
+        pytest.param(
+            ["--cooldown", "7", "pycowsay"],
+            "pylock.test.toml",
+            True,
+            "--lock cannot be combined with --cooldown",
+            id="cooldown",
         ),
         pytest.param(["pycowsay"], "lock.toml", True, "Lock files must be named", id="name"),
         pytest.param(["pycowsay"], "pylock.missing.toml", False, "Lock file does not exist", id="missing"),
@@ -844,27 +916,23 @@ def test_pip_args_forwarded_to_package_name_determination(pipx_temp_env, capsys)
     assert "Cannot determine package name from spec" not in captured.err
 
 
-def test_package_name_determination_preserves_install_error(monkeypatch):
-    class FailingBackend:
-        def install(self, **kwargs):
-            return subprocess.CompletedProcess(
-                ["pip", "install", "requires-newer-python"],
-                1,
-                stdout="",
-                stderr="ERROR: Package 'requires-newer-python' requires a different Python\n",
-            )
-
-    def no_installed_packages():
-        return set()
-
-    venv = Venv(Path("requires-newer-python-venv"))
-    monkeypatch.setattr(venv, "_backend", FailingBackend())
-    monkeypatch.setattr(venv, "list_installed_packages", no_installed_packages)
+def test_package_name_determination_preserves_install_error(mocker: MockerFixture) -> None:
+    venv: Final[Venv] = Venv(Path("requires-newer-python-venv"))
+    backend: Final[MagicMock] = mocker.create_autospec(Backend, instance=True)
+    backend.cooldown_args.return_value = []
+    backend.install.return_value = subprocess.CompletedProcess(
+        ["pip", "install", "requires-newer-python"],
+        1,
+        stdout="",
+        stderr="ERROR: Package 'requires-newer-python' requires a different Python\n",
+    )
+    mocker.patch.object(venv, "_backend", backend)
+    mocker.patch.object(venv, "list_installed_packages", return_value=set())
 
     with pytest.raises(PipxError) as excinfo:
         venv.install_package_no_deps("requires-newer-python", [])
 
-    error = str(excinfo.value)
+    error: Final[str] = str(excinfo.value)
     assert "requires a different Python" in error
     assert "Cannot determine package name from spec" not in error
 
@@ -1025,6 +1093,33 @@ def test_install_multiple_packages_preserves_editable_for_local_package(pipx_tem
 def test_preinstall(pipx_temp_env, caplog):
     assert not run_pipx_cli(["install", "--preinstall", "black", "nox"])
     assert "black" in caplog.text
+
+
+def test_preinstall_cooldown(
+    pipx_temp_env: None,
+    root: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    find_links: Final[Path] = (
+        root / ".pipx_tests" / "package_cache" / f"{sys.version_info.major}.{sys.version_info.minor}"
+    )
+
+    assert not run_pipx_cli(
+        [
+            "install",
+            "--preinstall",
+            PKG["black"]["spec"],
+            "--cooldown",
+            "7",
+            f"--pip-args=--no-index --find-links={find_links}",
+            PKG["nox"]["spec"],
+        ]
+    )
+
+    assert (
+        caplog.text.count("--uploaded-prior-to P7D"),
+        PipxMetadata(paths.ctx.venvs / "nox").main_package.cooldown_days,
+    ) == (2, 7)
 
 
 def test_preinstall_multiple(pipx_temp_env, caplog):

--- a/tests/test_install_all.py
+++ b/tests/test_install_all.py
@@ -1,45 +1,69 @@
 import json
+import sys
 from collections.abc import Callable
 from pathlib import Path
+from typing import Final
 
 import pytest
 
 from helpers import run_pipx_cli
+from package_info import PKG
 from pipx import paths
+from pipx.pipx_metadata_file import PipxMetadata
 
 
+@pytest.mark.parametrize(
+    ("install_all_args", "expected_cooldown"),
+    [
+        pytest.param([], 7, id="stored"),
+        pytest.param(["--cooldown", "0"], 0, id="override"),
+    ],
+)
 def test_install_all(
     pipx_temp_env: None,
+    root: Path,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
     make_pylock: Callable[[str, str], Path],
+    install_all_args: list[str],
+    expected_cooldown: int,
 ) -> None:
-    lock_file = make_pylock("pycowsay", "0.0.0.2")
+    find_links: Final[Path] = (
+        root / ".pipx_tests" / "package_cache" / f"{sys.version_info.major}.{sys.version_info.minor}"
+    )
+    pip_args: Final[str] = f"--pip-args=--no-index --find-links={find_links}"
+    lock_file: Final[Path] = make_pylock("pycowsay", "0.0.0.2")
     assert not run_pipx_cli(["install", "--app", "pycowsay", "--lock", str(lock_file), "pycowsay"])
-    assert not run_pipx_cli(["install", "black"])
-    assert not run_pipx_cli(["inject", "black", "pycowsay"])
+    assert not run_pipx_cli(["install", "--cooldown", "7", pip_args, PKG["black"]["spec"]])
+    assert not run_pipx_cli(["inject", "black", pip_args, "pycowsay"])
     capsys.readouterr()
 
     assert not run_pipx_cli(["list", "--json"])
-    pipx_list_path = tmp_path / "pipx_list.json"
+    pipx_list_path: Final[Path] = tmp_path / "pipx_list.json"
     pipx_list_path.write_text(capsys.readouterr().out, encoding="utf-8")
 
     assert not run_pipx_cli(["uninstall-all"])
-    assert not run_pipx_cli(["install-all", str(pipx_list_path)])
+    assert not run_pipx_cli(["install-all", *install_all_args, pip_args, str(pipx_list_path)])
     capsys.readouterr()
     assert not run_pipx_cli(["list", "--json"])
 
-    installed = json.loads(capsys.readouterr().out)["venvs"]
+    installed_names: Final[list[str]] = sorted(json.loads(capsys.readouterr().out)["venvs"])
+    black_metadata: Final[PipxMetadata] = PipxMetadata(paths.ctx.venvs / "black")
+    pycowsay_metadata: Final[PipxMetadata] = PipxMetadata(paths.ctx.venvs / "pycowsay")
     assert (
-        sorted(installed),
-        sorted(installed["black"]["metadata"]["injected_packages"]),
-        installed["pycowsay"]["metadata"]["main_package"]["expected_apps"],
-        installed["pycowsay"]["metadata"]["main_package"]["lock_file"],
+        installed_names,
+        sorted(black_metadata.injected_packages),
+        pycowsay_metadata.main_package.expected_apps,
+        pycowsay_metadata.main_package.lock_file,
+        black_metadata.main_package.cooldown_days,
+        black_metadata.injected_packages["pycowsay"].cooldown_days,
     ) == (
         ["black", "pycowsay"],
         ["pycowsay"],
         ["pycowsay"],
-        {"__Path__": str(lock_file.resolve()), "__type__": "Path"},
+        lock_file.resolve(),
+        expected_cooldown,
+        expected_cooldown,
     )
 
 

--- a/tests/test_pipx_metadata_file.py
+++ b/tests/test_pipx_metadata_file.py
@@ -142,11 +142,25 @@ def test_pipx_metadata_file_defaults_included_apps_from_version_0_9(tmp_path: Pa
     metadata.main_package = TEST_PACKAGE1
     (venv_dir / PIPX_INFO_FILENAME).write_text(
         json.dumps(metadata.to_dict(), cls=JsonEncoderHandlesPath)
-        .replace('"pipx_metadata_version": "0.10"', '"pipx_metadata_version": "0.9"')
+        .replace('"pipx_metadata_version": "0.11"', '"pipx_metadata_version": "0.9"')
         .replace('"include_apps_from": [], ', "")
     )
 
     assert PipxMetadata(venv_dir).main_package.include_apps_from == []
+
+
+def test_pipx_metadata_file_defaults_cooldown_from_version_0_10(tmp_path: Path) -> None:
+    venv_dir: Final[Path] = tmp_path / "venv"
+    venv_dir.mkdir()
+    metadata: Final[PipxMetadata] = PipxMetadata(venv_dir, read=False)
+    metadata.main_package = TEST_PACKAGE1
+    (venv_dir / PIPX_INFO_FILENAME).write_text(
+        json.dumps(metadata.to_dict(), cls=JsonEncoderHandlesPath)
+        .replace('"pipx_metadata_version": "0.11"', '"pipx_metadata_version": "0.10"')
+        .replace('"cooldown_days": null, ', "")
+    )
+
+    assert PipxMetadata(venv_dir).main_package.cooldown_days is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_reinstall.py
+++ b/tests/test_reinstall.py
@@ -17,6 +17,31 @@ def test_reinstall(pipx_temp_env, capsys):
     assert not run_pipx_cli(["reinstall", "--python", sys.executable, "pycowsay"])
 
 
+def test_reinstall_preserves_cooldowns(
+    pipx_temp_env: None,
+    root: Path,
+    empty_project: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    find_links: Final[Path] = (
+        root / ".pipx_tests" / "package_cache" / f"{sys.version_info.major}.{sys.version_info.minor}"
+    )
+    pip_args: Final[str] = f"--pip-args=--no-index --find-links={find_links}"
+    assert not run_pipx_cli(["install", "--cooldown", "7", pip_args, "pycowsay"])
+    assert not run_pipx_cli(["inject", "--cooldown", "5", pip_args, "pycowsay", str(empty_project)])
+    caplog.clear()
+
+    assert not run_pipx_cli(["reinstall", "--python", sys.executable, "pycowsay"])
+
+    metadata: Final[PipxMetadata] = PipxMetadata(paths.ctx.venvs / "pycowsay")
+    assert (
+        "--uploaded-prior-to P7D" in caplog.text,
+        "--uploaded-prior-to P5D" in caplog.text,
+        metadata.main_package.cooldown_days,
+        metadata.injected_packages["empty-project"].cooldown_days,
+    ) == (True, True, 7, 5)
+
+
 def test_reinstall_pylock_restores_source_after_build_failure(
     pipx_temp_env: None,
     make_pylock: Callable[[str, str], Path],

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import textwrap
 from pathlib import Path
+from typing import Final
 from unittest import mock
 
 import pytest
@@ -74,6 +75,36 @@ def test_run_does_not_mark_cache_as_installation(pipx_temp_env: None, mocker: Mo
 
     venv_dir = next(path for path in paths.ctx.venv_cache.iterdir() if path.is_dir())
     assert PipxMetadata(venv_dir).environment is None
+
+
+def test_run_cooldown_separates_cache(
+    pipx_temp_env: None,
+    root: Path,
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mocker.patch("os.execvpe", autospec=True, side_effect=execvpe_mock)
+    find_links: Final[Path] = (
+        root / ".pipx_tests" / "package_cache" / f"{sys.version_info.major}.{sys.version_info.minor}"
+    )
+    pip_args: Final[str] = f"--pip-args=--no-index --find-links={find_links}"
+
+    run_pipx_cli_exit(
+        ["run", "--backend", "pip", "--cooldown", "7", pip_args, PKG["pycowsay"]["spec"], "hello"],
+        assert_exit=0,
+    )
+    cached_venvs: Final[set[Path]] = {path for path in paths.ctx.venv_cache.iterdir() if path.is_dir()}
+    caplog.clear()
+
+    run_pipx_cli_exit(
+        ["run", "--backend", "pip", "--cooldown", "0", pip_args, PKG["pycowsay"]["spec"], "hello"],
+        assert_exit=0,
+    )
+
+    assert (
+        len({path for path in paths.ctx.venv_cache.iterdir() if path.is_dir()}),
+        "--uploaded-prior-to" in caplog.text,
+    ) == (len(cached_venvs) + 1, False)
 
 
 @mock.patch("os.execvpe", new=execvpe_mock)
@@ -373,6 +404,49 @@ def test_run_with_requirements_and_cli_with_pip_backend(pipx_temp_env, tmp_path)
     assert not out.exists()
 
 
+def test_run_script_cooldown(
+    pipx_temp_env: None,
+    root: Path,
+    tmp_path: Path,
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mocker.patch("os.execvpe", autospec=True, side_effect=execvpe_mock)
+    output: Final[Path] = tmp_path / "output.txt"
+    script: Final[Path] = tmp_path / "test.py"
+    script.write_text(
+        textwrap.dedent(
+            f"""
+            # /// script
+            # dependencies = ["pycowsay==0.0.0.2"]
+            # ///
+
+            from pathlib import Path
+            Path({str(output)!r}).write_text("done")
+            """
+        ).strip(),
+        encoding="utf-8",
+    )
+    find_links: Final[Path] = (
+        root / ".pipx_tests" / "package_cache" / f"{sys.version_info.major}.{sys.version_info.minor}"
+    )
+
+    run_pipx_cli_exit(
+        [
+            "run",
+            "--backend",
+            "pip",
+            "--cooldown",
+            "7",
+            f"--pip-args=--no-index --find-links={find_links}",
+            script.as_uri(),
+        ],
+        assert_exit=0,
+    )
+
+    assert (output.read_text(encoding="utf-8"), "--uploaded-prior-to P7D" in caplog.text) == ("done", True)
+
+
 @mock.patch("os.execvpe", new=execvpe_mock)
 def test_run_with_requirements_old(caplog, pipx_temp_env, tmp_path):
     script = tmp_path / "test.py"
@@ -623,13 +697,16 @@ def test_run_shared_lib_as_app(pipx_temp_env, monkeypatch, capfd):
 
 
 @mock.patch("os.execvpe", new=execvpe_mock)
-def test_run_local_path_entry_point(pipx_temp_env, caplog, root):
-    empty_project_path = (Path("testdata") / "empty_project").as_posix()
-    os.chdir(root)
-
+def test_run_local_path_entry_point(
+    pipx_temp_env: None,
+    caplog: pytest.LogCaptureFixture,
+    empty_project: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(empty_project.parent)
     caplog.set_level(logging.INFO)
 
-    run_pipx_cli_exit(["run", empty_project_path])
+    run_pipx_cli_exit(["run", f".{os.sep}{empty_project.name}"])
 
     assert "Using discovered entry point for 'pipx run'" in caplog.text
 
@@ -671,6 +748,41 @@ def test_run_with(capsys):
     run_pipx_cli_exit(["run", "--with", "black", "pycowsay", "--help"])
     captured = capsys.readouterr()
     assert "injected package black into venv pycowsay" in captured.out
+
+
+def test_run_with_cooldown(
+    pipx_temp_env: None,
+    root: Path,
+    empty_project: Path,
+    mocker: MockerFixture,
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mocker.patch("os.execvpe", autospec=True, side_effect=execvpe_mock)
+    find_links: Final[Path] = (
+        root / ".pipx_tests" / "package_cache" / f"{sys.version_info.major}.{sys.version_info.minor}"
+    )
+
+    run_pipx_cli_exit(
+        [
+            "run",
+            "--backend",
+            "pip",
+            "--cooldown",
+            "7",
+            "--with",
+            str(empty_project),
+            f"--pip-args=--no-index --find-links={find_links}",
+            PKG["pycowsay"]["spec"],
+            "hello",
+        ],
+        assert_exit=0,
+    )
+
+    assert (
+        "injected package empty-project into venv" in capsys.readouterr().out,
+        "--uploaded-prior-to P7D" in caplog.text,
+    ) == (True, True)
 
 
 @mock.patch("os.execvpe", new=execvpe_mock)

--- a/tests/test_run_uv.py
+++ b/tests/test_run_uv.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 import pytest
 
@@ -9,53 +9,77 @@ from pipx.commands.run_uv import run_script_via_uv_run, run_via_uv_tool_run
 from pipx.util import PipxError
 
 if TYPE_CHECKING:
+    from unittest.mock import MagicMock
+
     from pytest_mock import MockerFixture
 
 
 @pytest.fixture
 def fake_uv(mocker: MockerFixture) -> Path:
-    binary = Path("/opt/uv/bin/uv")
+    binary: Final[Path] = Path("/opt/uv/bin/uv")
     mocker.patch("pipx.commands.run_uv.resolve_uv_binary", return_value=binary)
     return binary
 
 
-def test_run_via_uv_tool_run_basic(mocker: MockerFixture, fake_uv: Path) -> None:
-    exec_mock = mocker.patch("pipx.commands.run_uv.exec_app")
+@pytest.mark.parametrize(
+    ("cooldown_days", "cooldown_args"),
+    [
+        pytest.param(None, [], id="unset"),
+        pytest.param(7, ["--exclude-newer", "P7D"], id="seven-days"),
+    ],
+)
+def test_run_via_uv_tool_run_basic(
+    exec_mock: MagicMock,
+    fake_uv: Path,
+    mocker: MockerFixture,
+    cooldown_days: int | None,
+    cooldown_args: list[str],
+) -> None:
     mocker.patch("pipx.commands.run_uv.which", return_value=None)
-    run_via_uv_tool_run(
-        app="black",
-        package_or_url="black",
-        dependencies=[],
-        app_args=["--check"],
-        python="python3.12",
-        pip_args=[],
-        venv_args=[],
-        use_cache=True,
-        verbose=False,
-    )
-    # ``mocker.patch`` keeps ``exec_app``'s ``NoReturn`` annotation, so pre-commit
-    # mypy flags everything below as unreachable; ``unused-ignore`` covers the
-    # local-checker case where the unreachable detection doesn't fire.
-    (cmd,), _ = exec_mock.call_args  # type: ignore[unreachable, unused-ignore]
-    assert cmd == [str(fake_uv), "tool", "run", "--python", "python3.12", "black", "--check"]
+    with pytest.raises(RuntimeError, match="exec"):
+        run_via_uv_tool_run(
+            app="black",
+            package_or_url="black",
+            dependencies=[],
+            app_args=["--check"],
+            python="python3.12",
+            pip_args=[],
+            venv_args=[],
+            use_cache=True,
+            verbose=False,
+            cooldown_days=cooldown_days,
+        )
+    assert exec_mock.call_args.args[0] == [
+        str(fake_uv),
+        "tool",
+        "run",
+        "--python",
+        "python3.12",
+        *cooldown_args,
+        "black",
+        "--check",
+    ]
 
 
-def test_run_via_uv_tool_run_threads_spec_and_with(mocker: MockerFixture, fake_uv: Path) -> None:
-    exec_mock = mocker.patch("pipx.commands.run_uv.exec_app")
+def test_run_via_uv_tool_run_threads_spec_and_with(
+    exec_mock: MagicMock,
+    fake_uv: Path,
+    mocker: MockerFixture,
+) -> None:
     mocker.patch("pipx.commands.run_uv.which", return_value=None)
-    run_via_uv_tool_run(
-        app="rope",
-        package_or_url="git+https://example.com/rope.git",
-        dependencies=["rich", "click"],
-        app_args=["--version"],
-        python="python3.12",
-        pip_args=["--index-url", "https://example.com/simple", "--pre"],
-        venv_args=[],
-        use_cache=False,
-        verbose=True,
-    )
-    (cmd,), _ = exec_mock.call_args  # type: ignore[unreachable, unused-ignore]
-    assert cmd == [
+    with pytest.raises(RuntimeError, match="exec"):
+        run_via_uv_tool_run(
+            app="rope",
+            package_or_url="git+https://example.com/rope.git",
+            dependencies=["rich", "click"],
+            app_args=["--version"],
+            python="python3.12",
+            pip_args=["--index-url", "https://example.com/simple", "--pre"],
+            venv_args=[],
+            use_cache=False,
+            verbose=True,
+        )
+    assert exec_mock.call_args.args[0] == [
         str(fake_uv),
         "tool",
         "run",
@@ -77,39 +101,64 @@ def test_run_via_uv_tool_run_threads_spec_and_with(mocker: MockerFixture, fake_u
     ]
 
 
-def test_run_via_uv_tool_run_omits_from_when_app_matches_spec(mocker: MockerFixture, fake_uv: Path) -> None:
-    exec_mock = mocker.patch("pipx.commands.run_uv.exec_app")
+def test_run_via_uv_tool_run_omits_from_when_app_matches_spec(
+    exec_mock: MagicMock,
+    fake_uv: Path,
+    mocker: MockerFixture,
+) -> None:
     mocker.patch("pipx.commands.run_uv.which", return_value=None)
-    run_via_uv_tool_run(
-        app="black",
-        package_or_url="black",
-        dependencies=[],
-        app_args=[],
-        python="",
-        pip_args=[],
-        venv_args=[],
-        use_cache=True,
-        verbose=False,
-    )
-    (cmd,), _ = exec_mock.call_args  # type: ignore[unreachable, unused-ignore]
-    assert "--from" not in cmd
+    with pytest.raises(RuntimeError, match="exec"):
+        run_via_uv_tool_run(
+            app="black",
+            package_or_url="black",
+            dependencies=[],
+            app_args=[],
+            python="",
+            pip_args=[],
+            venv_args=[],
+            use_cache=True,
+            verbose=False,
+        )
+    assert "--from" not in exec_mock.call_args.args[0]
 
 
-def test_run_script_via_uv_run_uses_uv_run_script(mocker: MockerFixture, fake_uv: Path, tmp_path: Path) -> None:
-    exec_mock = mocker.patch("pipx.commands.run_uv.exec_app")
-    script = tmp_path / "demo.py"
+@pytest.mark.parametrize(
+    ("cooldown_days", "cooldown_args"),
+    [
+        pytest.param(None, [], id="unset"),
+        pytest.param(7, ["--exclude-newer", "P7D"], id="seven-days"),
+    ],
+)
+def test_run_script_via_uv_run_uses_uv_run_script(
+    exec_mock: MagicMock,
+    fake_uv: Path,
+    tmp_path: Path,
+    cooldown_days: int | None,
+    cooldown_args: list[str],
+) -> None:
+    script: Final[Path] = tmp_path / "demo.py"
     script.write_text("print('hi')\n")
-    run_script_via_uv_run(
-        script_path=script,
-        app_args=["--quiet"],
-        python="python3.12",
-        pip_args=[],
-        venv_args=[],
-        use_cache=True,
-        verbose=False,
-    )
-    (cmd,), _ = exec_mock.call_args  # type: ignore[unreachable, unused-ignore]
-    assert cmd == [str(fake_uv), "run", "--script", "--python", "python3.12", str(script), "--quiet"]
+    with pytest.raises(RuntimeError, match="exec"):
+        run_script_via_uv_run(
+            script_path=script,
+            app_args=["--quiet"],
+            python="python3.12",
+            pip_args=[],
+            venv_args=[],
+            use_cache=True,
+            verbose=False,
+            cooldown_days=cooldown_days,
+        )
+    assert exec_mock.call_args.args[0] == [
+        str(fake_uv),
+        "run",
+        "--script",
+        "--python",
+        "python3.12",
+        *cooldown_args,
+        str(script),
+        "--quiet",
+    ]
 
 
 def test_run_via_uv_tool_run_rejects_venv_args(mocker: MockerFixture, fake_uv: Path) -> None:
@@ -127,3 +176,10 @@ def test_run_via_uv_tool_run_rejects_venv_args(mocker: MockerFixture, fake_uv: P
             use_cache=True,
             verbose=False,
         )
+
+
+@pytest.fixture
+def exec_mock(mocker: MockerFixture) -> MagicMock:
+    mocked_exec: Final[MagicMock] = mocker.MagicMock(side_effect=RuntimeError("exec"))
+    mocker.patch("pipx.commands.run_uv.exec_app", new=mocked_exec)
+    return mocked_exec

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,3 +1,4 @@
+import sys
 from collections.abc import Callable
 from pathlib import Path
 from typing import Final
@@ -238,6 +239,53 @@ def test_upgrade_pip_args(
         assert arg in metadata.main_package.pip_args
     for arg in unexpected_args:
         assert arg not in metadata.main_package.pip_args
+
+
+@pytest.mark.parametrize(
+    ("command", "expected_options", "expected_cooldowns"),
+    [
+        pytest.param(["upgrade", "--include-injected", "pycowsay"], (True, True), (7, 5), id="stored"),
+        pytest.param(
+            ["upgrade-all", "--include-injected", "--cooldown", "0"],
+            (False, False),
+            (0, 0),
+            id="override-all",
+        ),
+    ],
+)
+def test_upgrade_cooldown(
+    pipx_temp_env: None,
+    root: Path,
+    empty_project: Path,
+    caplog: pytest.LogCaptureFixture,
+    command: list[str],
+    expected_options: tuple[bool, bool],
+    expected_cooldowns: tuple[int, int],
+) -> None:
+    find_links: Final[Path] = (
+        root / ".pipx_tests" / "package_cache" / f"{sys.version_info.major}.{sys.version_info.minor}"
+    )
+    pip_args: Final[str] = f"--pip-args=--no-index --find-links={find_links}"
+    assert not run_pipx_cli(
+        [
+            "install",
+            "--cooldown",
+            "7",
+            pip_args,
+            PKG["pycowsay"]["spec"],
+        ]
+    )
+    assert not run_pipx_cli(["inject", "--cooldown", "5", pip_args, "pycowsay", str(empty_project)])
+    caplog.clear()
+
+    assert not run_pipx_cli(command)
+
+    metadata: Final[PipxMetadata] = PipxMetadata(paths.ctx.venvs / "pycowsay")
+    assert (
+        "--uploaded-prior-to P7D" in caplog.text,
+        "--uploaded-prior-to P5D" in caplog.text,
+        (metadata.main_package.cooldown_days, metadata.injected_packages["empty-project"].cooldown_days),
+    ) == (*expected_options, expected_cooldowns)
 
 
 def test_upgrade_injected_uses_stored_pip_args(pipx_temp_env: None, root: Path) -> None:


### PR DESCRIPTION
`--cooldown DAYS` sets a backend-neutral release-age policy wherever pipx resolves packages. pipx records the value with each installed package. Future resolution reuses it unless the caller overrides it.

pip maps the policy to `--uploaded-prior-to`; uv maps it to `--exclude-newer`. A zero-day value clears the policy. PEP 751 locks remain exact. The uv requirement rises to 0.9.17, which supports relative `--exclude-newer` durations.

Closes #1811
