### PR TITLE
✨ feat(install): add selectable output

### DIFF
--- a/changelog.d/828.feature.2.md
+++ b/changelog.d/828.feature.2.md
@@ -1,0 +1,1 @@
+Add `--output json` to `pipx install`.

--- a/src/pipx/commands/__init__.py
+++ b/src/pipx/commands/__init__.py
@@ -3,7 +3,7 @@ from pipx.commands.environment import environment
 from pipx.commands.expose import ExposureData, expose, unexpose
 from pipx.commands.health import HealthData, RepairData, health, repair
 from pipx.commands.inject import inject
-from pipx.commands.install import install, install_all
+from pipx.commands.install import InstallData, install, install_all
 from pipx.commands.interpreter import list_interpreters, prune_interpreters, upgrade_interpreters
 from pipx.commands.list_packages import list_packages
 from pipx.commands.manifest import lock_manifest, sync_manifest
@@ -19,6 +19,7 @@ from pipx.commands.upgrade import upgrade, upgrade_all, upgrade_shared
 __all__ = [
     "ExposureData",
     "HealthData",
+    "InstallData",
     "OutdatedData",
     "PinData",
     "RepairData",

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -3,7 +3,6 @@ import logging
 import os
 import shlex
 import shutil
-import sys
 import tempfile
 import time
 from collections.abc import Sequence
@@ -21,6 +20,7 @@ from pipx.constants import MAN_SECTIONS, WINDOWS
 from pipx.emojis import hazard, stars
 from pipx.package_specifier import parse_specifier_for_install, valid_pypi_name
 from pipx.pipx_metadata_file import PackageInfo
+from pipx.result import OutputMessage, OutputStream
 from pipx.util import PipxError, mkdir, pipx_wrap, rmdir, safe_unlink
 from pipx.venv import Venv
 
@@ -467,7 +467,7 @@ def run_post_install_actions(
     *,
     force: bool,
     previous_resource_paths: set[Path],
-) -> None:
+) -> tuple[OutputMessage, ...]:
     package_metadata = venv.package_metadata[package_name]
 
     display_name = f"{package_name}{package_metadata.suffix}"
@@ -495,20 +495,18 @@ def run_post_install_actions(
                 """
             )
         if package_metadata.apps_of_dependencies and not package_metadata.included_dependency_apps:
-            for (
-                dep,
-                dependent_apps,
-            ) in package_metadata.app_paths_of_dependencies.items():
-                print(f"Note: Dependent package '{dep}' contains {len(dependent_apps)} apps")
-                for app in dependent_apps:
-                    print(f"  - {app.name}")
             if venv.safe_to_remove():
                 venv.remove_venv()
+            dependency_apps: Final[str] = "\n".join(
+                f"{dependency}: {', '.join(app.name for app in apps)}"
+                for dependency, apps in package_metadata.app_paths_of_dependencies.items()
+            )
             raise PipxError(
                 f"""
                 No apps associated with package {display_name}. Use
                 '--include-apps-from PACKAGE' to select one of the dependencies
-                listed above, or '--include-deps' to include all of them.
+                listed below, or '--include-deps' to include all of them.
+                {dependency_apps}
                 {library_guidance}
                 """
             )
@@ -518,11 +516,14 @@ def run_post_install_actions(
         _remove_stale_venv_resources(previous_resource_paths, venv, local_bin_dir, local_man_dir)
 
     package_summary, _ = get_venv_summary(venv_dir, package_name=package_name, new_install=True)
-    pipx_logger = logging.getLogger("pipx")
-    if not pipx_logger.handlers or pipx_logger.handlers[0].level <= logging.WARNING:
-        print(package_summary)
-        warn_if_not_on_path(local_bin_dir)
-        print(f"done! {stars}", file=sys.stderr)
+    pipx_logger: Final[logging.Logger] = logging.getLogger("pipx")
+    if pipx_logger.handlers and pipx_logger.handlers[0].level > logging.WARNING:
+        return ()
+    messages: Final[list[OutputMessage]] = [OutputMessage(package_summary)]
+    if path_warning := warn_if_not_on_path(local_bin_dir):
+        messages.append(path_warning)
+    messages.append(OutputMessage(f"done! {stars}", stream=OutputStream.STDERR))
+    return tuple(messages)
 
 
 def _remove_stale_venv_resources(
@@ -567,9 +568,9 @@ def validate_expected_apps(venv: Venv, package_name: str, expected_apps: Sequenc
         )
 
 
-def warn_if_not_on_path(local_bin_dir: Path) -> None:
+def warn_if_not_on_path(local_bin_dir: Path) -> OutputMessage | None:
     if not userpath.in_current_path(str(local_bin_dir)):
-        _LOGGER.warning(
+        return OutputMessage(
             pipx_wrap(
                 f"""
                 {hazard}  Note: '{local_bin_dir}' is not on your PATH
@@ -579,8 +580,10 @@ def warn_if_not_on_path(local_bin_dir: Path) -> None:
                 shell's config file (e.g. ~/.bashrc).
                 """,
                 subsequent_indent=" " * 4,
-            )
+            ),
+            stream=OutputStream.LOG,
         )
+    return None
 
 
 def add_suffix(name: str, suffix: str) -> str:

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -20,6 +20,7 @@ from pipx.commands.transaction import preserve_venv
 from pipx.constants import EXIT_CODE_INJECT_ERROR, EXIT_CODE_OK, ExitCode
 from pipx.emojis import hazard, stars
 from pipx.package_specifier import get_extras
+from pipx.result import render_messages
 from pipx.util import PipxError, pipx_wrap
 from pipx.venv import Venv
 
@@ -136,14 +137,17 @@ def inject_dep(
             cooldown_days=cooldown_days,
         )
         if include_apps:
-            run_post_install_actions(
-                venv,
-                package_name,
-                paths.ctx.bin_dir,
-                paths.ctx.man_dir,
-                venv_dir,
-                force=force,
-                previous_resource_paths=previous_resource_paths,
+            render_messages(
+                run_post_install_actions(
+                    venv,
+                    package_name,
+                    paths.ctx.bin_dir,
+                    paths.ctx.man_dir,
+                    venv_dir,
+                    force=force,
+                    previous_resource_paths=previous_resource_paths,
+                ),
+                quiet=0,
             )
 
     if is_main_package:

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -1,12 +1,11 @@
+from __future__ import annotations
+
 import json
 import re
 import sys
-from collections.abc import Iterator, Sequence
-from dataclasses import replace
-from pathlib import Path
-from typing import Final
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, Final
 
-from filelock import BaseFileLock
 from packaging.utils import canonicalize_name
 
 from pipx import commands, paths
@@ -21,7 +20,6 @@ from pipx.commands.common import (
 )
 from pipx.commands.transaction import preserve_venv
 from pipx.constants import (
-    EXIT_CODE_INSTALL_VENV_EXISTS,
     EXIT_CODE_OK,
     ExitCode,
 )
@@ -29,8 +27,24 @@ from pipx.emojis import sleep
 from pipx.interpreter import get_default_python
 from pipx.package_specifier import package_spec_satisfied
 from pipx.pipx_metadata_file import PackageInfo, PipxMetadata, load_spec_file
+from pipx.result import (
+    OperationData,
+    OperationResult,
+    OutputFormat,
+    OutputLevel,
+    OutputMessage,
+    OutputStream,
+    render_messages,
+    render_result,
+)
 from pipx.util import PipxError, pipx_wrap, rmdir
 from pipx.venv import Venv, VenvContainer
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Sequence
+    from pathlib import Path
+
+    from filelock import BaseFileLock
 
 _PYLOCK_NAME_RE: Final[re.Pattern[str]] = re.compile(r"pylock(?:\.[^.]+)?\.toml")
 
@@ -65,37 +79,30 @@ def install(
     preserve_existing: bool = False,
     replace_expected_apps: bool = False,
     replace_lock: bool = False,
-) -> ExitCode:
-    """Returns pipx exit code."""
-    # package_spec is anything pip-installable, including package_name, vcs spec,
-    #   zip file, or tar.gz file.
-
-    lock_file = _validate_install_options(
-        package_specs,
-        expected_apps,
-        preinstall_packages,
-        lock_file,
-        cooldown_days,
-        upgrade=upgrade,
-        upgrade_strategy=upgrade_strategy,
-    )
-
-    python = python or get_default_python()
-
-    package_names = package_names or []
-    if len(package_names) != len(package_specs):
-        package_names = [
-            package_name_from_spec(
-                package_spec,
-                python,
-                pip_args=pip_args,
-                verbose=verbose,
-                backend=backend,
-                env_backend=env_backend,
-                cooldown_days=cooldown_days,
-            )
-            for package_spec in package_specs
-        ]
+    emit_output: bool = True,
+) -> OperationResult[InstallData]:
+    messages: Final[list[OutputMessage]] = []
+    packages: Final[list[_InstalledPackage]] = []
+    skipped: Final[list[_SkippedInstall]] = []
+    failures: Final[list[_FailedInstall]] = []
+    try:
+        lock_file, python, package_names = _prepare_install(
+            package_names,
+            package_specs,
+            python,
+            pip_args,
+            verbose,
+            lock_file,
+            expected_apps,
+            preinstall_packages,
+            cooldown_days=cooldown_days,
+            upgrade=upgrade,
+            upgrade_strategy=upgrade_strategy,
+            backend=backend,
+            env_backend=env_backend,
+        )
+    except PipxError as error:
+        return _finish_install(_failed_install_result(package_specs[0], error), emit_output=emit_output)
 
     venv_container: Final[VenvContainer] = VenvContainer(venv_dir.parent if venv_dir is not None else paths.ctx.venvs)
     for package_name, package_spec in zip(package_names, package_specs, strict=False):
@@ -140,61 +147,39 @@ def install(
             )
             required_exposure = venv.pipx_metadata.exposure_enabled if exposure_enabled is None else exposure_enabled
             if exists:
-                if not reinstall and force and python_flag_passed:
-                    print(
-                        pipx_wrap(
-                            f"""
-                            --python is ignored when --force is passed.
-                            If you want to reinstall {package_name} with {python},
-                            run `pipx reinstall {package_spec} --python {python}` instead.
-                            """
-                        )
-                    )
-                if force:
-                    print(f"Installing to existing venv {venv.name!r}")
-                elif upgrade:
-                    _upgrade_existing_venv(
-                        venv,
-                        package_name,
-                        package_spec,
-                        local_bin_dir,
-                        local_man_dir,
-                        pip_args,
-                        verbose,
-                        upgrade_strategy,
-                        required_apps,
-                        required_cooldown,
-                    )
+                existing = _handle_existing_install(
+                    venv,
+                    package_name,
+                    package_spec,
+                    local_bin_dir,
+                    local_man_dir,
+                    python,
+                    pip_args,
+                    verbose,
+                    force=force,
+                    reinstall=reinstall,
+                    upgrade=upgrade,
+                    python_flag_passed=python_flag_passed,
+                    upgrade_strategy=upgrade_strategy,
+                    expected_apps=required_apps,
+                    cooldown_days=required_cooldown,
+                )
+                messages.extend(existing.messages)
+                packages.extend(existing.packages)
+                skipped.extend(existing.skipped)
+                if not existing.continue_install:
                     if len(package_specs) == 1:
-                        return EXIT_CODE_OK
-                    venv_dir = None
-                    continue
-                else:
-                    installed_version = venv.pipx_metadata.main_package.package_version
-                    version_info = f" ({installed_version})" if installed_version else ""
-                    print(
-                        pipx_wrap(
-                            f"""
-                            {venv.name!r}{version_info} already seems to be installed. Not
-                            modifying existing installation in '{venv_dir}'.
-                            Pass '--force' to force installation, or use
-                            'pipx upgrade {venv.name}' to upgrade.
-                            """
-                        )
-                    )
-                    if len(package_specs) == 1:
-                        return EXIT_CODE_INSTALL_VENV_EXISTS
+                        break
                     venv_dir = None
                     continue
 
             previous_resource_paths: set[Path] = get_expected_venv_resource_paths(venv, local_bin_dir, local_man_dir)
-            with preserve_venv(
-                venv_dir,
-                enabled=exists
-                and (preserve_existing or bool(required_apps or include_apps_from) or required_lock is not None),
-            ):
-                venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
-                try:
+            preserve_existing_venv = exists and (
+                preserve_existing or bool(required_apps or include_apps_from) or required_lock is not None
+            )
+            try:
+                with preserve_venv(venv_dir, enabled=preserve_existing_venv):
+                    venv.check_upgrade_shared_libs(pip_args=pip_args, verbose=verbose)
                     if exists and (required_lock is not None or (replace_lock and recorded_lock is not None)):
                         recorded_backend = venv.pipx_metadata.backend
                         rmdir(venv_dir)
@@ -225,22 +210,80 @@ def install(
                         cooldown_days=required_cooldown,
                     )
                     validate_expected_apps(venv, package_name, required_apps)
-                    run_post_install_actions(
-                        venv,
-                        package_name,
-                        local_bin_dir,
-                        local_man_dir,
-                        venv_dir,
-                        force=force,
-                        previous_resource_paths=previous_resource_paths,
+                    messages.extend(
+                        run_post_install_actions(
+                            venv,
+                            package_name,
+                            local_bin_dir,
+                            local_man_dir,
+                            venv_dir,
+                            force=force,
+                            previous_resource_paths=previous_resource_paths,
+                        )
                     )
-                except (Exception, KeyboardInterrupt):
-                    print()
+            except (Exception, KeyboardInterrupt) as error:
+                if not preserve_existing_venv:
                     venv.remove_venv()
+                if not isinstance(error, PipxError):
                     raise
+                failures.append(_FailedInstall(venv.name, str(error)))
+                messages.append(OutputMessage(str(error), stream=OutputStream.STDERR, level=OutputLevel.ERROR))
+                break
+            packages.append(_installed_package(venv, package_name))
         venv_dir = None
 
-    return EXIT_CODE_OK
+    return _finish_install(
+        OperationResult(
+            command="install",
+            data=InstallData(packages=tuple(packages), skipped=tuple(skipped), failures=tuple(failures)),
+            messages=tuple(messages),
+            exit_code=ExitCode(1 if failures else 0),
+        ),
+        emit_output=emit_output,
+    )
+
+
+def _prepare_install(
+    package_names: list[str] | None,
+    package_specs: list[str],
+    python: str | None,
+    pip_args: list[str],
+    verbose: bool,
+    lock_file: Path | None,
+    expected_apps: Sequence[str],
+    preinstall_packages: Sequence[str] | None,
+    *,
+    cooldown_days: int | None,
+    upgrade: bool,
+    upgrade_strategy: str | None,
+    backend: str | None,
+    env_backend: str | None,
+) -> tuple[Path | None, str, list[str]]:
+    lock_file = _validate_install_options(
+        package_specs,
+        expected_apps,
+        preinstall_packages,
+        lock_file,
+        cooldown_days,
+        upgrade=upgrade,
+        upgrade_strategy=upgrade_strategy,
+    )
+    python = python or get_default_python()
+    package_names = package_names or []
+    if len(package_names) != len(package_specs):
+        package_names = [
+            package_name_from_spec(
+                package_spec,
+                python,
+                pip_args=pip_args,
+                verbose=verbose,
+                backend=backend,
+                env_backend=env_backend,
+                cooldown_days=cooldown_days,
+            )
+            for package_spec in package_specs
+        ]
+    return lock_file, python, package_names
 
 
 def _validate_install_options(
@@ -275,6 +318,29 @@ def _validate_install_options(
     return lock_file
 
 
+def _failed_install_result(environment: str, error: PipxError) -> OperationResult[InstallData]:
+    message: Final[str] = str(error)
+    return OperationResult(
+        command="install",
+        data=InstallData(packages=(), skipped=(), failures=(_FailedInstall(environment, message),)),
+        messages=(OutputMessage(message, stream=OutputStream.STDERR, level=OutputLevel.ERROR),),
+        exit_code=ExitCode(1),
+    )
+
+
+def _finish_install(result: OperationResult[InstallData], *, emit_output: bool) -> OperationResult[InstallData]:
+    if not emit_output:
+        return result
+    if result.data.failures:
+        render_messages(
+            tuple(message for message in result.messages if message.level is OutputLevel.NORMAL),
+            quiet=0,
+        )
+        raise PipxError(result.data.failures[0].error)
+    render_result(result, output=OutputFormat.HUMAN, quiet=0)
+    return result
+
+
 def _resolve_cooldown(
     lock_file: Path | None,
     requested: int | None,
@@ -289,6 +355,87 @@ def _resolve_cooldown(
     return requested if requested is not None else stored
 
 
+def _handle_existing_install(
+    venv: Venv,
+    package_name: str,
+    package_spec: str,
+    local_bin_dir: Path,
+    local_man_dir: Path,
+    python: str,
+    pip_args: list[str],
+    verbose: bool,
+    *,
+    force: bool,
+    reinstall: bool,
+    upgrade: bool,
+    python_flag_passed: bool,
+    upgrade_strategy: str | None,
+    expected_apps: Sequence[str],
+    cooldown_days: int | None,
+) -> _ExistingInstall:
+    messages: Final[list[OutputMessage]] = []
+    if not reinstall and force and python_flag_passed:
+        messages.append(
+            OutputMessage(
+                pipx_wrap(
+                    f"""
+                    --python is ignored when --force is passed.
+                    If you want to reinstall {package_name} with {python},
+                    run `pipx reinstall {package_spec} --python {python}` instead.
+                    """
+                )
+            )
+        )
+    if force:
+        messages.append(OutputMessage(f"Installing to existing venv {venv.name!r}"))
+        return _ExistingInstall(
+            continue_install=True,
+            packages=(),
+            skipped=(),
+            messages=tuple(messages),
+        )
+    if upgrade:
+        reason, upgrade_messages = _upgrade_existing_venv(
+            venv,
+            package_name,
+            package_spec,
+            local_bin_dir,
+            local_man_dir,
+            pip_args,
+            verbose,
+            upgrade_strategy,
+            expected_apps,
+            cooldown_days,
+        )
+        messages.extend(upgrade_messages)
+        return _ExistingInstall(
+            continue_install=False,
+            packages=(_installed_package(venv, package_name),) if reason is None else (),
+            skipped=(_SkippedInstall(venv.name, package_name, reason),) if reason is not None else (),
+            messages=tuple(messages),
+        )
+
+    installed_version = venv.pipx_metadata.main_package.package_version
+    messages.append(
+        OutputMessage(
+            pipx_wrap(
+                f"""
+                {venv.name!r}{f" ({installed_version})" if installed_version else ""} already seems to be installed. Not
+                modifying existing installation in '{venv.root}'.
+                Pass '--force' to force installation, or use
+                'pipx upgrade {venv.name}' to upgrade.
+                """
+            )
+        )
+    )
+    return _ExistingInstall(
+        continue_install=False,
+        packages=(),
+        skipped=(_SkippedInstall(venv.name, package_name, "already-installed"),),
+        messages=tuple(messages),
+    )
+
+
 def _upgrade_existing_venv(
     venv: Venv,
     package_name: str,
@@ -300,14 +447,13 @@ def _upgrade_existing_venv(
     upgrade_strategy: str | None,
     expected_apps: Sequence[str],
     cooldown_days: int | None,
-) -> None:
+) -> tuple[str | None, tuple[OutputMessage, ...]]:
     package_metadata = venv.pipx_metadata.main_package
     installed_version: Final[str] = package_metadata.package_version
     if package_metadata.lock_file is not None:
         validate_expected_apps(venv, package_name, expected_apps)
         _record_expected_apps(venv, expected_apps)
-        print(locked_package_message(venv.name))
-        return
+        return "locked", (OutputMessage(locked_package_message(venv.name)),)
     if package_spec_satisfied(
         package_spec,
         package_name,
@@ -316,13 +462,15 @@ def _upgrade_existing_venv(
     ):
         validate_expected_apps(venv, package_name, expected_apps)
         _record_expected_apps(venv, expected_apps)
-        print(f"{package_name} {installed_version} already satisfies {package_spec}")
-        return
+        return "already-satisfied", (
+            OutputMessage(f"{package_name} {installed_version} already satisfies {package_spec}"),
+        )
     if package_metadata.pinned:
         validate_expected_apps(venv, package_name, expected_apps)
         _record_expected_apps(venv, expected_apps)
-        print(f"Not upgrading pinned package {venv.name}. Run `pipx unpin {venv.name}` to unpin it.")
-        return
+        return "pinned", (
+            OutputMessage(f"Not upgrading pinned package {venv.name}. Run `pipx unpin {venv.name}` to unpin it."),
+        )
 
     with preserve_venv(venv.root, enabled=bool(expected_apps)):
         main_pip_args: Final[list[str]] = pip_args or package_metadata.pip_args
@@ -345,13 +493,15 @@ def _upgrade_existing_venv(
         package_metadata = venv.pipx_metadata.main_package
         if venv.pipx_metadata.exposure_enabled:
             expose_package_resources(package_metadata, local_bin_dir, local_man_dir, force=False)
-    print(
-        pipx_wrap(
-            f"""
-            upgraded package {venv.name} from {installed_version} to
-            {package_metadata.package_version} (location: {venv.root!s})
-            """
-        )
+    return None, (
+        OutputMessage(
+            pipx_wrap(
+                f"""
+                upgraded package {venv.name} from {installed_version} to
+                {package_metadata.package_version} (location: {venv.root!s})
+                """
+            )
+        ),
     )
 
 
@@ -361,6 +511,16 @@ def _record_expected_apps(venv: Venv, expected_apps: Sequence[str]) -> None:
         return
     venv.pipx_metadata.main_package = replace(venv.pipx_metadata.main_package, expected_apps=expected)
     venv.pipx_metadata.write()
+
+
+def _installed_package(venv: Venv, package_name: str) -> _InstalledPackage:
+    package: Final[PackageInfo] = venv.package_metadata[package_name]
+    return _InstalledPackage(
+        environment=venv.name,
+        package=str(package.package),
+        version=package.package_version,
+        location=str(venv.root),
+    )
 
 
 def install_all(
@@ -492,7 +652,44 @@ def get_python_interpreter(
     return None
 
 
+@dataclass(frozen=True)
+class _InstalledPackage:
+    environment: str
+    package: str
+    version: str
+    location: str
+
+
+@dataclass(frozen=True)
+class _SkippedInstall:
+    environment: str
+    package: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class _FailedInstall:
+    environment: str
+    error: str
+
+
+@dataclass(frozen=True)
+class _ExistingInstall:
+    continue_install: bool
+    packages: tuple[_InstalledPackage, ...]
+    skipped: tuple[_SkippedInstall, ...]
+    messages: tuple[OutputMessage, ...]
+
+
+@dataclass(frozen=True)
+class InstallData(OperationData):
+    packages: tuple[_InstalledPackage, ...]
+    skipped: tuple[_SkippedInstall, ...]
+    failures: tuple[_FailedInstall, ...]
+
+
 __all__ = [
+    "InstallData",
     "extract_venv_metadata",
     "generate_package_spec",
     "get_python_interpreter",

--- a/src/pipx/commands/manifest.py
+++ b/src/pipx/commands/manifest.py
@@ -19,7 +19,7 @@ from pipx.commands.install import install
 from pipx.commands.uninstall import uninstall
 from pipx.constants import EXIT_CODE_OK, ExitCode
 from pipx.pipx_metadata_file import PipxMetadata
-from pipx.result import render_result
+from pipx.result import OutputFormat, render_result
 from pipx.util import PipxError
 
 if TYPE_CHECKING:
@@ -334,7 +334,7 @@ def _prune_environments(
         with venv_container.venv_lock(venv_dir):
             render_result(
                 uninstall(venv_dir, local_bin_dir, local_man_dir, verbose),
-                json_output=False,
+                output=OutputFormat.HUMAN,
                 quiet=0,
             )
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -47,7 +47,7 @@ from pipx.interpreter import (
     get_default_python_spec,
 )
 from pipx.package_specifier import valid_pypi_name
-from pipx.result import OperationResult, render_result
+from pipx.result import OperationResult, OutputFormat, render_result
 from pipx.shared_libs import skip_shared_libs_maintenance
 from pipx.util import PipxError, mkdir, pipx_wrap, rmdir
 from pipx.venv import VenvContainer
@@ -319,8 +319,14 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:
     with skip_shared_libs_maintenance(getattr(args, "skip_maintenance", False)):
         result = args.func(args, ctx)
         if isinstance(result, OperationResult):
-            return render_result(result, json_output=getattr(args, "json", False), quiet=getattr(args, "quiet", 0))
+            return render_result(result, output=_output_format(args), quiet=getattr(args, "quiet", 0))
         return result
+
+
+def _output_format(args: argparse.Namespace) -> OutputFormat:
+    if getattr(args, "json", False):
+        return OutputFormat.JSON
+    return OutputFormat(getattr(args, "output", OutputFormat.HUMAN))
 
 
 def _validate_backend_available(cli_backend: str | None, env_backend: str | None) -> None:
@@ -520,10 +526,16 @@ def _add_install(subparsers: argparse._SubParsersAction, shared_parser: argparse
     )
     add_pip_venv_args(p)
     add_backend_arg(p)
+    p.add_argument(
+        "--output",
+        choices=[output.value for output in OutputFormat],
+        default=OutputFormat.HUMAN,
+        help="Select the output format.",
+    )
     p.set_defaults(func=_cmd_install)
 
 
-def _cmd_install(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
+def _cmd_install(args: argparse.Namespace, ctx: DispatchContext) -> OperationResult[commands.InstallData]:
     return commands.install(
         None,
         None,
@@ -548,6 +560,7 @@ def _cmd_install(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
         env_backend=ctx.env_backend,
         upgrade_strategy=args.upgrade_strategy,
         cooldown_days=ctx.cooldown_days,
+        emit_output=False,
     )
 
 
@@ -1604,7 +1617,9 @@ def setup(args: argparse.Namespace) -> None:
     if not constants.WINDOWS and getattr(args, "is_global", False):
         paths.ctx.make_global()
 
-    verbose = -2 if getattr(args, "json", False) else getattr(args, "verbose", 0) - getattr(args, "quiet", 0)
+    verbose: Final[int] = (
+        -2 if _output_format(args) is OutputFormat.JSON else getattr(args, "verbose", 0) - getattr(args, "quiet", 0)
+    )
 
     setup_logging(verbose)
     paths.ctx.log_warnings()

--- a/src/pipx/result.py
+++ b/src/pipx/result.py
@@ -18,6 +18,11 @@ class OutputLevel(enum.IntEnum):
     CRITICAL = 2
 
 
+class OutputFormat(str, enum.Enum):
+    HUMAN = "human"
+    JSON = "json"
+
+
 class OutputStream(str, enum.Enum):
     LOG = "log"
     STDOUT = "stdout"
@@ -48,8 +53,17 @@ class OperationResult(Generic[_PayloadT]):
     exit_code: ExitCode = EXIT_CODE_OK
 
 
-def render_result(result: OperationResult[_PayloadT], *, json_output: bool, quiet: int) -> ExitCode:
-    if json_output:
+def render_messages(messages: tuple[OutputMessage, ...], *, quiet: int) -> None:
+    for message in messages:
+        if quiet <= message.level:
+            if message.stream is OutputStream.LOG:
+                _LOGGER.warning(message.text)
+            else:
+                print(message.text, file=sys.stderr if message.stream is OutputStream.STDERR else sys.stdout)
+
+
+def render_result(result: OperationResult[_PayloadT], *, output: OutputFormat, quiet: int) -> ExitCode:
+    if output is OutputFormat.JSON:
         print(
             json.dumps(
                 {
@@ -64,20 +78,17 @@ def render_result(result: OperationResult[_PayloadT], *, json_output: bool, quie
         )
         return result.exit_code
 
-    for message in result.messages:
-        if quiet <= message.level:
-            if message.stream is OutputStream.LOG:
-                _LOGGER.warning(message.text)
-            else:
-                print(message.text, file=sys.stderr if message.stream is OutputStream.STDERR else sys.stdout)
+    render_messages(result.messages, quiet=quiet)
     return result.exit_code
 
 
 __all__ = [
     "OperationData",
     "OperationResult",
+    "OutputFormat",
     "OutputLevel",
     "OutputMessage",
     "OutputStream",
+    "render_messages",
     "render_result",
 ]

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,15 +1,16 @@
+from __future__ import annotations
+
+import json
 import os
 import re
 import shutil
 import subprocess
 import sys
-from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
 from unittest import mock
 
 import pytest
-from pytest_mock import MockerFixture
 
 from helpers import app_name, run_pipx_cli, skip_if_windows, unwrap_log_text
 from package_info import PKG
@@ -21,7 +22,11 @@ from pipx.util import PipxError
 from pipx.venv import Venv
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from unittest.mock import MagicMock
+
+    from _pytest.capture import CaptureResult
+    from pytest_mock import MockerFixture
 
 TEST_DATA_PATH = "./testdata/test_package_specifier"
 
@@ -68,6 +73,24 @@ def test_install_easy_multiple_packages(capsys, pipx_temp_env, caplog):
         ["pycowsay", PKG["black"]["spec"]],
         ["pycowsay", "black"],
     )
+
+
+def test_install_multiple_packages_reports_success_before_failure(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    missing_package: Final[str] = "pipx-package-does-not-exist"
+
+    return_code: Final[int] = run_pipx_cli(["install", "pycowsay", missing_package])
+
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
+    assert (
+        return_code,
+        "installed package pycowsay" in captured.out,
+        "Error installing pipx-package-does-not-exist" in captured.err,
+        (paths.ctx.venvs / "pycowsay").exists(),
+        (paths.ctx.venvs / missing_package).exists(),
+    ) == (1, True, True, True, False)
 
 
 @pytest.mark.parametrize(
@@ -588,7 +611,7 @@ def test_install_force_preserves_expected_app(pipx_temp_env: None) -> None:
 def test_install_backup_failure_preserves_existing_environment(
     pipx_temp_env: None,
     capsys: pytest.CaptureFixture[str],
-    mocker: "MockerFixture",
+    mocker: MockerFixture,
 ) -> None:
     assert not run_pipx_cli(["install", "--app", "pycowsay", PKG["pycowsay"]["spec"]])
     mocker.patch("pipx.commands.transaction.copytree", autospec=True, side_effect=OSError("disk full"))
@@ -710,7 +733,7 @@ def test_install_reuses_empty_environment_dir(pipx_temp_env: None) -> None:
     ) == (EXIT_CODE_OK, "pycowsay")
 
 
-def test_install_upgrade_satisfied_spec_is_offline(pipx_temp_env, capsys, mocker: "MockerFixture"):
+def test_install_upgrade_satisfied_spec_is_offline(pipx_temp_env, capsys, mocker: MockerFixture):
     assert not run_pipx_cli(["install", PKG["black"]["spec"]])
     check_shared = mocker.patch.object(Venv, "check_upgrade_shared_libs", autospec=True)
     upgrade_package = mocker.patch.object(Venv, "upgrade_package", autospec=True)
@@ -727,7 +750,7 @@ def test_install_upgrade_strategy_requires_upgrade(pipx_temp_env, capsys):
     assert "--upgrade-strategy requires --upgrade" in capsys.readouterr().err
 
 
-def test_install_existing_package_skips_shared_lib_maintenance(pipx_temp_env: None, mocker: "MockerFixture") -> None:
+def test_install_existing_package_skips_shared_lib_maintenance(pipx_temp_env: None, mocker: MockerFixture) -> None:
     assert run_pipx_cli(["install", PKG["pycowsay"]["spec"]]) == 0
     mocker.patch.object(shared_libs.shared_libs, "has_been_updated_this_run", False)
     mocker.patch(
@@ -1247,6 +1270,123 @@ def test_install_quiet_flag(pipx_temp_env, capsys):
     assert "These apps are now" not in captured.out
     assert "done!" not in captured.out
     assert "done!" not in captured.err
+
+
+def test_install_json(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert not run_pipx_cli(["install", "--output", "json", "pycowsay"])
+
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
+    assert not captured.err
+    assert json.loads(captured.out) == {
+        "command": "install",
+        "data": {
+            "failures": [],
+            "packages": [
+                {
+                    "environment": "pycowsay",
+                    "location": str(paths.ctx.venvs / "pycowsay"),
+                    "package": "pycowsay",
+                    "version": "0.0.0.2",
+                }
+            ],
+            "skipped": [],
+        },
+        "pipx_result_version": "0.1",
+        "status": "success",
+    }
+
+
+def test_install_json_reports_existing(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    capsys.readouterr()
+
+    assert not run_pipx_cli(["install", "--output", "json", "pycowsay"])
+
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
+    assert not captured.err
+    assert json.loads(captured.out) == {
+        "command": "install",
+        "data": {
+            "failures": [],
+            "packages": [],
+            "skipped": [
+                {
+                    "environment": "pycowsay",
+                    "package": "pycowsay",
+                    "reason": "already-installed",
+                }
+            ],
+        },
+        "pipx_result_version": "0.1",
+        "status": "success",
+    }
+
+
+def test_install_json_reports_invalid_option(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert run_pipx_cli(["install", "--output", "json", "--upgrade-strategy", "eager", "pycowsay"])
+
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
+    assert not captured.err
+    assert json.loads(captured.out) == {
+        "command": "install",
+        "data": {
+            "failures": [
+                {
+                    "environment": "pycowsay",
+                    "error": "--upgrade-strategy requires --upgrade",
+                }
+            ],
+            "packages": [],
+            "skipped": [],
+        },
+        "pipx_result_version": "0.1",
+        "status": "error",
+    }
+
+
+def test_install_json_reports_missing_app(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert run_pipx_cli(["install", "--output", "json", "--app", "missing", "pycowsay"])
+
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
+    assert not captured.err
+    assert (
+        json.loads(captured.out),
+        (paths.ctx.venvs / "pycowsay").exists(),
+    ) == (
+        {
+            "command": "install",
+            "data": {
+                "failures": [
+                    {
+                        "environment": "pycowsay",
+                        "error": "Package pycowsay does not provide expected app missing. Available apps:\npycowsay.",
+                    }
+                ],
+                "packages": [],
+                "skipped": [],
+            },
+            "pipx_result_version": "0.1",
+            "status": "error",
+        },
+        False,
+    )
+
+
+def test_install_keyboard_interrupt_removes_environment(pipx_temp_env: None, mocker: MockerFixture) -> None:
+    mocker.patch.object(Venv, "install_package", autospec=True, side_effect=KeyboardInterrupt)
+
+    assert (
+        run_pipx_cli(["install", "pycowsay"]),
+        (paths.ctx.venvs / "pycowsay").exists(),
+    ) == (1, False)
+
+
+def test_install_error_removes_environment(pipx_temp_env: None, mocker: MockerFixture) -> None:
+    mocker.patch.object(Venv, "install_package", autospec=True, side_effect=RuntimeError("failed"))
+
+    with pytest.raises(RuntimeError, match="failed"):
+        run_pipx_cli(["install", "pycowsay"])
+    assert not (paths.ctx.venvs / "pycowsay").exists()
 
 
 def test_install_skip_maintenance_without_index(


### PR DESCRIPTION
Scripts must parse `pipx install` terminal output because the command does not use the versioned result envelope shared by other state-changing commands. This advances [#828](https://github.com/pypa/pipx/issues/828).

The command accepts `--output human` or `--output json`; the selector can accommodate another renderer without adding another flag. The structured result records installed, skipped, and failed environments, while human output keeps its summaries and partial-success reporting. Failed installs keep rollback behavior in either format.
