### PR TITLE
✨ feat(cache): manage run environments

### DIFF
--- a/changelog.d/1681.feature.md
+++ b/changelog.d/1681.feature.md
@@ -1,0 +1,1 @@
+Add `pipx cache` and `pipx run --refresh`.

--- a/docs/explanation/comparisons.md
+++ b/docs/explanation/comparisons.md
@@ -44,6 +44,9 @@ managers writes the same filename. Each manager refuses to overwrite a binary th
 | Install from a git URL       | `pipx install 'git+https://…'`                    | `uv tool install 'git+https://…'`                                   |
 | Install editable from path   | `pipx install -e ./mypkg`                         | `uv tool install -e ./mypkg`                                        |
 | One-off run (no install)     | `pipx run black .`                                | `uvx black .`                                                       |
+| Refresh one-off run          | `pipx run --refresh black .`                      | `uvx --refresh black .`                                             |
+| Show ephemeral cache         | `pipx cache dir`                                  | `uv cache dir`                                                      |
+| Purge ephemeral cache        | `pipx cache purge`                                | `uv cache clean`                                                    |
 | One-off run with extra dep   | _no clean equivalent_                             | `uvx --with mkdocs-material mkdocs`                                 |
 | Pinned-version one-off       | `pipx run --spec 'ruff==0.6.0' ruff check`        | `uvx ruff@0.6.0 check`                                              |
 | Add a dep to existing tool   | `pipx inject mkdocs mkdocs-material`              | `uv tool install mkdocs --with mkdocs-material` (rebuilds)          |
@@ -91,7 +94,8 @@ managers writes the same filename. Each manager refuses to overwrite a binary th
 ### Gotchas
 
 - `uvx` reuses cached envs across invocations until you prune the cache (`uv cache clean`), pin a new version
-    (`uvx black@latest`), or pass `--refresh`. `pipx run` also caches, but the temp venv expires after 14 days idle.
+    (`uvx black@latest`), or pass `--refresh`. `pipx run` caches for 14 days and accepts `--refresh` for an early
+    replacement.
 - `uvx` prefers a persistent install when one exists. After `uv tool install ruff`, plain `uvx ruff` reuses that env
     instead of building an ephemeral one. Pass `--isolated` to bypass.
 - `uv tool` ignores project-local `.python-version` files. `uv run` honors them; tool envs do not. pipx never reads

--- a/docs/how-to/use-uv-backend.md
+++ b/docs/how-to/use-uv-backend.md
@@ -47,7 +47,8 @@ pipx environment --value PIPX_RESOLVED_BACKEND  # see what pipx will use right n
 - pipx creates new venvs with `uv venv`. The venv contains no `pip` and no `pipx_shared.pth` file.
 - `pipx runpip` runs `uv pip <args> --python <venv>/bin/python`. uv rejects flags it doesn't understand instead of pipx
     silently dropping them.
-- `pipx run` execs `uv tool run`; the cache lives in uv's cache directory. Pass `--no-cache` to skip it.
+- `pipx run` execs `uv tool run`; the cache lives in uv's cache directory. Pass `--no-cache` to skip it or `--refresh`
+    to replace the matching cached environment.
 - `pipx run script.py` execs `uv run --script script.py` for PEP 723 inline scripts.
 - `--cooldown DAYS` maps to uv's `--exclude-newer P{DAYS}D`. Relative cooldowns require uv 0.9.17 or newer.
 
@@ -66,6 +67,6 @@ pipx environment --value PIPX_RESOLVED_BACKEND  # see what pipx will use right n
 ## Cache layout
 
 `pipx run` under the uv backend caches in `UV_CACHE_DIR` instead of `PIPX_VENV_CACHEDIR`. Switching the default backend
-on a host that already used `pipx run` leaves the old pipx cache behind: `pipx environment` prints both paths so you can
-inspect them and remove the unused one manually. The 14-day expiry sweep that pipx applies to its own venv cache does
-not extend to uv's cache, which uv manages on its own schedule (`uv cache clean`).
+on a host that already used `pipx run` leaves the old pipx cache behind. Use `pipx cache dir` to find that cache and
+`pipx cache purge` to remove its environments. The 14-day expiry sweep that pipx applies to its own venv cache does not
+extend to uv's cache, which uv manages on its own schedule (`uv cache clean`).

--- a/docs/man/pipx.1.rst
+++ b/docs/man/pipx.1.rst
@@ -16,8 +16,8 @@ SYNOPSIS
 
 **pipx** [*global-options*] [**install** | **install-all** | **lock** | **sync** | **uninject** | **inject** |
 **expose** | **unexpose** | **pin** | **unpin** | **upgrade** | **upgrade-all** | **upgrade-shared** | **uninstall** |
-**uninstall-all** | **reinstall** | **reinstall-all** | **health** | **repair** | **list** | **interpreter** | **run** |
-**runpip** | **ensurepath** | **environment** | **completions** | **help**] [*command-options*]
+**uninstall-all** | **reinstall** | **reinstall-all** | **health** | **repair** | **list** | **interpreter** | **cache**
+| **run** | **runpip** | **ensurepath** | **environment** | **completions** | **help**] [*command-options*]
 
 DESCRIPTION
 -----------
@@ -90,6 +90,9 @@ COMMANDS
 
 **interpreter**
     Interact with interpreters managed by pipx
+
+**cache**
+    Manage cached run environments
 
 **run**
     Download the latest version of a package to a temporary virtual environment, then run an app from it. Also

--- a/docs/tutorial/run-applications.md
+++ b/docs/tutorial/run-applications.md
@@ -45,6 +45,28 @@ Arguments after the application name pass straight through:
 
 pipx caches virtual environments per app for a few days. After they expire, pipx fetches the latest version.
 
+### Refresh or clear cached runs
+
+Use `--refresh` when a cached environment is corrupt or you want to replace it before it expires. pipx discards only
+that application's cached environment and retains the replacement:
+
+```
+pipx run --refresh APP
+```
+
+`--no-cache` also rebuilds the environment, but marks the replacement for removal by a later run. The two options are
+mutually exclusive.
+
+Inspect or clear every pipx-managed run environment with:
+
+```
+pipx cache dir
+pipx cache purge
+```
+
+The uv backend keeps ephemeral environments in uv's cache. `pipx run --refresh --backend uv APP` forwards uv's native
+refresh option; use `uv cache dir` and `uv cache clean` to inspect or clear that cache.
+
 ### Ambiguous arguments
 
 pipx can consume arguments meant for the application:
@@ -52,7 +74,7 @@ pipx can consume arguments meant for the application:
 ```
 > pipx run pycowsay --py
 
-usage: pipx run [-h] [--no-cache] [--pypackages] [--spec SPEC] [--verbose] [--python PYTHON]
+usage: pipx run [-h] [--no-cache | --refresh] [--pypackages] [--spec SPEC] [--verbose] [--python PYTHON]
                 [--system-site-packages] [--index-url INDEX_URL] [--editable] [--pip-args PIP_ARGS]
                 [--cooldown DAYS]
                 app ...

--- a/src/pipx/commands/__init__.py
+++ b/src/pipx/commands/__init__.py
@@ -1,3 +1,4 @@
+from pipx.commands.cache import print_cache_dir, purge_cache
 from pipx.commands.ensure_path import ensure_pipx_paths
 from pipx.commands.environment import environment
 from pipx.commands.expose import ExposureData, expose, unexpose
@@ -36,7 +37,9 @@ __all__ = [
     "list_packages",
     "lock_manifest",
     "pin",
+    "print_cache_dir",
     "prune_interpreters",
+    "purge_cache",
     "reinstall",
     "reinstall_all",
     "repair",

--- a/src/pipx/commands/cache.py
+++ b/src/pipx/commands/cache.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+from pipx.constants import EXIT_CODE_OK, ExitCode
+from pipx.util import rmdir
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pipx.venv import VenvContainer
+
+
+def print_cache_dir(venv_container: VenvContainer) -> ExitCode:
+    print(venv_container)
+    return EXIT_CODE_OK
+
+
+def purge_cache(venv_container: VenvContainer) -> ExitCode:
+    venv_dirs: Final[tuple[Path, ...]] = tuple(venv_container.iter_venv_dirs())
+    removed = 0
+    for venv_dir in venv_container.iter_locked_venv_dirs(venv_dirs):
+        rmdir(venv_dir)
+        removed += 1
+    noun: Final[str] = "environment" if removed == 1 else "environments"
+    print(f"Removed {removed} cached {noun}.")
+    return EXIT_CODE_OK
+
+
+__all__ = [
+    "print_cache_dir",
+    "purge_cache",
+]

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -6,6 +6,8 @@ import sys
 import time
 import urllib.parse
 import urllib.request
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from shutil import which
 from typing import Final, NoReturn
@@ -27,7 +29,7 @@ from pipx.util import (
     rmdir,
     run_pypackage_bin,
 )
-from pipx.venv import Venv
+from pipx.venv import Venv, VenvContainer
 
 if sys.version_info < (3, 11):
     import tomli as tomllib
@@ -89,6 +91,7 @@ def run_script(
     verbose: bool,
     use_cache: bool,
     *,
+    refresh: bool = False,
     backend: str | None = None,
     env_backend: str | None = None,
     resolved_backend: str | None = None,
@@ -119,6 +122,7 @@ def run_script(
                 venv_args=venv_args,
                 use_cache=use_cache,
                 verbose=verbose,
+                refresh=refresh,
                 dependencies=dependencies,
                 cooldown_days=cooldown_days,
             )
@@ -138,25 +142,26 @@ def run_script(
         )
 
     if not requirements:
-        python_path = Path(python)
-    else:
-        # Note that the environment name is based on the identified
-        # requirements, and *not* on the script name. This is deliberate, as
-        # it ensures that two scripts with the same requirements can use the
-        # same environment, which means fewer environments need to be
-        # managed. The requirements are normalised (in
-        # _get_requirements_from_script), so that irrelevant differences in
-        # whitespace, and similar, don't prevent environment sharing.
-        venv_dir = _get_temporary_venv_path(
-            requirements,
-            python,
-            pip_args,
-            venv_args,
-            resolved_backend or "pip",
-            cooldown_days,
-        )
+        _exec_script(Path(python), content, app_args)
+
+    # Note that the environment name is based on the identified
+    # requirements, and *not* on the script name. This is deliberate, as
+    # it ensures that two scripts with the same requirements can use the
+    # same environment, which means fewer environments need to be
+    # managed. The requirements are normalised (in
+    # _get_requirements_from_script), so that irrelevant differences in
+    # whitespace, and similar, don't prevent environment sharing.
+    venv_dir = _get_temporary_venv_path(
+        requirements,
+        python,
+        pip_args,
+        venv_args,
+        resolved_backend or "pip",
+        cooldown_days,
+    )
+    with _locked_venv_cache(venv_dir):
         venv = Venv(venv_dir, backend=backend, env_backend=env_backend)
-        _prepare_venv_cache(venv, None, use_cache)
+        _prepare_venv_cache(venv, None, use_cache, refresh=refresh)
         if venv_dir.exists():
             _LOGGER.info(f"Reusing cached venv {venv_dir}")
         else:
@@ -171,8 +176,10 @@ def run_script(
                 # when `pipx run` is next executed, rather than just failing.
                 (venv_dir / _VENV_EXPIRED_FILENAME).touch()
                 raise
-        python_path = venv.python_path
+        _exec_script(venv.python_path, content, app_args)
 
+
+def _exec_script(python_path: Path, content: str | Path, app_args: list[str]) -> NoReturn:
     if isinstance(content, Path):
         exec_app([python_path, content, *app_args])
     else:
@@ -191,6 +198,7 @@ def run_package(
     verbose: bool,
     use_cache: bool,
     *,
+    refresh: bool = False,
     infer_app_name: bool = False,
     backend: str | None = None,
     env_backend: str | None = None,
@@ -237,49 +245,50 @@ def run_package(
         cooldown_days,
     )
 
-    venv = Venv(venv_dir, backend=backend, env_backend=env_backend)
-    if infer_app_name and venv.pipx_metadata.main_package.package is not None:
-        app = venv.pipx_metadata.main_package.package
-        app_filename = f"{app}.exe" if WINDOWS else app
-    bin_path = venv.bin_path / app_filename
-    _prepare_venv_cache(venv, bin_path, use_cache)
+    with _locked_venv_cache(venv_dir):
+        venv = Venv(venv_dir, backend=backend, env_backend=env_backend)
+        if infer_app_name and venv.pipx_metadata.main_package.package is not None:
+            app = venv.pipx_metadata.main_package.package
+            app_filename = f"{app}.exe" if WINDOWS else app
+        bin_path = venv.bin_path / app_filename
+        _prepare_venv_cache(venv, bin_path, use_cache, refresh=refresh)
 
-    if venv.has_app(app, app_filename):
-        _LOGGER.info(f"Reusing cached venv {venv_dir}")
-    else:
-        _LOGGER.info(f"venv location is {venv_dir}")
-        venv, app, app_filename = _prepare_venv(
-            Path(venv_dir),
-            package_or_url,
-            app,
-            app_filename,
-            python,
-            pip_args,
-            venv_args,
-            use_cache,
-            verbose,
-            infer_app_name=infer_app_name,
-            backend=backend,
-            env_backend=env_backend,
-            cooldown_days=cooldown_days,
-        )
+        if venv.has_app(app, app_filename):
+            _LOGGER.info(f"Reusing cached venv {venv_dir}")
+        else:
+            _LOGGER.info(f"venv location is {venv_dir}")
+            venv, app, app_filename = _prepare_venv(
+                Path(venv_dir),
+                package_or_url,
+                app,
+                app_filename,
+                python,
+                pip_args,
+                venv_args,
+                use_cache,
+                verbose,
+                infer_app_name=infer_app_name,
+                backend=backend,
+                env_backend=env_backend,
+                cooldown_days=cooldown_days,
+            )
 
-    for dependency in dependencies:
-        inject_dep(
-            venv_dir=venv_dir,
-            package_name=None,
-            package_spec=dependency,
-            pip_args=pip_args,
-            verbose=verbose,
-            include_apps=False,
-            include_dependencies=False,
-            include_apps_from=(),
-            force=False,
-            backend=backend,
-            env_backend=env_backend,
-            cooldown_days=cooldown_days,
-        )
-    venv.run_app(app, app_filename, app_args)
+        for dependency in dependencies:
+            inject_dep(
+                venv_dir=venv_dir,
+                package_name=None,
+                package_spec=dependency,
+                pip_args=pip_args,
+                verbose=verbose,
+                include_apps=False,
+                include_dependencies=False,
+                include_apps_from=(),
+                force=False,
+                backend=backend,
+                env_backend=env_backend,
+                cooldown_days=cooldown_days,
+            )
+        venv.run_app(app, app_filename, app_args)
 
 
 def run(
@@ -295,6 +304,7 @@ def run(
     verbose: bool,
     use_cache: bool,
     *,
+    refresh: bool = False,
     no_path_check: bool = False,
     backend: str | None = None,
     env_backend: str | None = None,
@@ -325,6 +335,7 @@ def run(
             venv_args,
             verbose,
             use_cache,
+            refresh=refresh,
             backend=backend,
             env_backend=env_backend,
             resolved_backend=resolved_backend,
@@ -343,6 +354,7 @@ def run(
             pip_args=pip_args,
             venv_args=venv_args,
             use_cache=use_cache,
+            refresh=refresh,
             verbose=verbose,
             no_path_check=no_path_check,
             cooldown_days=cooldown_days,
@@ -360,6 +372,7 @@ def run(
             pypackages,
             verbose,
             use_cache,
+            refresh=refresh,
             infer_app_name=spec is None and _is_vcs_url(app),
             backend=backend,
             env_backend=env_backend,
@@ -485,19 +498,33 @@ def _is_temporary_venv_expired(venv_dir: Path) -> bool:
     return age > expiration_threshold_sec or (venv_dir / _VENV_EXPIRED_FILENAME).exists()
 
 
-def _prepare_venv_cache(venv: Venv, bin_path: Path | None, use_cache: bool) -> None:
+@contextmanager
+def _locked_venv_cache(venv_dir: Path) -> Iterator[None]:
+    venv_container: Final[VenvContainer] = VenvContainer(paths.ctx.venv_cache)
+    for cached_venv_dir in sorted(venv_container.iter_venv_dirs()):
+        if cached_venv_dir == venv_dir:
+            continue
+        with venv_container.venv_lock(cached_venv_dir):
+            _remove_expired_venv(cached_venv_dir)
+    with venv_container.venv_lock(venv_dir):
+        _remove_expired_venv(venv_dir)
+        yield
+
+
+def _prepare_venv_cache(venv: Venv, bin_path: Path | None, use_cache: bool, *, refresh: bool = False) -> None:
     venv_dir = venv.root
-    if not use_cache and (bin_path is None or bin_path.exists()):
+    if refresh and venv_dir.exists():
+        _LOGGER.info(f"Refreshing cached venv {venv_dir!s}")
+        rmdir(venv_dir)
+    elif not use_cache and (bin_path is None or bin_path.exists()):
         _LOGGER.info(f"Removing cached venv {venv_dir!s}")
         rmdir(venv_dir)
-    _remove_all_expired_venvs()
 
 
-def _remove_all_expired_venvs() -> None:
-    for venv_dir in Path(paths.ctx.venv_cache).iterdir():
-        if venv_dir.is_dir() and _is_temporary_venv_expired(venv_dir):
-            _LOGGER.info(f"Removing expired venv {venv_dir!s}")
-            rmdir(venv_dir)
+def _remove_expired_venv(venv_dir: Path) -> None:
+    if venv_dir.is_dir() and _is_temporary_venv_expired(venv_dir):
+        _LOGGER.info(f"Removing expired venv {venv_dir!s}")
+        rmdir(venv_dir)
 
 
 def _http_get_request(url: str) -> str:

--- a/src/pipx/commands/run_uv.py
+++ b/src/pipx/commands/run_uv.py
@@ -45,6 +45,7 @@ def run_via_uv_tool_run(
     venv_args: list[str],
     use_cache: bool,
     verbose: bool,
+    refresh: bool = False,
     no_path_check: bool = False,
     cooldown_days: int | None = None,
 ) -> NoReturn:
@@ -69,6 +70,8 @@ def run_via_uv_tool_run(
         cmd += ["--with", dependency]
     if not use_cache:
         cmd.append("--no-cache")
+    if refresh:
+        cmd.append("--refresh")
     if verbose:
         cmd.append("--verbose")
     cmd += translate_pip_args_for_uv(pip_args)
@@ -87,6 +90,7 @@ def run_script_via_uv_run(
     venv_args: list[str],
     use_cache: bool,
     verbose: bool,
+    refresh: bool = False,
     dependencies: list[str] | None = None,
     cooldown_days: int | None = None,
 ) -> NoReturn:
@@ -96,6 +100,8 @@ def run_script_via_uv_run(
         cmd += ["--python", python]
     if not use_cache:
         cmd.append("--no-cache")
+    if refresh:
+        cmd.append("--refresh")
     if verbose:
         cmd.append("--verbose")
     for dependency in dependencies or []:

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -1196,6 +1196,44 @@ def _cmd_interpreter_upgrade(args: argparse.Namespace, ctx: DispatchContext) -> 
     return commands.upgrade_interpreters(ctx.venv_container, ctx.verbose)
 
 
+def _add_cache(
+    subparsers: argparse._SubParsersAction, shared_parser: argparse.ArgumentParser
+) -> argparse.ArgumentParser:
+    parser: Final[argparse.ArgumentParser] = subparsers.add_parser(
+        "cache",
+        help="Manage cached run environments",
+        description="Manage cached run environments",
+        parents=[shared_parser],
+    )
+    subcommands: Final[argparse._SubParsersAction] = parser.add_subparsers(
+        title="subcommands",
+        description="Get help for commands with pipx cache COMMAND --help",
+        dest="cache_command",
+    )
+    dir_parser: Final[argparse.ArgumentParser] = subcommands.add_parser(
+        "dir",
+        help="Show the cache directory",
+        description="Show the cache directory",
+    )
+    purge_parser: Final[argparse.ArgumentParser] = subcommands.add_parser(
+        "purge",
+        help="Remove cached run environments",
+        description="Remove cached run environments",
+    )
+    dir_parser.set_defaults(func=_cmd_cache_dir)
+    purge_parser.set_defaults(func=_cmd_cache_purge)
+    parser.set_defaults(func=_make_print_help(parser))
+    return parser
+
+
+def _cmd_cache_dir(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
+    return commands.print_cache_dir(VenvContainer(paths.ctx.venv_cache))
+
+
+def _cmd_cache_purge(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
+    return commands.purge_cache(VenvContainer(paths.ctx.venv_cache))
+
+
 def _add_run(subparsers: argparse._SubParsersAction, shared_parser: argparse.ArgumentParser) -> None:
     p = subparsers.add_parser(
         "run",
@@ -1221,10 +1259,16 @@ def _add_run(subparsers: argparse._SubParsersAction, shared_parser: argparse.Arg
         ),
         parents=[shared_parser],
     )
-    p.add_argument(
+    cache_group: Final[argparse._MutuallyExclusiveGroup] = p.add_mutually_exclusive_group()
+    cache_group.add_argument(
         "--no-cache",
         action="store_true",
         help="Do not reuse cached virtual environment if it exists",
+    )
+    cache_group.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Rebuild and cache the virtual environment",
     )
     p.add_argument(
         "--no-path-check",
@@ -1276,6 +1320,7 @@ def _cmd_run(args: argparse.Namespace, ctx: DispatchContext) -> NoReturn:
         args.pypackages,
         ctx.verbose,
         not args.no_cache,
+        refresh=args.refresh,
         no_path_check=args.no_path_check,
         backend=ctx.backend,
         env_backend=ctx.env_backend,
@@ -1494,6 +1539,7 @@ def get_command_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Ar
     _add_repair(subparsers, completer_venvs.use, shared_parser)
     _add_list(subparsers, shared_parser)
     subparsers_with_subcommands["interpreter"] = _add_interpreter(subparsers, shared_parser)
+    subparsers_with_subcommands["cache"] = _add_cache(subparsers, shared_parser)
     _add_run(subparsers, shared_parser)
     _add_runpip(subparsers, completer_venvs.use, shared_parser)
     _add_ensurepath(subparsers, shared_parser)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Final
+
+import pytest
+
+from helpers import run_pipx_cli
+from pipx import paths
+
+
+def test_cache_dir(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert not run_pipx_cli(["cache", "dir"])
+
+    assert capsys.readouterr().out.strip() == str(paths.ctx.venv_cache)
+
+
+@pytest.mark.parametrize(
+    ("count", "expected"),
+    [
+        pytest.param(0, "Removed 0 cached environments.\n", id="empty"),
+        pytest.param(1, "Removed 1 cached environment.\n", id="one"),
+        pytest.param(2, "Removed 2 cached environments.\n", id="multiple"),
+    ],
+)
+def test_cache_purge_removes_run_environments(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    count: int,
+    expected: str,
+) -> None:
+    cache_names: Final[tuple[str, ...]] = tuple(f"cache-{index}" for index in range(count))
+    paths.ctx.venv_cache.mkdir(parents=True)
+    for cache_name in cache_names:
+        (paths.ctx.venv_cache / cache_name).mkdir()
+
+    assert not run_pipx_cli(["cache", "purge"])
+
+    assert (
+        capsys.readouterr().out,
+        tuple(path for path in paths.ctx.venv_cache.iterdir() if path.is_dir()),
+    ) == (expected, ())

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -68,6 +68,39 @@ def test_cache(pipx_temp_env, monkeypatch, capsys, caplog):
     assert "Removing cached venv" in caplog.text
 
 
+@mock.patch("os.execvpe", new=execvpe_mock)
+def test_run_refresh_rebuilds_cached_environment(pipx_temp_env: None) -> None:
+    run_pipx_cli_exit(["run", "pycowsay", "cowsay", "args"])
+    venv_dir: Final[Path] = next(path for path in paths.ctx.venv_cache.iterdir() if path.is_dir())
+    marker: Final[Path] = venv_dir / "marker"
+    marker.touch()
+
+    run_pipx_cli_exit(["run", "--refresh", "pycowsay", "cowsay", "args"])
+
+    assert not marker.exists()
+
+
+@mock.patch("os.execvpe", new=execvpe_mock)
+def test_run_refresh_retains_replacement(pipx_temp_env: None) -> None:
+    run_pipx_cli_exit(["run", "--refresh", "pycowsay", "cowsay", "args"])
+    venv_dir: Final[Path] = next(path for path in paths.ctx.venv_cache.iterdir() if path.is_dir())
+    marker: Final[Path] = venv_dir / "marker"
+    marker.touch()
+
+    run_pipx_cli_exit(["run", "pycowsay", "cowsay", "args"])
+
+    assert marker.exists()
+
+
+def test_run_cache_options_are_mutually_exclusive(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit, match="2"):
+        run_pipx_cli(["run", "--no-cache", "--refresh", "pycowsay"])
+    assert "not allowed with argument" in capsys.readouterr().err
+
+
 def test_run_does_not_mark_cache_as_installation(pipx_temp_env: None, mocker: MockerFixture) -> None:
     mocker.patch("os.execvpe", new=execvpe_mock)
 

--- a/tests/test_run_uv.py
+++ b/tests/test_run_uv.py
@@ -122,6 +122,28 @@ def test_run_via_uv_tool_run_omits_from_when_app_matches_spec(
     assert "--from" not in exec_mock.call_args.args[0]
 
 
+def test_run_via_uv_tool_run_refreshes_cache(
+    exec_mock: MagicMock,
+    fake_uv: Path,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("pipx.commands.run_uv.which", return_value=None)
+    with pytest.raises(RuntimeError, match="exec"):
+        run_via_uv_tool_run(
+            app="black",
+            package_or_url="black",
+            dependencies=[],
+            app_args=[],
+            python="",
+            pip_args=[],
+            venv_args=[],
+            use_cache=True,
+            refresh=True,
+            verbose=False,
+        )
+    assert "--refresh" in exec_mock.call_args.args[0]
+
+
 @pytest.mark.parametrize(
     ("cooldown_days", "cooldown_args"),
     [
@@ -159,6 +181,27 @@ def test_run_script_via_uv_run_uses_uv_run_script(
         str(script),
         "--quiet",
     ]
+
+
+def test_run_script_via_uv_run_refreshes_cache(
+    exec_mock: MagicMock,
+    fake_uv: Path,
+    tmp_path: Path,
+) -> None:
+    script: Final[Path] = tmp_path / "demo.py"
+    script.write_text("print('hi')\n")
+    with pytest.raises(RuntimeError, match="exec"):
+        run_script_via_uv_run(
+            script_path=script,
+            app_args=[],
+            python="",
+            pip_args=[],
+            venv_args=[],
+            use_cache=True,
+            verbose=False,
+            refresh=True,
+        )
+    assert "--refresh" in exec_mock.call_args.args[0]
 
 
 def test_run_via_uv_tool_run_rejects_venv_args(mocker: MockerFixture, fake_uv: Path) -> None:


### PR DESCRIPTION
`pipx run` caches environments for 14 days, but corrupt entries require manual deletion and `--no-cache` rebuilds an environment that the next invocation discards. Closes https://github.com/pypa/pipx/issues/1681 and closes https://github.com/pypa/pipx/issues/464.

`pipx cache dir` locates pipx-managed run environments, `pipx cache purge` removes them, and `pipx run --refresh` replaces one entry while retaining the result. The uv backend receives its native `--refresh`; uv remains responsible for its own cache.

Cache mutation uses per-environment locks. Expiry sweeps hold one lock at a time, while rebuilds and removals serialize the affected entry.
