### PR TITLE
⚡ perf(upgrade): check updates in parallel

### DIFF
--- a/changelog.d/1353.performance.md
+++ b/changelog.d/1353.performance.md
@@ -1,0 +1,1 @@
+Check upgrades in parallel and skip installs for current packages.

--- a/src/pipx/commands/outdated.py
+++ b/src/pipx/commands/outdated.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from functools import partial
+from typing import TYPE_CHECKING, Final
 
 from packaging.utils import canonicalize_name
 
@@ -12,51 +14,179 @@ from pipx.util import PipxError
 from pipx.venv import Venv, VenvContainer
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Collection, Sequence
+    from pathlib import Path
+
     from pipx.pipx_metadata_file import PackageInfo
 
+_MAX_OUTDATED_WORKERS: Final[int] = 8
 
-def list_outdated(venv_container: VenvContainer, *, include_injected: bool) -> OperationResult[OutdatedData]:
-    packages_checked = 0
-    failures: list[_FailedEnvironment] = []
-    messages: list[OutputMessage] = []
-    outdated_packages: list[_OutdatedPackage] = []
-    skipped: list[_SkippedPackage] = []
-    for venv_dir in venv_container.iter_locked_venv_dirs(venv_container.iter_venv_dirs()):
-        venv = Venv(venv_dir)
-        if not venv.package_metadata:
-            error = "Missing internal pipx metadata."
-            failures.append(_FailedEnvironment(venv.name, error))
-            messages.append(OutputMessage(f"{venv.name}: {error}", stream=OutputStream.STDERR, level=OutputLevel.ERROR))
+
+def list_outdated(
+    venv_container: VenvContainer,
+    *,
+    include_injected: bool,
+) -> OperationResult[OutdatedData]:
+    data: Final[OutdatedData] = inspect_outdated(venv_container, include_injected=include_injected)
+    messages: Final[list[OutputMessage]] = [
+        OutputMessage(
+            f"{failure.environment}: {failure.error}",
+            stream=OutputStream.STDERR,
+            level=OutputLevel.ERROR,
+        )
+        for failure in data.failures
+    ]
+    messages.extend(_package_message(package) for package in data.packages)
+    if not data.packages and not data.failures:
+        messages.append(
+            OutputMessage(
+                "pipx found no available upgrades."
+                if data.packages_checked
+                else "pipx found no index packages to check."
+            )
+        )
+    return OperationResult(
+        command="list",
+        data=data,
+        messages=tuple(messages),
+        exit_code=ExitCode(1 if data.failures else 0),
+    )
+
+
+def inspect_outdated(
+    venv_container: VenvContainer,
+    *,
+    include_injected: bool,
+    upgradable_only: bool = False,
+    pip_args: Sequence[str] = (),
+    skip: Collection[str] = (),
+    backend: str | None = None,
+    env_backend: str | None = None,
+) -> OutdatedData:
+    venv_dirs: Final[tuple[Path, ...]] = tuple(
+        sorted(venv_dir for venv_dir in venv_container.iter_venv_dirs() if venv_dir.name not in skip)
+    )
+    checks: Final[tuple[_EnvironmentOutdated, ...]] = _list_environments_outdated(
+        venv_container,
+        venv_dirs,
+        include_injected=include_injected,
+        upgradable_only=upgradable_only,
+        pip_args=pip_args,
+        backend=backend,
+        env_backend=env_backend,
+    )
+    packages: Final[tuple[_OutdatedPackage, ...]] = tuple(
+        sorted(
+            (package for check in checks for package in check.packages),
+            key=lambda package: (package.environment, package.package),
+        )
+    )
+    failures: Final[tuple[_FailedEnvironment, ...]] = tuple(
+        sorted(
+            (failure for check in checks for failure in check.failures),
+            key=lambda failure: (failure.environment, failure.error),
+        )
+    )
+    skipped: Final[tuple[_SkippedPackage, ...]] = tuple(
+        sorted(
+            (package for check in checks for package in check.skipped),
+            key=lambda package: (package.environment, package.package),
+        )
+    )
+    return OutdatedData(
+        packages_checked=sum(check.packages_checked for check in checks),
+        packages=packages,
+        skipped=skipped,
+        failures=failures,
+    )
+
+
+def _list_environments_outdated(
+    venv_container: VenvContainer,
+    venv_dirs: tuple[Path, ...],
+    *,
+    include_injected: bool,
+    upgradable_only: bool,
+    pip_args: Sequence[str],
+    backend: str | None,
+    env_backend: str | None,
+) -> tuple[_EnvironmentOutdated, ...]:
+    if not venv_dirs:
+        return ()
+    check: Final[Callable[[Path], _EnvironmentOutdated]] = partial(
+        _list_environment_outdated,
+        venv_container,
+        include_injected=include_injected,
+        upgradable_only=upgradable_only,
+        pip_args=pip_args,
+        backend=backend,
+        env_backend=env_backend,
+    )
+    if len(venv_dirs) == 1:
+        return (check(venv_dirs[0]),)
+    with ThreadPoolExecutor(max_workers=min(_MAX_OUTDATED_WORKERS, len(venv_dirs))) as executor:
+        return tuple(executor.map(check, venv_dirs))
+
+
+def _list_environment_outdated(
+    venv_container: VenvContainer,
+    venv_dir: Path,
+    *,
+    include_injected: bool,
+    upgradable_only: bool,
+    pip_args: Sequence[str],
+    backend: str | None,
+    env_backend: str | None,
+) -> _EnvironmentOutdated:
+    with venv_container.venv_lock(venv_dir):
+        if not venv_dir.is_dir():
+            return _EnvironmentOutdated()
+        return _list_venv_outdated(
+            Venv(venv_dir, backend=backend, env_backend=env_backend),
+            include_injected=include_injected,
+            upgradable_only=upgradable_only,
+            pip_args=pip_args,
+        )
+
+
+def _list_venv_outdated(
+    venv: Venv,
+    *,
+    include_injected: bool,
+    upgradable_only: bool,
+    pip_args: Sequence[str],
+) -> _EnvironmentOutdated:
+    if not venv.package_metadata:
+        return _EnvironmentOutdated(failures=(_FailedEnvironment(venv.name, "Missing internal pipx metadata."),))
+    if upgradable_only and venv.pipx_metadata.main_package.lock_file is not None:
+        return _EnvironmentOutdated()
+
+    failures: Final[list[_FailedEnvironment]] = []
+    packages: Final[list[_OutdatedPackage]] = []
+    packages_by_index: Final[dict[tuple[str, ...], dict[str, PackageInfo]]] = {}
+    skipped: Final[list[_SkippedPackage]] = []
+    for package_name, package_info in venv.package_metadata.items():
+        if package_name != venv.main_package_name and not include_injected:
             continue
-        packages_by_index: dict[tuple[str, ...], dict[str, PackageInfo]] = {}
-        for package_name, package_info in venv.package_metadata.items():
-            if package_name != venv.main_package_name and not include_injected:
-                continue
-            display_name = f"{package_name}{package_info.suffix}"
-            if package_info.package_or_url is None:
-                error = f"Package {display_name} has corrupt pipx metadata."
-                failures.append(_FailedEnvironment(venv.name, error))
-                messages.append(
-                    OutputMessage(f"{venv.name}: {error}", stream=OutputStream.STDERR, level=OutputLevel.ERROR)
-                )
-                continue
-            if "--editable" in package_info.pip_args:
-                skipped.append(_SkippedPackage(venv.name, display_name, "editable"))
-                continue
-            if valid_pypi_name(package_info.package_or_url) is None:
-                skipped.append(_SkippedPackage(venv.name, display_name, "non-index"))
-                continue
-            packages_by_index.setdefault(tuple(extract_index_options(package_info.pip_args)), {})[
+        display_name: str = f"{package_name}{package_info.suffix}"
+        if package_info.package_or_url is None:
+            failures.append(_FailedEnvironment(venv.name, f"Package {display_name} has corrupt pipx metadata."))
+        elif upgradable_only and package_info.pinned:
+            continue
+        elif "--editable" in package_info.pip_args:
+            skipped.append(_SkippedPackage(venv.name, display_name, "editable"))
+        elif valid_pypi_name(package_info.package_or_url) is None:
+            skipped.append(_SkippedPackage(venv.name, display_name, "non-index"))
+        else:
+            packages_by_index.setdefault(tuple(extract_index_options(list(pip_args) or package_info.pip_args)), {})[
                 canonicalize_name(package_name)
             ] = package_info
 
-        for index_args, package_infos in packages_by_index.items():
-            packages_checked += len(package_infos)
-            try:
-                for package in venv.list_outdated_packages(list(index_args)):
-                    if (managed_package := package_infos.get(canonicalize_name(package.name))) is None:
-                        continue
-                    outdated_packages.append(
+    for index_args, package_infos in packages_by_index.items():
+        try:
+            for package in venv.list_outdated_packages(list(index_args)):
+                if (managed_package := package_infos.get(canonicalize_name(package.name))) is not None:
+                    packages.append(
                         _OutdatedPackage(
                             environment=venv.name,
                             package=f"{managed_package.package}{managed_package.suffix}",
@@ -66,35 +196,20 @@ def list_outdated(venv_container: VenvContainer, *, include_injected: bool) -> O
                             pinned=managed_package.pinned,
                         )
                     )
-            except PipxError as error:
-                failures.append(_FailedEnvironment(venv.name, str(error)))
-                messages.append(
-                    OutputMessage(f"{venv.name}: {error}", stream=OutputStream.STDERR, level=OutputLevel.ERROR)
-                )
-
-    packages = tuple(sorted(outdated_packages, key=lambda package: (package.environment, package.package)))
-    messages.extend(_package_message(package) for package in packages)
-    if not packages and not failures:
-        messages.append(
-            OutputMessage(
-                "pipx found no available upgrades." if packages_checked else "pipx found no index packages to check."
-            )
-        )
-    return OperationResult(
-        command="list",
-        data=OutdatedData(
-            packages_checked=packages_checked,
-            packages=packages,
-            skipped=tuple(sorted(skipped, key=lambda package: (package.environment, package.package))),
-            failures=tuple(sorted(failures, key=lambda failure: (failure.environment, failure.error))),
-        ),
-        messages=tuple(messages),
-        exit_code=ExitCode(1 if failures else 0),
+        except PipxError as error:
+            failures.append(_FailedEnvironment(venv.name, str(error)))
+    return _EnvironmentOutdated(
+        sum(len(package_infos) for package_infos in packages_by_index.values()),
+        tuple(packages),
+        tuple(skipped),
+        tuple(failures),
     )
 
 
 def _package_message(package: _OutdatedPackage) -> OutputMessage:
-    subject = f"{package.package} (injected in {package.environment})" if package.injected else package.package
+    subject: Final[str] = (
+        f"{package.package} (injected in {package.environment})" if package.injected else package.package
+    )
     return OutputMessage(
         f"{subject}{' [pinned]' if package.pinned else ''}: {package.version} -> {package.latest_version}"
     )
@@ -124,6 +239,14 @@ class _FailedEnvironment:
 
 
 @dataclass(frozen=True)
+class _EnvironmentOutdated:
+    packages_checked: int = 0
+    packages: tuple[_OutdatedPackage, ...] = ()
+    skipped: tuple[_SkippedPackage, ...] = ()
+    failures: tuple[_FailedEnvironment, ...] = ()
+
+
+@dataclass(frozen=True)
 class OutdatedData(OperationData):
     packages_checked: int
     packages: tuple[_OutdatedPackage, ...]
@@ -133,5 +256,6 @@ class OutdatedData(OperationData):
 
 __all__ = [
     "OutdatedData",
+    "inspect_outdated",
     "list_outdated",
 ]

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -1,16 +1,15 @@
+from __future__ import annotations
+
 import logging
 import os
-from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import Enum
-from pathlib import Path
-from typing import Final
-
-from filelock import BaseFileLock
+from typing import TYPE_CHECKING, Final
 
 from pipx import commands, paths
 from pipx.colors import bold, red
 from pipx.commands.common import expose_package_resources, locked_package_message, validate_expected_apps
+from pipx.commands.outdated import inspect_outdated
 from pipx.commands.transaction import preserve_venv
 from pipx.constants import EXIT_CODE_OK, ExitCode
 from pipx.emojis import sleep
@@ -20,7 +19,443 @@ from pipx.shared_libs import shared_libs
 from pipx.util import PipxError, pipx_wrap
 from pipx.venv import Venv, VenvContainer
 
+if TYPE_CHECKING:
+    from collections.abc import Collection, Sequence
+    from pathlib import Path
+
+    from filelock import BaseFileLock
+
+    from pipx.commands.outdated import OutdatedData
+    from pipx.pipx_metadata_file import PackageInfo
+
 _LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
+
+
+def upgrade(
+    venv_dirs: dict[str, Path],
+    python: str | None,
+    pip_args: list[str],
+    venv_args: list[str],
+    verbose: bool,
+    *,
+    include_injected: bool,
+    force: bool,
+    install: bool,
+    python_flag_passed: bool = False,
+    backend: str | None = None,
+    env_backend: str | None = None,
+    cooldown_days: int | None = None,
+) -> OperationResult[UpgradeData]:
+    results: Final[list[PackageUpgradeResult]] = []
+
+    for venv_dir in venv_dirs.values():
+        with VenvContainer(venv_dir.parent).venv_lock(venv_dir) as venv_lock:
+            results.extend(
+                _upgrade_venv(
+                    venv_dir,
+                    pip_args,
+                    verbose,
+                    include_injected=include_injected,
+                    force=force,
+                    install=install,
+                    venv_args=venv_args,
+                    python=python,
+                    python_flag_passed=python_flag_passed,
+                    backend=backend,
+                    env_backend=env_backend,
+                    venv_lock=venv_lock,
+                    cooldown_days=cooldown_days,
+                )
+            )
+
+    package_results: Final[tuple[PackageUpgradeResult, ...]] = tuple(results)
+    return OperationResult(
+        command="upgrade",
+        data=UpgradeData(packages=package_results, skipped=(), failures=()),
+        messages=tuple(
+            message for result in package_results for message in _package_messages(result, upgrading_all=False)
+        ),
+    )
+
+
+def upgrade_all(
+    venv_container: VenvContainer,
+    verbose: bool,
+    *,
+    pip_args: list[str],
+    include_injected: bool,
+    skip: Sequence[str],
+    force: bool,
+    python_flag_passed: bool = False,
+    backend: str | None = None,
+    env_backend: str | None = None,
+    cooldown_days: int | None = None,
+) -> OperationResult[UpgradeData]:
+    outdated: Final[OutdatedData] = inspect_outdated(
+        venv_container,
+        include_injected=include_injected,
+        upgradable_only=True,
+        pip_args=pip_args,
+        skip=skip,
+        backend=backend,
+        env_backend=env_backend,
+    )
+    candidates: Final[set[tuple[str, str]]] = {
+        (package.environment, package.package) for package in outdated.packages
+    } | {
+        (package.environment, package.package)
+        for package in outdated.skipped
+        if package.reason in {"editable", "non-index"}
+    }
+    check_failures: Final[dict[str, list[str]]] = {}
+    for failure in outdated.failures:
+        check_failures.setdefault(failure.environment, []).append(failure.error)
+
+    failures: Final[list[FailedUpgrade]] = []
+    messages: Final[list[OutputMessage]] = []
+    results: Final[list[PackageUpgradeResult]] = []
+    skipped: Final[list[SkippedUpgrade]] = []
+
+    for venv_dir in venv_container.iter_venv_dirs():
+        if venv_dir.name in skip:
+            skipped.append(SkippedUpgrade(venv_dir.name, "requested"))
+            continue
+        with venv_container.venv_lock(venv_dir) as venv_lock:
+            venv: Venv = Venv(venv_dir, verbose=verbose, backend=backend, env_backend=env_backend)
+            if "--editable" in venv.pipx_metadata.main_package.pip_args:
+                skipped.append(SkippedUpgrade(venv_dir.name, "editable"))
+                continue
+            try:
+                _validate_venv_for_upgrade(venv_dir, venv)
+                if venv.pipx_metadata.main_package.lock_file is None and (errors := check_failures.get(venv.name)):
+                    raise PipxError("\n".join(errors), wrap_message=False)
+                packages_to_upgrade: set[str] = {
+                    package_name
+                    for package_name, package in venv.package_metadata.items()
+                    if (package_name == venv.main_package_name or include_injected)
+                    and (venv.name, f"{package_name}{package.suffix}") in candidates
+                }
+                package_results: tuple[PackageUpgradeResult, ...] = _upgrade_venv(
+                    venv_dir,
+                    pip_args,
+                    verbose=verbose,
+                    include_injected=include_injected,
+                    force=force,
+                    python_flag_passed=python_flag_passed,
+                    backend=backend,
+                    env_backend=env_backend,
+                    venv=venv,
+                    packages_to_upgrade=packages_to_upgrade,
+                    venv_lock=venv_lock,
+                    cooldown_days=cooldown_days,
+                )
+                results.extend(package_results)
+                for result in package_results:
+                    messages.extend(_package_messages(result, upgrading_all=True))
+            except PipxError as error:
+                failures.append(FailedUpgrade(venv_dir.name, str(error)))
+                messages.append(OutputMessage(str(error), stream=OutputStream.STDERR, level=OutputLevel.ERROR))
+    if not any(result.status is UpgradeStatus.UPGRADED for result in results):
+        messages.append(OutputMessage(f"No packages upgraded after running 'pipx upgrade-all' {sleep}"))
+    if failures:
+        messages.append(
+            OutputMessage(
+                f"The following package(s) failed to upgrade: {','.join(failure.environment for failure in failures)}",
+                stream=OutputStream.STDERR,
+                level=OutputLevel.ERROR,
+            )
+        )
+    return OperationResult(
+        command="upgrade-all",
+        data=UpgradeData(packages=tuple(results), skipped=tuple(skipped), failures=tuple(failures)),
+        messages=tuple(messages),
+        exit_code=ExitCode(1 if failures else 0),
+    )
+
+
+def upgrade_shared(
+    verbose: bool,
+    pip_args: list[str],
+) -> ExitCode:
+    # pip-backed installs use this environment regardless of the installed environments' backends.
+    shared_libs.upgrade(verbose=verbose, pip_args=pip_args, raises=True)
+    return EXIT_CODE_OK
+
+
+def _upgrade_venv(
+    venv_dir: Path,
+    pip_args: list[str],
+    verbose: bool,
+    *,
+    include_injected: bool,
+    force: bool,
+    install: bool = False,
+    venv_args: list[str] | None = None,
+    python: str | None = None,
+    python_flag_passed: bool = False,
+    backend: str | None = None,
+    env_backend: str | None = None,
+    venv: Venv | None = None,
+    packages_to_upgrade: Collection[str] | None = None,
+    venv_lock: BaseFileLock | None = None,
+    cooldown_days: int | None = None,
+) -> tuple[PackageUpgradeResult, ...]:
+    if not venv_dir.is_dir():
+        if install:
+            commands.install(
+                venv_dir=None,
+                venv_args=venv_args or [],
+                package_names=None,
+                package_specs=[str(venv_dir).split(os.path.sep)[-1]],
+                local_bin_dir=paths.ctx.bin_dir,
+                local_man_dir=paths.ctx.man_dir,
+                python=python,
+                pip_args=pip_args,
+                verbose=verbose,
+                force=force,
+                reinstall=False,
+                include_dependencies=False,
+                include_apps_from=(),
+                preinstall_packages=None,
+                python_flag_passed=python_flag_passed,
+                backend=backend,
+                env_backend=env_backend,
+                venv_lock=venv_lock,
+                cooldown_days=cooldown_days,
+            )
+            return ()
+        raise PipxError(
+            f"""
+            Package is not installed. Expected to find {venv_dir!s}, but it
+            does not exist.
+            """
+        )
+
+    if venv_args and not install:
+        _LOGGER.info(f"Ignoring {', '.join(venv_args)} as not combined with --install")
+
+    if python and not install:
+        _LOGGER.info("Ignoring --python as not combined with --install")
+
+    if venv is None:
+        venv = Venv(venv_dir, verbose=verbose, backend=backend, env_backend=env_backend)
+        _validate_venv_for_upgrade(venv_dir, venv)
+
+    main_package: Final[PackageInfo] = venv.pipx_metadata.main_package
+    if main_package.lock_file is not None:
+        return (
+            PackageUpgradeResult(
+                environment=venv.name,
+                package=venv.name,
+                previous_version=main_package.package_version,
+                version=main_package.package_version,
+                status=UpgradeStatus.LOCKED,
+                injected=False,
+                location=str(venv.root),
+            ),
+        )
+
+    main_pip_args: Final[list[str]] = pip_args or main_package.pip_args
+    if packages_to_upgrade is None or packages_to_upgrade:
+        venv.check_upgrade_shared_libs(pip_args=main_pip_args, verbose=verbose)
+
+    with preserve_venv(
+        venv_dir,
+        enabled=(packages_to_upgrade is None or bool(packages_to_upgrade))
+        and any(package.expected_apps for package in venv.package_metadata.values()),
+    ):
+        return _upgrade_packages(
+            venv,
+            main_pip_args,
+            pip_args,
+            include_injected=include_injected,
+            force=force,
+            packages_to_upgrade=packages_to_upgrade,
+            cooldown_days=cooldown_days,
+        )
+
+
+def _validate_venv_for_upgrade(venv_dir: Path, venv: Venv) -> None:
+    if not venv.python_path.is_file():
+        raise PipxError(
+            f"Not upgrading {red(bold(venv_dir.name))}. It has an invalid python interpreter {venv.python_path}.\n"
+            f"This usually happens after a system Python upgrade.\n"
+            f"To fix, execute: pipx reinstall-all",
+            wrap_message=False,
+        )
+
+    if not venv.package_metadata:
+        raise PipxError(
+            f"Not upgrading {red(bold(venv_dir.name))}. It has missing internal pipx metadata.\n"
+            f"It was likely installed using a pipx version before 0.15.0.0.\n"
+            f"Please uninstall and install this package to fix.",
+            wrap_message=False,
+        )
+
+
+def _upgrade_packages(
+    venv: Venv,
+    main_pip_args: list[str],
+    pip_args: list[str],
+    *,
+    include_injected: bool,
+    force: bool,
+    packages_to_upgrade: Collection[str] | None,
+    cooldown_days: int | None,
+) -> tuple[PackageUpgradeResult, ...]:
+    package_names: Final[list[str]] = [venv.main_package_name]
+    if include_injected:
+        package_names.extend(
+            package_name for package_name in venv.package_metadata if package_name != venv.main_package_name
+        )
+
+    selected: Final[set[str]] = (
+        set(package_names) if packages_to_upgrade is None else set(package_names).intersection(packages_to_upgrade)
+    )
+    if cooldown_days is not None:
+        cooldown_packages: Final[tuple[str, ...]] = tuple(
+            package_name
+            for package_name in package_names
+            if package_name not in selected
+            and not venv.package_metadata[package_name].pinned
+            and venv.package_metadata[package_name].cooldown_days != cooldown_days
+        )
+        for package_name in cooldown_packages:
+            updated: PackageInfo = replace(venv.package_metadata[package_name], cooldown_days=cooldown_days)
+            if package_name == venv.main_package_name:
+                venv.pipx_metadata.main_package = updated
+            else:
+                venv.pipx_metadata.injected_packages[package_name] = updated
+        if cooldown_packages:
+            venv.pipx_metadata.write()
+    if selected:
+        venv.upgrade_packaging_libraries(main_pip_args)
+    results: Final[list[PackageUpgradeResult]] = []
+    for package_name in package_names:
+        if package_name in selected:
+            results.append(
+                _upgrade_package(
+                    venv,
+                    package_name,
+                    main_pip_args
+                    if package_name == venv.main_package_name
+                    else pip_args or venv.package_metadata[package_name].pip_args,
+                    is_main_package=package_name == venv.main_package_name,
+                    force=force,
+                    cooldown_days=cooldown_days,
+                )
+            )
+        else:
+            results.append(
+                _package_result(
+                    venv,
+                    package_name,
+                    UpgradeStatus.PINNED if venv.package_metadata[package_name].pinned else UpgradeStatus.UNCHANGED,
+                )
+            )
+
+    return tuple(results)
+
+
+def _upgrade_package(
+    venv: Venv,
+    package_name: str,
+    pip_args: list[str],
+    is_main_package: bool,
+    force: bool,
+    cooldown_days: int | None,
+) -> PackageUpgradeResult:
+    package_metadata = venv.package_metadata[package_name]
+
+    if package_metadata.package_or_url is None:
+        raise PipxError(f"Internal Error: package {package_name} has corrupt pipx metadata.")
+    if package_metadata.pinned:
+        return _package_result(venv, package_name, UpgradeStatus.PINNED)
+
+    old_version: Final[str] = package_metadata.package_version
+
+    venv.upgrade_package(
+        package_name,
+        parse_specifier_for_upgrade(package_metadata.package_or_url),
+        pip_args,
+        include_dependencies=package_metadata.include_dependencies,
+        include_apps_from=package_metadata.include_apps_from,
+        include_apps=package_metadata.include_apps,
+        is_main_package=is_main_package,
+        suffix=package_metadata.suffix,
+        cooldown_days=cooldown_days if cooldown_days is not None else package_metadata.cooldown_days,
+    )
+
+    package_metadata = venv.package_metadata[package_name]
+    validate_expected_apps(venv, package_name, package_metadata.expected_apps)
+
+    new_version: Final[str] = package_metadata.package_version
+
+    if venv.pipx_metadata.exposure_enabled:
+        expose_package_resources(package_metadata, paths.ctx.bin_dir, paths.ctx.man_dir, force=force)
+
+    return PackageUpgradeResult(
+        environment=venv.name,
+        package=f"{package_metadata.package}{package_metadata.suffix}",
+        previous_version=old_version,
+        version=new_version,
+        status=UpgradeStatus.UNCHANGED if old_version == new_version else UpgradeStatus.UPGRADED,
+        injected=package_name != venv.main_package_name,
+        location=str(venv.root),
+    )
+
+
+def _package_result(venv: Venv, package_name: str, status: UpgradeStatus) -> PackageUpgradeResult:
+    package_metadata: Final[PackageInfo] = venv.package_metadata[package_name]
+    return PackageUpgradeResult(
+        environment=venv.name,
+        package=f"{package_metadata.package}{package_metadata.suffix}",
+        previous_version=package_metadata.package_version,
+        version=package_metadata.package_version,
+        status=status,
+        injected=package_name != venv.main_package_name,
+        location=str(venv.root),
+    )
+
+
+def _package_messages(result: PackageUpgradeResult, *, upgrading_all: bool) -> tuple[OutputMessage, ...]:
+    if result.status is UpgradeStatus.LOCKED:
+        return (OutputMessage(locked_package_message(result.environment)),)
+    if result.status is UpgradeStatus.PINNED:
+        subject: Final[str] = (
+            f"package {result.package} in venv {result.environment}"
+            if result.injected
+            else f"package {result.environment}"
+        )
+        return (
+            OutputMessage(
+                f"Not upgrading pinned {subject}. Run `pipx unpin {result.environment}` to unpin it.",
+                stream=OutputStream.LOG,
+            ),
+        )
+    if result.status is UpgradeStatus.UNCHANGED:
+        if upgrading_all:
+            return ()
+        return (
+            OutputMessage(
+                pipx_wrap(
+                    f"""
+                    {result.package} is already at latest version {result.previous_version}
+                    (location: {result.location})
+                    """
+                )
+            ),
+        )
+    return (
+        OutputMessage(
+            pipx_wrap(
+                f"""
+                upgraded package {result.package} from {result.previous_version} to
+                {result.version} (location: {result.location})
+                """
+            )
+        ),
+    )
 
 
 class UpgradeStatus(str, Enum):
@@ -58,382 +493,6 @@ class UpgradeData(OperationData):
     packages: tuple[PackageUpgradeResult, ...]
     skipped: tuple[SkippedUpgrade, ...]
     failures: tuple[FailedUpgrade, ...]
-
-
-def _upgrade_package(
-    venv: Venv,
-    package_name: str,
-    pip_args: list[str],
-    is_main_package: bool,
-    force: bool,
-    cooldown_days: int | None,
-) -> PackageUpgradeResult:
-    package_metadata = venv.package_metadata[package_name]
-
-    if package_metadata.package_or_url is None:
-        raise PipxError(f"Internal Error: package {package_name} has corrupt pipx metadata.")
-    elif package_metadata.pinned:
-        return PackageUpgradeResult(
-            environment=venv.name,
-            package=f"{package_metadata.package}{package_metadata.suffix}",
-            previous_version=package_metadata.package_version,
-            version=package_metadata.package_version,
-            status=UpgradeStatus.PINNED,
-            injected=package_metadata.package != venv.main_package_name,
-            location=str(venv.root),
-        )
-
-    package_or_url = parse_specifier_for_upgrade(package_metadata.package_or_url)
-    old_version = package_metadata.package_version
-
-    venv.upgrade_package(
-        package_name,
-        package_or_url,
-        pip_args,
-        include_dependencies=package_metadata.include_dependencies,
-        include_apps_from=package_metadata.include_apps_from,
-        include_apps=package_metadata.include_apps,
-        is_main_package=is_main_package,
-        suffix=package_metadata.suffix,
-        cooldown_days=cooldown_days if cooldown_days is not None else package_metadata.cooldown_days,
-    )
-
-    package_metadata = venv.package_metadata[package_name]
-    validate_expected_apps(venv, package_name, package_metadata.expected_apps)
-
-    display_name = f"{package_metadata.package}{package_metadata.suffix}"
-    new_version = package_metadata.package_version
-
-    if venv.pipx_metadata.exposure_enabled:
-        expose_package_resources(package_metadata, paths.ctx.bin_dir, paths.ctx.man_dir, force=force)
-
-    return PackageUpgradeResult(
-        environment=venv.name,
-        package=display_name,
-        previous_version=old_version,
-        version=new_version,
-        status=UpgradeStatus.UNCHANGED if old_version == new_version else UpgradeStatus.UPGRADED,
-        injected=package_name != venv.main_package_name,
-        location=str(venv.root),
-    )
-
-
-def _package_messages(result: PackageUpgradeResult, *, upgrading_all: bool) -> tuple[OutputMessage, ...]:
-    if result.status is UpgradeStatus.LOCKED:
-        return (OutputMessage(locked_package_message(result.environment)),)
-    if result.status is UpgradeStatus.PINNED:
-        subject = (
-            f"package {result.package} in venv {result.environment}"
-            if result.injected
-            else f"package {result.environment}"
-        )
-        return (
-            OutputMessage(
-                f"Not upgrading pinned {subject}. Run `pipx unpin {result.environment}` to unpin it.",
-                stream=OutputStream.LOG,
-            ),
-        )
-    if result.status is UpgradeStatus.UNCHANGED:
-        if upgrading_all:
-            return ()
-        return (
-            OutputMessage(
-                pipx_wrap(
-                    f"""
-                    {result.package} is already at latest version {result.previous_version}
-                    (location: {result.location})
-                    """
-                )
-            ),
-        )
-    return (
-        OutputMessage(
-            pipx_wrap(
-                f"""
-                upgraded package {result.package} from {result.previous_version} to
-                {result.version} (location: {result.location})
-                """
-            )
-        ),
-    )
-
-
-def _upgrade_venv(
-    venv_dir: Path,
-    pip_args: list[str],
-    verbose: bool,
-    *,
-    include_injected: bool,
-    force: bool,
-    install: bool = False,
-    venv_args: list[str] | None = None,
-    python: str | None = None,
-    python_flag_passed: bool = False,
-    backend: str | None = None,
-    env_backend: str | None = None,
-    venv: Venv | None = None,
-    shared_libs_already_checked: bool = False,
-    venv_lock: BaseFileLock | None = None,
-    cooldown_days: int | None = None,
-) -> tuple[PackageUpgradeResult, ...]:
-    """Return package upgrade results.
-
-    ``upgrade-all`` passes ``venv`` and ``shared_libs_already_checked=True``
-    after its own pre-checks to avoid re-running them per venv.
-    """
-    if not venv_dir.is_dir():
-        if install:
-            if venv_args is None:
-                venv_args = []
-            commands.install(
-                venv_dir=None,
-                venv_args=venv_args,
-                package_names=None,
-                package_specs=[str(venv_dir).split(os.path.sep)[-1]],
-                local_bin_dir=paths.ctx.bin_dir,
-                local_man_dir=paths.ctx.man_dir,
-                python=python,
-                pip_args=pip_args,
-                verbose=verbose,
-                force=force,
-                reinstall=False,
-                include_dependencies=False,
-                include_apps_from=(),
-                preinstall_packages=None,
-                python_flag_passed=python_flag_passed,
-                backend=backend,
-                env_backend=env_backend,
-                venv_lock=venv_lock,
-                cooldown_days=cooldown_days,
-            )
-            return ()
-        else:
-            raise PipxError(
-                f"""
-                Package is not installed. Expected to find {venv_dir!s}, but it
-                does not exist.
-                """
-            )
-
-    if venv_args and not install:
-        _LOGGER.info(f"Ignoring {', '.join(venv_args)} as not combined with --install")
-
-    if python and not install:
-        _LOGGER.info("Ignoring --python as not combined with --install")
-
-    if venv is None:
-        venv = Venv(venv_dir, verbose=verbose, backend=backend, env_backend=env_backend)
-    main_pip_args = pip_args or venv.pipx_metadata.main_package.pip_args
-    if not shared_libs_already_checked:
-        venv.check_upgrade_shared_libs(pip_args=main_pip_args, verbose=verbose)
-
-    if not venv.python_path.is_file():
-        raise PipxError(
-            f"Not upgrading {red(bold(venv_dir.name))}. It has an invalid python interpreter {venv.python_path}.\n"
-            f"This usually happens after a system Python upgrade.\n"
-            f"To fix, execute: pipx reinstall-all",
-            wrap_message=False,
-        )
-
-    if not venv.package_metadata:
-        raise PipxError(
-            f"Not upgrading {red(bold(venv_dir.name))}. It has missing internal pipx metadata.\n"
-            f"It was likely installed using a pipx version before 0.15.0.0.\n"
-            f"Please uninstall and install this package to fix.",
-            wrap_message=False,
-        )
-
-    main_package = venv.pipx_metadata.main_package
-    if main_package.lock_file is not None:
-        return (
-            PackageUpgradeResult(
-                environment=venv.name,
-                package=venv.name,
-                previous_version=main_package.package_version,
-                version=main_package.package_version,
-                status=UpgradeStatus.LOCKED,
-                injected=False,
-                location=str(venv.root),
-            ),
-        )
-
-    with preserve_venv(
-        venv_dir,
-        enabled=any(package.expected_apps for package in venv.package_metadata.values()),
-    ):
-        return _upgrade_packages(
-            venv,
-            main_pip_args,
-            pip_args,
-            include_injected=include_injected,
-            force=force,
-            cooldown_days=cooldown_days,
-        )
-
-
-def _upgrade_packages(
-    venv: Venv,
-    main_pip_args: list[str],
-    pip_args: list[str],
-    *,
-    include_injected: bool,
-    force: bool,
-    cooldown_days: int | None,
-) -> tuple[PackageUpgradeResult, ...]:
-    venv.upgrade_packaging_libraries(main_pip_args)
-    results: Final[list[PackageUpgradeResult]] = [
-        _upgrade_package(
-            venv,
-            venv.main_package_name,
-            main_pip_args,
-            is_main_package=True,
-            force=force,
-            cooldown_days=cooldown_days,
-        )
-    ]
-
-    if include_injected:
-        for package_name in venv.package_metadata:
-            if package_name == venv.main_package_name:
-                continue
-            results.append(
-                _upgrade_package(
-                    venv,
-                    package_name,
-                    pip_args or venv.package_metadata[package_name].pip_args,
-                    is_main_package=False,
-                    force=force,
-                    cooldown_days=cooldown_days,
-                )
-            )
-
-    return tuple(results)
-
-
-def upgrade(
-    venv_dirs: dict[str, Path],
-    python: str | None,
-    pip_args: list[str],
-    venv_args: list[str],
-    verbose: bool,
-    *,
-    include_injected: bool,
-    force: bool,
-    install: bool,
-    python_flag_passed: bool = False,
-    backend: str | None = None,
-    env_backend: str | None = None,
-    cooldown_days: int | None = None,
-) -> OperationResult[UpgradeData]:
-    results: list[PackageUpgradeResult] = []
-
-    for venv_dir in venv_dirs.values():
-        with VenvContainer(venv_dir.parent).venv_lock(venv_dir) as venv_lock:
-            results.extend(
-                _upgrade_venv(
-                    venv_dir,
-                    pip_args,
-                    verbose,
-                    include_injected=include_injected,
-                    force=force,
-                    install=install,
-                    venv_args=venv_args,
-                    python=python,
-                    python_flag_passed=python_flag_passed,
-                    backend=backend,
-                    env_backend=env_backend,
-                    venv_lock=venv_lock,
-                    cooldown_days=cooldown_days,
-                )
-            )
-
-    package_results = tuple(results)
-    return OperationResult(
-        command="upgrade",
-        data=UpgradeData(packages=package_results, skipped=(), failures=()),
-        messages=tuple(
-            message for result in package_results for message in _package_messages(result, upgrading_all=False)
-        ),
-    )
-
-
-def upgrade_all(
-    venv_container: VenvContainer,
-    verbose: bool,
-    *,
-    pip_args: list[str],
-    include_injected: bool,
-    skip: Sequence[str],
-    force: bool,
-    python_flag_passed: bool = False,
-    backend: str | None = None,
-    env_backend: str | None = None,
-    cooldown_days: int | None = None,
-) -> OperationResult[UpgradeData]:
-    failures: list[FailedUpgrade] = []
-    messages: list[OutputMessage] = []
-    results: list[PackageUpgradeResult] = []
-    skipped: list[SkippedUpgrade] = []
-
-    for venv_dir in venv_container.iter_venv_dirs():
-        # Cheap skip-list check first so we don't pay metadata read +
-        # cross-backend warning + shared-libs health check on excluded venvs.
-        if venv_dir.name in skip:
-            skipped.append(SkippedUpgrade(venv_dir.name, "requested"))
-            continue
-        with venv_container.venv_lock(venv_dir) as venv_lock:
-            venv = Venv(venv_dir, verbose=verbose, backend=backend, env_backend=env_backend)
-            if "--editable" in venv.pipx_metadata.main_package.pip_args:
-                skipped.append(SkippedUpgrade(venv_dir.name, "editable"))
-                continue
-            venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
-            try:
-                package_results = _upgrade_venv(
-                    venv_dir,
-                    pip_args,
-                    verbose=verbose,
-                    include_injected=include_injected,
-                    force=force,
-                    python_flag_passed=python_flag_passed,
-                    backend=backend,
-                    env_backend=env_backend,
-                    venv=venv,
-                    shared_libs_already_checked=True,
-                    venv_lock=venv_lock,
-                    cooldown_days=cooldown_days,
-                )
-                results.extend(package_results)
-                for result in package_results:
-                    messages.extend(_package_messages(result, upgrading_all=True))
-            except PipxError as e:
-                failures.append(FailedUpgrade(venv_dir.name, str(e)))
-                messages.append(OutputMessage(str(e), stream=OutputStream.STDERR, level=OutputLevel.ERROR))
-    if not any(result.status is UpgradeStatus.UPGRADED for result in results):
-        messages.append(OutputMessage(f"No packages upgraded after running 'pipx upgrade-all' {sleep}"))
-    if failures:
-        messages.append(
-            OutputMessage(
-                f"The following package(s) failed to upgrade: {','.join(failure.environment for failure in failures)}",
-                stream=OutputStream.STDERR,
-                level=OutputLevel.ERROR,
-            )
-        )
-    return OperationResult(
-        command="upgrade-all",
-        data=UpgradeData(packages=tuple(results), skipped=tuple(skipped), failures=tuple(failures)),
-        messages=tuple(messages),
-        exit_code=ExitCode(1 if failures else 0),
-    )
-
-
-def upgrade_shared(
-    verbose: bool,
-    pip_args: list[str],
-) -> ExitCode:
-    # Always refreshes: the next pip-backed install needs a fresh shared-libs
-    # venv even when all currently-installed venvs are uv-backed.
-    shared_libs.upgrade(verbose=verbose, pip_args=pip_args, raises=True)
-    return EXIT_CODE_OK
 
 
 __all__ = [

--- a/tests/test_outdated.py
+++ b/tests/test_outdated.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
+from contextlib import nullcontext
 from dataclasses import replace
 from typing import TYPE_CHECKING, Final, Literal, TypeAlias, cast
 
@@ -12,10 +14,14 @@ from pipx import paths
 from pipx.pipx_metadata_file import PIPX_INFO_FILENAME, PipxMetadata
 
 if TYPE_CHECKING:
+    from contextlib import AbstractContextManager
     from pathlib import Path
     from unittest.mock import MagicMock
 
+    from _pytest.capture import CaptureResult
     from pytest_mock import MockerFixture
+
+    from pipx.venv import VenvContainer
 
 _JsonValue: TypeAlias = None | bool | int | float | str | list["_JsonValue"] | dict[str, "_JsonValue"]
 _OUTDATED_JSON: Final[str] = (
@@ -43,6 +49,28 @@ def test_list_outdated_backend(
 
     captured = capsys.readouterr()
     assert (captured.out, captured.err) == ("pipx found no available upgrades.\n", "")
+
+
+def test_list_outdated_skips_removed_environment(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    mocker: MockerFixture,
+) -> None:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    capsys.readouterr()
+
+    def remove_environment(_: VenvContainer, venv_dir: Path) -> AbstractContextManager[None]:
+        shutil.rmtree(venv_dir)
+        return nullcontext()
+
+    lock: Final[MagicMock] = mocker.patch(
+        "pipx.venv.VenvContainer.venv_lock", autospec=True, side_effect=remove_environment
+    )
+
+    assert not run_pipx_cli(["list", "--outdated"])
+
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
+    assert (captured.out, captured.err, lock.call_count) == ("pipx found no index packages to check.\n", "", 1)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,7 +1,8 @@
+import json
 import sys
 from collections.abc import Callable
 from pathlib import Path
-from typing import Final
+from typing import Final, cast
 
 import pytest
 
@@ -16,7 +17,7 @@ from helpers import (
 )
 from package_info import PKG
 from pipx import paths
-from pipx.pipx_metadata_file import PackageInfo, PipxMetadata
+from pipx.pipx_metadata_file import PIPX_INFO_FILENAME, PackageInfo, PipxMetadata
 
 
 def test_upgrade(pipx_temp_env, capsys):
@@ -130,6 +131,37 @@ def test_upgrade_missing_interpreter(pipx_temp_env, capsys):
     captured = capsys.readouterr()
     assert "invalid python interpreter" in captured.err
     assert "pipx reinstall-all" in captured.err
+
+
+def test_upgrade_reports_corrupt_package(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    metadata_path: Final[Path] = paths.ctx.venvs / "pycowsay" / PIPX_INFO_FILENAME
+    metadata: Final[dict[str, dict[str, str | None]]] = cast(
+        "dict[str, dict[str, str | None]]",
+        json.loads(metadata_path.read_text(encoding="utf-8")),
+    )
+    metadata["main_package"]["package_or_url"] = None
+    metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+    capsys.readouterr()
+
+    assert run_pipx_cli(["upgrade", "pycowsay"])
+
+    assert "package pycowsay has corrupt pipx metadata" in capsys.readouterr().err
+
+
+def test_upgrade_ignores_venv_args_without_install(
+    pipx_temp_env: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    caplog.clear()
+
+    assert not run_pipx_cli(["upgrade", "pycowsay", "--system-site-packages"])
+
+    assert "Ignoring --system-site-packages as not combined with --install" in caplog.text
 
 
 def test_upgrade_editable(pipx_temp_env, capsys, root):
@@ -266,15 +298,7 @@ def test_upgrade_cooldown(
         root / ".pipx_tests" / "package_cache" / f"{sys.version_info.major}.{sys.version_info.minor}"
     )
     pip_args: Final[str] = f"--pip-args=--no-index --find-links={find_links}"
-    assert not run_pipx_cli(
-        [
-            "install",
-            "--cooldown",
-            "7",
-            pip_args,
-            PKG["pycowsay"]["spec"],
-        ]
-    )
+    assert not run_pipx_cli(["install", "--cooldown", "7", pip_args, PKG["pycowsay"]["spec"]])
     assert not run_pipx_cli(["inject", "--cooldown", "5", pip_args, "pycowsay", str(empty_project)])
     caplog.clear()
 

--- a/tests/test_upgrade_all.py
+++ b/tests/test_upgrade_all.py
@@ -1,24 +1,172 @@
+from __future__ import annotations
+
 import json
-from collections.abc import Callable
-from pathlib import Path
+import subprocess
+import sys
+from threading import Barrier
+from typing import TYPE_CHECKING, Final
 
 import pytest
 
 from helpers import PIPX_METADATA_LEGACY_VERSIONS, mock_legacy_venv, run_pipx_cli
+from package_info import PKG
 from pipx import paths
+from pipx.pipx_metadata_file import PipxMetadata
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+    from pathlib import Path
+    from unittest.mock import MagicMock
+
+    from _pytest.capture import CaptureResult
+    from pytest_mock import MockerFixture
 
 
-def test_upgrade_all(pipx_temp_env, capsys):
+def test_upgrade_all(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
     assert run_pipx_cli(["upgrade", "pycowsay"])
     assert not run_pipx_cli(["install", "pycowsay"])
     assert not run_pipx_cli(["upgrade-all"])
 
 
-def test_upgrade_all_none(pipx_temp_env, capsys):
+def test_upgrade_all_none(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
     assert not run_pipx_cli(["install", "pycowsay"])
     assert not run_pipx_cli(["upgrade-all"])
-    captured = capsys.readouterr()
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
     assert "No packages upgraded after running 'pipx upgrade-all'" in captured.out
+
+
+def test_upgrade_all_checks_current_packages_concurrently(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    mocker: MockerFixture,
+) -> None:
+    for suffix in ("_one", "_two", "_three"):
+        assert not run_pipx_cli(["install", "pycowsay", f"--suffix={suffix}"])
+    capsys.readouterr()
+    barrier: Final[Barrier] = Barrier(3)
+
+    def check_package(
+        cmd: Sequence[str | Path],
+        capture_stdout: bool = True,
+        capture_stderr: bool = True,
+        log_cmd_str: str | None = None,
+        log_stdout: bool = True,
+        log_stderr: bool = True,
+        run_dir: str | None = None,
+        env_overrides: dict[str, str | None] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        del capture_stdout, capture_stderr, log_cmd_str, log_stdout, log_stderr, run_dir, env_overrides
+        assert "list" in cmd and "--outdated" in cmd
+        barrier.wait(timeout=5)
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout="[]", stderr="")
+
+    check: Final[MagicMock] = mocker.patch("pipx.backends.pip.run_subprocess", autospec=True, side_effect=check_package)
+
+    assert (run_pipx_cli(["upgrade-all"]), check.call_count) == (0, 3)
+
+
+def test_upgrade_all_does_not_copy_current_environment(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    mocker: MockerFixture,
+) -> None:
+    assert not run_pipx_cli(["install", "--app", "pycowsay", "pycowsay"])
+    capsys.readouterr()
+    mocker.patch(
+        "pipx.backends.pip.run_subprocess",
+        autospec=True,
+        return_value=subprocess.CompletedProcess(args=["pip", "list"], returncode=0, stdout="[]", stderr=""),
+    )
+    backup: Final[MagicMock] = mocker.patch("pipx.commands.transaction.copytree", autospec=True)
+
+    assert (run_pipx_cli(["upgrade-all"]), backup.call_count) == (0, 0)
+
+
+def test_upgrade_all_updates_current_cooldowns(
+    pipx_temp_env: None,
+    root: Path,
+    mocker: MockerFixture,
+) -> None:
+    find_links: Final[Path] = (
+        root / ".pipx_tests" / "package_cache" / f"{sys.version_info.major}.{sys.version_info.minor}"
+    )
+    pip_args: Final[str] = f"--pip-args=--no-index --find-links={find_links}"
+    assert not run_pipx_cli(["install", "--cooldown", "7", pip_args, PKG["pycowsay"]["spec"]])
+    assert not run_pipx_cli(["inject", "--cooldown", "5", pip_args, "pycowsay", PKG["black"]["spec"]])
+    mocker.patch(
+        "pipx.backends.pip.run_subprocess",
+        autospec=True,
+        return_value=subprocess.CompletedProcess(args=["pip", "list"], returncode=0, stdout="[]", stderr=""),
+    )
+
+    assert not run_pipx_cli(["upgrade-all", "--include-injected", "--cooldown", "0"])
+
+    metadata: Final[PipxMetadata] = PipxMetadata(paths.ctx.venvs / "pycowsay")
+    assert (metadata.main_package.cooldown_days, metadata.injected_packages["black"].cooldown_days) == (0, 0)
+
+
+@pytest.mark.parametrize("injected", [pytest.param(False, id="main"), pytest.param(True, id="injected")])
+def test_upgrade_all_upgrades_outdated_package(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    injected: bool,
+) -> None:
+    if injected:
+        assert not run_pipx_cli(["install", "pycowsay"])
+        assert not run_pipx_cli(["inject", "pycowsay", PKG["black"]["spec"]])
+    else:
+        assert not run_pipx_cli(["install", PKG["black"]["spec"]])
+    capsys.readouterr()
+
+    assert not run_pipx_cli(["upgrade-all", *(["--include-injected"] if injected else [])])
+
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
+    assert "upgraded package black from 22.8.0 to " in captured.out
+
+
+def test_upgrade_all_reports_outdated_check_failure(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    mocker: MockerFixture,
+) -> None:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    capsys.readouterr()
+    check: Final[MagicMock] = mocker.patch(
+        "pipx.backends.pip.run_subprocess",
+        autospec=True,
+        return_value=subprocess.CompletedProcess(
+            args=["pip", "list"],
+            returncode=1,
+            stdout="",
+            stderr="index unavailable",
+        ),
+    )
+
+    assert run_pipx_cli(["upgrade-all"])
+
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
+    assert (check.call_count, "Package backend exited with code 1" in captured.err) == (1, True)
+
+
+def test_upgrade_all_skips_pinned_package_check(
+    pipx_temp_env: None,
+    caplog: pytest.LogCaptureFixture,
+    mocker: MockerFixture,
+) -> None:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    assert not run_pipx_cli(["pin", "pycowsay"])
+    caplog.clear()
+    check: Final[MagicMock] = mocker.patch(
+        "pipx.backends.pip.run_subprocess",
+        autospec=True,
+        return_value=subprocess.CompletedProcess(args=["pip", "list"], returncode=0, stdout="[]", stderr=""),
+    )
+
+    assert (
+        run_pipx_cli(["upgrade-all"]),
+        check.call_count,
+        "Not upgrading pinned package pycowsay" in caplog.text,
+    ) == (0, 0, True)
 
 
 def test_upgrade_all_quiet(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
@@ -27,7 +175,7 @@ def test_upgrade_all_quiet(pipx_temp_env: None, capsys: pytest.CaptureFixture[st
 
     assert not run_pipx_cli(["upgrade-all", "--quiet"])
 
-    captured = capsys.readouterr()
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
     assert not captured.out
     assert not captured.err
 
@@ -38,7 +186,7 @@ def test_upgrade_all_json(pipx_temp_env: None, capsys: pytest.CaptureFixture[str
 
     assert not run_pipx_cli(["upgrade-all", "--json"])
 
-    captured = capsys.readouterr()
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
     assert not captured.err
     assert json.loads(captured.out) == {
         "command": "upgrade-all",
@@ -66,24 +214,33 @@ def test_upgrade_all_pylock_json(
     pipx_temp_env: None,
     make_pylock: Callable[[str, str], Path],
     capsys: pytest.CaptureFixture[str],
+    mocker: MockerFixture,
 ) -> None:
-    lock_file = make_pylock("pycowsay", "0.0.0.2")
+    lock_file: Final[Path] = make_pylock("pycowsay", "0.0.0.2")
     assert not run_pipx_cli(["install", "--lock", str(lock_file), "pycowsay"])
     capsys.readouterr()
+    check: Final[MagicMock] = mocker.patch(
+        "pipx.backends.pip.run_subprocess",
+        autospec=True,
+        return_value=subprocess.CompletedProcess(args=["pip", "list"], returncode=0, stdout="[]", stderr=""),
+    )
 
     assert not run_pipx_cli(["upgrade-all", "--json"])
 
-    assert json.loads(capsys.readouterr().out)["data"]["packages"] == [
-        {
-            "environment": "pycowsay",
-            "injected": False,
-            "location": str(paths.ctx.venvs / "pycowsay"),
-            "package": "pycowsay",
-            "previous_version": "0.0.0.2",
-            "status": "locked",
-            "version": "0.0.0.2",
-        }
-    ]
+    assert (json.loads(capsys.readouterr().out)["data"]["packages"], check.call_count) == (
+        [
+            {
+                "environment": "pycowsay",
+                "injected": False,
+                "location": str(paths.ctx.venvs / "pycowsay"),
+                "package": "pycowsay",
+                "previous_version": "0.0.0.2",
+                "status": "locked",
+                "version": "0.0.0.2",
+            }
+        ],
+        0,
+    )
 
 
 def test_upgrade_all_json_failure(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
@@ -93,14 +250,27 @@ def test_upgrade_all_json_failure(pipx_temp_env: None, capsys: pytest.CaptureFix
 
     assert run_pipx_cli(["upgrade-all", "--json"])
 
-    captured = capsys.readouterr()
-    result = json.loads(captured.out)
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
     assert not captured.err
-    assert result["status"] == "error"
-    assert result["data"]["packages"] == []
-    assert result["data"]["skipped"] == []
-    assert result["data"]["failures"][0]["environment"] == "pycowsay"
-    assert "missing internal pipx metadata" in result["data"]["failures"][0]["error"]
+    assert json.loads(captured.out) == {
+        "command": "upgrade-all",
+        "data": {
+            "failures": [
+                {
+                    "environment": "pycowsay",
+                    "error": (
+                        "Not upgrading pycowsay. It has missing internal pipx metadata.\n"
+                        "It was likely installed using a pipx version before 0.15.0.0.\n"
+                        "Please uninstall and install this package to fix."
+                    ),
+                }
+            ],
+            "packages": [],
+            "skipped": [],
+        },
+        "pipx_result_version": "0.1",
+        "status": "error",
+    }
 
 
 def test_upgrade_all_json_requested_skip(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
@@ -109,9 +279,11 @@ def test_upgrade_all_json_requested_skip(pipx_temp_env: None, capsys: pytest.Cap
 
     assert not run_pipx_cli(["upgrade-all", "--skip", "pycowsay", "--json"])
 
-    result = json.loads(capsys.readouterr().out)
-    assert result["data"]["packages"] == []
-    assert result["data"]["skipped"] == [{"environment": "pycowsay", "reason": "requested"}]
+    assert json.loads(capsys.readouterr().out)["data"] == {
+        "failures": [],
+        "packages": [],
+        "skipped": [{"environment": "pycowsay", "reason": "requested"}],
+    }
 
 
 def test_upgrade_all_json_editable_skip(pipx_temp_env: None, capsys: pytest.CaptureFixture[str], root: Path) -> None:
@@ -120,18 +292,38 @@ def test_upgrade_all_json_editable_skip(pipx_temp_env: None, capsys: pytest.Capt
 
     assert not run_pipx_cli(["upgrade-all", "--json"])
 
-    result = json.loads(capsys.readouterr().out)
-    assert result["data"]["packages"] == []
-    assert result["data"]["skipped"] == [{"environment": "empty-project", "reason": "editable"}]
+    assert json.loads(capsys.readouterr().out)["data"] == {
+        "failures": [],
+        "packages": [],
+        "skipped": [{"environment": "empty-project", "reason": "editable"}],
+    }
 
 
-def test_upgrade_all_with_pip_args(pipx_temp_env, capsys):
+def test_upgrade_all_with_index_args(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    mocker: MockerFixture,
+) -> None:
     assert not run_pipx_cli(["install", "pycowsay"])
-    assert not run_pipx_cli(["upgrade-all", "--pip-args=--no-cache-dir"])
+    check: Final[MagicMock] = mocker.patch(
+        "pipx.backends.pip.run_subprocess",
+        autospec=True,
+        return_value=subprocess.CompletedProcess(args=["pip", "list"], returncode=0, stdout="[]", stderr=""),
+    )
+
+    assert (
+        run_pipx_cli(["upgrade-all", "--pip-args=--index-url=https://example.com"]),
+        check.call_count,
+        "--index-url=https://example.com" in check.call_args.args[0],
+    ) == (0, 1, True)
 
 
 @pytest.mark.parametrize("metadata_version", PIPX_METADATA_LEGACY_VERSIONS)
-def test_upgrade_all_legacy_venv(pipx_temp_env, capsys, metadata_version):
+def test_upgrade_all_legacy_venv(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    metadata_version: str | None,
+) -> None:
     assert run_pipx_cli(["upgrade", "pycowsay"])
     assert not run_pipx_cli(["install", "pycowsay"])
     mock_legacy_venv("pycowsay", metadata_version=metadata_version)


### PR DESCRIPTION
A no-op `pipx upgrade-all` checks each managed package by reinstalling it in sequence. Users with current packages pay the install cost when no managed package has an update. This closes [#1353](https://github.com/pypa/pipx/issues/1353).

The command reuses the outdated-package inspector to query environments with up to eight workers, then acquires each environment lock before applying upgrades in sequence. It skips index requests for pinned and locked packages. Non-index and editable packages retain their upgrade path; pipx leaves an environment unchanged when its availability query fails.
