### PR TITLE
✨ feat(exec): run installed applications

### DIFF
--- a/changelog.d/1726.feature.md
+++ b/changelog.d/1726.feature.md
@@ -1,0 +1,1 @@
+Add `pipx exec ENVIRONMENT APPLICATION` for installed environments.

--- a/docs/man/pipx.1.rst
+++ b/docs/man/pipx.1.rst
@@ -17,7 +17,7 @@ SYNOPSIS
 **pipx** [*global-options*] [**install** | **install-all** | **lock** | **sync** | **uninject** | **inject** |
 **expose** | **unexpose** | **pin** | **unpin** | **upgrade** | **upgrade-all** | **upgrade-shared** | **uninstall** |
 **uninstall-all** | **reinstall** | **reinstall-all** | **health** | **repair** | **list** | **interpreter** | **cache**
-| **run** | **runpip** | **ensurepath** | **environment** | **completions** | **help**] [*command-options*]
+| **run** | **exec** | **runpip** | **ensurepath** | **environment** | **completions** | **help**] [*command-options*]
 
 DESCRIPTION
 -----------
@@ -97,6 +97,9 @@ COMMANDS
 **run**
     Download the latest version of a package to a temporary virtual environment, then run an app from it. Also
     compatible with local ``__pypackages__`` directory (experimental).
+
+**exec**
+    Run an application from an existing pipx environment
 
 **runpip**
     Run pip in an existing pipx-managed Virtual Environment

--- a/docs/tutorial/install-applications.md
+++ b/docs/tutorial/install-applications.md
@@ -68,6 +68,20 @@ pipx install "nox[tox_to_nox]" --include-apps-from tox
 Repeat `--include-apps-from` to select more dependencies. pipx records the selection for upgrade and reinstall. The
 install fails and rolls back when a selected package is not a dependency with apps or manual pages.
 
+### Running an application without exposing it
+
+Use `exec` to run a recorded application from an existing environment without adding it to the pipx binary directory.
+
+```
+pipx inject nox tox
+pipx exec nox tox --version
+```
+
+The application may belong to the main package, an injected package, or a dependency. pipx adds the selected
+environment's binary directory to the child process `PATH` and sets `VIRTUAL_ENV`, so sibling applications can call each
+other. `exec` does not install packages, change the environment, expose applications, or start a shell. Use `inject`
+first when the environment does not contain the application.
+
 ### Requiring an application entry point
 
 Pass `--app` when automation depends on a specific command.

--- a/src/pipx/commands/__init__.py
+++ b/src/pipx/commands/__init__.py
@@ -1,6 +1,7 @@
 from pipx.commands.cache import print_cache_dir, purge_cache
 from pipx.commands.ensure_path import ensure_pipx_paths
 from pipx.commands.environment import environment
+from pipx.commands.execute import execute
 from pipx.commands.expose import ExposureData, expose, unexpose
 from pipx.commands.health import HealthData, RepairData, health, repair
 from pipx.commands.inject import inject
@@ -27,6 +28,7 @@ __all__ = [
     "UninstallData",
     "ensure_pipx_paths",
     "environment",
+    "execute",
     "expose",
     "health",
     "inject",

--- a/src/pipx/commands/execute.py
+++ b/src/pipx/commands/execute.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import os
+from itertools import chain
+from typing import TYPE_CHECKING, Final, NoReturn
+
+from pipx.constants import WINDOWS
+from pipx.util import PipxError, exec_app
+from pipx.venv import Venv
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pipx.pipx_metadata_file import PackageInfo
+
+
+def execute(package: str, venv_dir: Path, app: str, app_args: list[str]) -> NoReturn:
+    if not venv_dir.is_dir():
+        raise PipxError(f"pipx does not manage environment {package!r}.")
+
+    venv: Final[Venv] = Venv(venv_dir)
+    app_paths: Final[dict[str, Path]] = _application_paths(venv)
+    if (app_path := app_paths.get(app)) is None:
+        available: Final[str] = ", ".join(sorted(app_paths)) or "none"
+        raise PipxError(
+            f"Application {app!r} was not found in environment {package!r}.\nAvailable applications: {available}",
+            wrap_message=False,
+        )
+    if not app_path.is_file():
+        raise PipxError(
+            f"Application {app!r} is missing from environment {package!r} at {app_path}.\n"
+            f"Reinstall it with `pipx reinstall {package}`.",
+            wrap_message=False,
+        )
+
+    environment: Final[dict[str, str]] = dict(os.environ)
+    environment["VIRTUAL_ENV"] = str(venv_dir)
+    environment["PATH"] = (
+        os.pathsep.join((str(venv.bin_path), path)) if (path := environment.get("PATH")) else str(venv.bin_path)
+    )
+    exec_app([app_path, *app_args], env=environment)
+
+
+def _application_paths(venv: Venv) -> dict[str, Path]:
+    packages: Final[tuple[PackageInfo, ...]] = (
+        venv.pipx_metadata.main_package,
+        *venv.pipx_metadata.injected_packages.values(),
+    )
+    return {
+        _logical_app_name(path): path
+        for package in packages
+        for path in chain(package.app_paths, *package.app_paths_of_dependencies.values())
+    }
+
+
+def _logical_app_name(path: Path) -> str:
+    return path.stem if WINDOWS and path.suffix.lower() == ".exe" else path.name
+
+
+__all__ = [
+    "execute",
+]

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -11,6 +11,7 @@ import shlex
 import sys
 import textwrap
 import time
+import typing
 import urllib.parse
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -56,6 +57,10 @@ from pipx.version import version as __version__
 logger = logging.getLogger(__name__)
 
 VenvCompleter = Callable[[str], list[str]]
+
+
+class _CompletableAction(typing.Protocol):
+    completer: VenvCompleter
 
 
 def print_version() -> None:
@@ -1328,6 +1333,36 @@ def _cmd_run(args: argparse.Namespace, ctx: DispatchContext) -> NoReturn:
     )
 
 
+def _add_execute(
+    subparsers: argparse._SubParsersAction,
+    venv_completer: VenvCompleter,
+    shared_parser: argparse.ArgumentParser,
+) -> None:
+    parser: Final[argparse.ArgumentParser] = subparsers.add_parser(
+        "exec",
+        help="Run an application from an existing pipx environment",
+        description="Run an application from an existing pipx environment",
+        parents=[shared_parser],
+    )
+    cast(
+        "_CompletableAction", parser.add_argument("package", help="Name of the existing pipx environment")
+    ).completer = venv_completer
+    parser.add_argument("app", help="Application to run")
+    parser.add_argument(
+        "app_args",
+        nargs=argparse.REMAINDER,
+        default=[],
+        help="Arguments to pass to the application",
+    )
+    parser.set_defaults(func=_cmd_execute)
+
+
+def _cmd_execute(args: argparse.Namespace, ctx: DispatchContext) -> NoReturn:
+    venv_dir: Final[Path] = _venv_dir(args, ctx)
+    with ctx.venv_container.venv_lock(venv_dir):
+        commands.execute(args.package, venv_dir, args.app, args.app_args)
+
+
 def _add_runpip(subparsers, venv_completer: VenvCompleter, shared_parser: argparse.ArgumentParser) -> None:
     p = subparsers.add_parser(
         "runpip",
@@ -1541,6 +1576,7 @@ def get_command_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Ar
     subparsers_with_subcommands["interpreter"] = _add_interpreter(subparsers, shared_parser)
     subparsers_with_subcommands["cache"] = _add_cache(subparsers, shared_parser)
     _add_run(subparsers, shared_parser)
+    _add_execute(subparsers, completer_venvs.use, shared_parser)
     _add_runpip(subparsers, completer_venvs.use, shared_parser)
     _add_ensurepath(subparsers, shared_parser)
     _add_environment(subparsers, shared_parser)

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Final
+
+import pytest
+
+from helpers import app_name, run_pipx_cli
+from pipx import paths
+from pipx.util import get_venv_paths
+
+if TYPE_CHECKING:
+    from unittest.mock import MagicMock
+
+    from pytest_mock import MockerFixture
+
+
+@pytest.mark.parametrize(
+    ("setup_commands", "environment_name", "application"),
+    [
+        pytest.param([["install", "pylint==3.0.4"]], "pylint", "isort", id="dependency"),
+        pytest.param(
+            [["install", "pycowsay"], ["inject", "pycowsay", "black"]],
+            "pycowsay",
+            "black",
+            id="injected",
+        ),
+    ],
+)
+def test_execute_runs_recorded_app(
+    pipx_temp_env: None,
+    mocker: MockerFixture,
+    setup_commands: list[list[str]],
+    environment_name: str,
+    application: str,
+) -> None:
+    for setup_command in setup_commands:
+        assert not run_pipx_cli(setup_command)
+    boundary: Final[MagicMock] = mocker.patch.object(
+        importlib.import_module("pipx.commands.execute"),
+        "exec_app",
+        autospec=True,
+        side_effect=RuntimeError("exec"),
+    )
+
+    with pytest.raises(RuntimeError, match="exec"):
+        run_pipx_cli(["exec", environment_name, application, "--version"])
+
+    command: Final[list[str | Path]] = boundary.call_args.args[0]
+    environment: Final[dict[str, str]] = boundary.call_args.kwargs["env"]
+    venv_dir: Final[Path] = paths.ctx.venvs / environment_name
+    bin_dir: Final[Path] = get_venv_paths(venv_dir)[0]
+    assert (
+        Path(command[0]),
+        command[1:],
+        environment["VIRTUAL_ENV"],
+        environment["PATH"].split(os.pathsep)[0],
+    ) == (bin_dir / app_name(application), ["--version"], str(venv_dir), str(bin_dir))
+
+
+def test_execute_rejects_unknown_app(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    capsys.readouterr()
+
+    assert run_pipx_cli(["exec", "pycowsay", "missing"]) == 1
+
+    assert " ".join(capsys.readouterr().err.split()) == (
+        "Application 'missing' was not found in environment 'pycowsay'. Available applications: pycowsay"
+    )
+
+
+def test_execute_rejects_unknown_environment(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert run_pipx_cli(["exec", "missing", "app"]) == 1
+
+    assert capsys.readouterr().err == "pipx does not manage environment 'missing'.\n"
+
+
+def test_execute_rejects_missing_recorded_app(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    venv_dir: Final[Path] = paths.ctx.venvs / "pycowsay"
+    app_path: Final[Path] = get_venv_paths(venv_dir)[0] / app_name("pycowsay")
+    app_path.unlink()
+    capsys.readouterr()
+
+    assert run_pipx_cli(["exec", "pycowsay", "pycowsay"]) == 1
+
+    assert " ".join(capsys.readouterr().err.split()) == (
+        f"Application 'pycowsay' is missing from environment 'pycowsay' at {app_path}. "
+        "Reinstall it with `pipx reinstall pycowsay`."
+    )


### PR DESCRIPTION
Applications supplied by dependencies require global exposure before pipx can run them, which can shadow an unrelated command on `PATH`. Users also cannot choose between same-named applications in separate environments. This resolves https://github.com/pypa/pipx/issues/1726.

`pipx exec ENVIRONMENT APPLICATION [ARGS...]` resolves only applications recorded in the selected installed environment, including injected and dependency applications. It holds that environment's lock, prepends its binary directory to the child `PATH`, sets `VIRTUAL_ENV`, and leaves package and exposure state unchanged.

The command does not install packages, create environments, expose files, or start a shell. Missing environments and applications fail with available application names or reinstall guidance for missing files.
