### PR TITLE
✨ feat(inject): add selectable output

### DIFF
--- a/changelog.d/828.feature.3.md
+++ b/changelog.d/828.feature.3.md
@@ -1,0 +1,1 @@
+Add `--output json` to `pipx inject` and `pipx uninject`.

--- a/docs/how-to/inject-packages.md
+++ b/docs/how-to/inject-packages.md
@@ -15,6 +15,13 @@ pipx inject ipython -r useful-packages.txt
 pipx inject ipython extra-pkg -r more-packages.txt
 ```
 
+Scripts can request the versioned result envelope from either command.
+
+```
+pipx inject ipython matplotlib --output json
+pipx uninject ipython matplotlib --output json
+```
+
 ### Expose injected apps
 
 By default, injected packages do not add their entry points to your `PATH`. Use `--include-apps` to expose them.

--- a/src/pipx/commands/__init__.py
+++ b/src/pipx/commands/__init__.py
@@ -4,7 +4,7 @@ from pipx.commands.environment import environment
 from pipx.commands.execute import execute
 from pipx.commands.expose import ExposureData, expose, unexpose
 from pipx.commands.health import HealthData, RepairData, health, repair
-from pipx.commands.inject import inject
+from pipx.commands.inject import InjectionData, inject
 from pipx.commands.install import InstallData, install, install_all
 from pipx.commands.interpreter import list_interpreters, prune_interpreters, upgrade_interpreters
 from pipx.commands.list_packages import list_packages
@@ -21,6 +21,7 @@ from pipx.commands.upgrade import upgrade, upgrade_all, upgrade_shared
 __all__ = [
     "ExposureData",
     "HealthData",
+    "InjectionData",
     "InstallData",
     "OutdatedData",
     "PinData",

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 import logging
 import os
 import re
-import sys
-from collections.abc import Generator, Iterable, Sequence
-from pathlib import Path
-from typing import Final
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Final
 
 from packaging.utils import canonicalize_name
 
@@ -17,12 +18,27 @@ from pipx.commands.common import (
     run_post_install_actions,
 )
 from pipx.commands.transaction import preserve_venv
-from pipx.constants import EXIT_CODE_INJECT_ERROR, EXIT_CODE_OK, ExitCode
+from pipx.constants import EXIT_CODE_INJECT_ERROR, EXIT_CODE_OK
 from pipx.emojis import hazard, stars
 from pipx.package_specifier import get_extras
-from pipx.result import render_messages
+from pipx.result import (
+    OperationData,
+    OperationResult,
+    OutputFormat,
+    OutputLevel,
+    OutputMessage,
+    OutputStream,
+    render_messages,
+    render_result,
+)
 from pipx.util import PipxError, pipx_wrap
 from pipx.venv import Venv
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable, Sequence
+    from pathlib import Path
+
+    from pipx.pipx_metadata_file import PackageInfo
 
 _LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
@@ -44,7 +60,8 @@ def inject_dep(
     backend: str | None = None,
     env_backend: str | None = None,
     cooldown_days: int | None = None,
-) -> bool:
+    emit_output: bool = True,
+) -> OperationResult[InjectionData]:
     _LOGGER.debug("Injecting package %s", package_spec)
 
     if not venv_dir.exists() or next(venv_dir.iterdir(), None) is None:
@@ -95,16 +112,28 @@ def inject_dep(
     is_main_package = canonicalize_name(package_name) == canonicalize_name(venv.main_package_name)
     if not force and venv.has_package(package_name) and (not is_main_package or not get_extras(package_spec)):
         _LOGGER.info("Package %s is already installed", package_name)
-        print(
-            pipx_wrap(
-                f"""
-                {hazard} {package_name} already seems to be installed in {venv.name!r}.
-                Not modifying existing installation in '{venv_dir}'.
-                Pass '--force' to force installation.
-                """
-            )
+        return _finish_inject(
+            OperationResult(
+                command="inject",
+                data=InjectionData(
+                    packages=(),
+                    skipped=(InjectionSkip(venv.name, package_name, "already-installed"),),
+                    failures=(),
+                ),
+                messages=(
+                    OutputMessage(
+                        pipx_wrap(
+                            f"""
+                            {hazard} {package_name} already seems to be installed in {venv.name!r}.
+                            Not modifying existing installation in '{venv_dir}'.
+                            Pass '--force' to force installation.
+                            """
+                        )
+                    ),
+                ),
+            ),
+            emit_output=emit_output,
         )
-        return True
 
     pinned = False
     if is_main_package:
@@ -122,6 +151,7 @@ def inject_dep(
     previous_resource_paths: Final[set[Path]] = get_expected_venv_resource_paths(
         venv, paths.ctx.bin_dir, paths.ctx.man_dir
     )
+    messages: Final[list[OutputMessage]] = []
     with preserve_venv(venv_dir, enabled=bool(include_apps_from)):
         venv.install_package(
             package_name=package_name,
@@ -137,7 +167,7 @@ def inject_dep(
             cooldown_days=cooldown_days,
         )
         if include_apps:
-            render_messages(
+            messages.extend(
                 run_post_install_actions(
                     venv,
                     package_name,
@@ -147,17 +177,35 @@ def inject_dep(
                     force=force,
                     previous_resource_paths=previous_resource_paths,
                 ),
-                quiet=0,
             )
 
+    status: Final[InjectionStatus] = InjectionStatus.UPDATED if is_main_package else InjectionStatus.INJECTED
     if is_main_package:
-        print(f"  updated package {bold(package_name)} in venv {bold(venv.name)}")
+        messages.append(OutputMessage(f"  updated package {bold(package_name)} in venv {bold(venv.name)}"))
     else:
-        print(f"  injected package {bold(package_name)} into venv {bold(venv.name)}")
-    print(f"done! {stars}", file=sys.stderr)
-
-    # Any failure to install will raise PipxError, otherwise success
-    return True
+        messages.append(OutputMessage(f"  injected package {bold(package_name)} into venv {bold(venv.name)}"))
+    messages.append(OutputMessage(f"done! {stars}", stream=OutputStream.STDERR))
+    package: Final[PackageInfo] = venv.package_metadata[package_name]
+    return _finish_inject(
+        OperationResult(
+            command="inject",
+            data=InjectionData(
+                packages=(
+                    InjectionPackage(
+                        environment=venv.name,
+                        package=f"{package.package}{package.suffix}",
+                        version=package.package_version,
+                        status=status,
+                        location=str(venv.root),
+                    ),
+                ),
+                skipped=(),
+                failures=(),
+            ),
+            messages=tuple(messages),
+        ),
+        emit_output=emit_output,
+    )
 
 
 def inject(
@@ -175,43 +223,86 @@ def inject(
     backend: str | None = None,
     env_backend: str | None = None,
     cooldown_days: int | None = None,
-) -> ExitCode:
-    """Returns pipx exit code."""
-    # Combined collection of package specifications
-    packages = list(package_specs)
+    emit_output: bool = True,
+) -> OperationResult[InjectionData]:
+    package_set: Final[set[str]] = set(package_specs)
     for filename in requirement_files:
-        packages.extend(parse_requirements(filename))
-
-    # Remove duplicates and order deterministically
-    packages = sorted(set(packages))
+        package_set.update(parse_requirements(filename))
+    packages: Final[list[str]] = sorted(package_set)
 
     if not packages:
-        raise PipxError("No packages have been specified.")
+        return _finish_inject(
+            _inject_failure(venv_dir.name, None, "No packages have been specified."),
+            emit_output=emit_output,
+        )
     _LOGGER.info("Injecting packages: %r", packages)
 
-    # Inject packages
-    if not include_apps and (include_dependencies or include_apps_from):
-        include_apps = True
-    all_success = True
+    expose_apps: Final[bool] = include_apps or include_dependencies or bool(include_apps_from)
+    changed: Final[list[InjectionPackage]] = []
+    failures: Final[list[InjectionFailure]] = []
+    messages: Final[list[OutputMessage]] = []
+    skipped: Final[list[InjectionSkip]] = []
     for dependency in packages:
-        all_success &= inject_dep(
-            venv_dir,
-            package_name=None,
-            package_spec=dependency,
-            pip_args=pip_args,
-            verbose=verbose,
-            include_apps=include_apps,
-            include_dependencies=include_dependencies,
-            include_apps_from=include_apps_from,
-            force=force,
-            suffix=suffix,
-            backend=backend,
-            env_backend=env_backend,
-            cooldown_days=cooldown_days,
-        )
+        try:
+            result: OperationResult[InjectionData] = inject_dep(
+                venv_dir,
+                package_name=None,
+                package_spec=dependency,
+                pip_args=pip_args,
+                verbose=verbose,
+                include_apps=expose_apps,
+                include_dependencies=include_dependencies,
+                include_apps_from=include_apps_from,
+                force=force,
+                suffix=suffix,
+                backend=backend,
+                env_backend=env_backend,
+                cooldown_days=cooldown_days,
+                emit_output=False,
+            )
+        except PipxError as error:
+            failures.append(InjectionFailure(venv_dir.name, dependency, error.raw_message))
+            messages.append(OutputMessage(str(error), stream=OutputStream.STDERR, level=OutputLevel.ERROR))
+            break
+        changed.extend(result.data.packages)
+        skipped.extend(result.data.skipped)
+        messages.extend(result.messages)
 
-    # Any failure to install will raise PipxError, otherwise success
-    return EXIT_CODE_OK if all_success else EXIT_CODE_INJECT_ERROR
+    return _finish_inject(
+        OperationResult(
+            command="inject",
+            data=InjectionData(packages=tuple(changed), skipped=tuple(skipped), failures=tuple(failures)),
+            messages=tuple(messages),
+            exit_code=EXIT_CODE_INJECT_ERROR if failures else EXIT_CODE_OK,
+        ),
+        emit_output=emit_output,
+    )
+
+
+def _inject_failure(environment: str, package: str | None, error: str) -> OperationResult[InjectionData]:
+    return OperationResult(
+        command="inject",
+        data=InjectionData(packages=(), skipped=(), failures=(InjectionFailure(environment, package, error),)),
+        messages=(OutputMessage(error, stream=OutputStream.STDERR, level=OutputLevel.ERROR),),
+        exit_code=EXIT_CODE_INJECT_ERROR,
+    )
+
+
+def _finish_inject(
+    result: OperationResult[InjectionData],
+    *,
+    emit_output: bool,
+) -> OperationResult[InjectionData]:
+    if not emit_output:
+        return result
+    if result.data.failures:
+        render_messages(
+            tuple(message for message in result.messages if message.level is OutputLevel.NORMAL),
+            quiet=0,
+        )
+        raise PipxError(result.data.failures[0].error)
+    render_result(result, output=OutputFormat.HUMAN, quiet=0)
+    return result
 
 
 def parse_requirements(filename: str | os.PathLike) -> Generator[str, None, None]:
@@ -228,7 +319,48 @@ def parse_requirements(filename: str | os.PathLike) -> Generator[str, None, None
                 yield pkgspec
 
 
+class InjectionStatus(str, Enum):
+    INJECTED = "injected"
+    UNINJECTED = "uninjected"
+    UPDATED = "updated"
+
+
+@dataclass(frozen=True)
+class InjectionPackage:
+    environment: str
+    package: str
+    version: str
+    status: InjectionStatus
+    location: str
+
+
+@dataclass(frozen=True)
+class InjectionSkip:
+    environment: str
+    package: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class InjectionFailure:
+    environment: str
+    package: str | None
+    error: str
+
+
+@dataclass(frozen=True)
+class InjectionData(OperationData):
+    packages: tuple[InjectionPackage, ...]
+    skipped: tuple[InjectionSkip, ...]
+    failures: tuple[InjectionFailure, ...]
+
+
 __all__ = [
+    "InjectionData",
+    "InjectionFailure",
+    "InjectionPackage",
+    "InjectionSkip",
+    "InjectionStatus",
     "inject",
     "inject_dep",
     "parse_requirements",

--- a/src/pipx/commands/uninject.py
+++ b/src/pipx/commands/uninject.py
@@ -1,11 +1,19 @@
+from __future__ import annotations
+
 import logging
-from importlib import metadata
 from pathlib import Path
+from typing import TYPE_CHECKING, Final
 
 from packaging.utils import canonicalize_name
 
 from pipx.colors import bold
 from pipx.commands.common import add_suffix
+from pipx.commands.inject import (
+    InjectionData,
+    InjectionFailure,
+    InjectionPackage,
+    InjectionStatus,
+)
 from pipx.commands.uninstall import (
     _get_package_bin_dir_app_paths,
     _get_package_man_paths,
@@ -14,12 +22,17 @@ from pipx.constants import (
     EXIT_CODE_OK,
     EXIT_CODE_UNINJECT_ERROR,
     MAN_SECTIONS,
-    ExitCode,
 )
 from pipx.emojis import stars
-from pipx.util import PipxError, pipx_wrap, safe_unlink
+from pipx.result import OperationResult, OutputLevel, OutputMessage, OutputStream
+from pipx.util import pipx_wrap, safe_unlink
 from pipx.venv import Venv
 from pipx.venv_inspect import fetch_info_in_venv, get_distributions_by_name, get_required_dependency_names
+
+if TYPE_CHECKING:
+    from importlib import metadata
+
+    from pipx.pipx_metadata_file import PackageInfo
 
 logger = logging.getLogger(__name__)
 
@@ -32,38 +45,53 @@ def uninject(
     local_man_dir: Path,
     leave_deps: bool,
     verbose: bool,
-) -> ExitCode:
-    """Returns pipx exit code"""
-
+) -> OperationResult[InjectionData]:
     if not venv_dir.exists() or next(venv_dir.iterdir(), None) is None:
-        raise PipxError(f"Virtual environment {venv_dir.name} does not exist.")
-
-    venv = Venv(venv_dir, verbose=verbose)
-
-    if not venv.package_metadata:
-        raise PipxError(
-            f"""
-            Can't uninject from Virtual Environment {venv_dir.name!r}.
-            {venv_dir.name!r} has missing internal pipx metadata.
-            It was likely installed using a pipx version before 0.15.0.0.
-            Please uninstall and install {venv_dir.name!r} manually to fix.
-            """
+        return _uninject_failure(
+            venv_dir.name,
+            None,
+            f"Virtual environment {venv_dir.name} does not exist.",
+            stream=OutputStream.STDERR,
         )
 
-    all_success = True
+    venv: Final[Venv] = Venv(venv_dir, verbose=verbose)
+
+    if not venv.package_metadata:
+        return _uninject_failure(
+            venv.name,
+            None,
+            pipx_wrap(
+                f"""
+                Can't uninject from Virtual Environment {venv_dir.name!r}.
+                {venv_dir.name!r} has missing internal pipx metadata.
+                It was likely installed using a pipx version before 0.15.0.0.
+                Please uninstall and install {venv_dir.name!r} manually to fix.
+                """
+            ),
+            stream=OutputStream.STDERR,
+        )
+
+    failures: Final[list[InjectionFailure]] = []
+    messages: Final[list[OutputMessage]] = []
+    packages: Final[list[InjectionPackage]] = []
     for dep in dependencies:
-        all_success &= uninject_dep(
+        result: OperationResult[InjectionData] = uninject_dep(
             venv,
             dep,
             local_bin_dir=local_bin_dir,
             local_man_dir=local_man_dir,
             leave_deps=leave_deps,
         )
+        failures.extend(result.data.failures)
+        messages.extend(result.messages)
+        packages.extend(result.data.packages)
 
-    if all_success:
-        return EXIT_CODE_OK
-    else:
-        return EXIT_CODE_UNINJECT_ERROR
+    return OperationResult(
+        command="uninject",
+        data=InjectionData(packages=tuple(packages), skipped=(), failures=tuple(failures)),
+        messages=tuple(messages),
+        exit_code=EXIT_CODE_UNINJECT_ERROR if failures else EXIT_CODE_OK,
+    )
 
 
 def uninject_dep(
@@ -73,26 +101,31 @@ def uninject_dep(
     local_bin_dir: Path,
     local_man_dir: Path,
     leave_deps: bool = False,
-) -> bool:
+) -> OperationResult[InjectionData]:
     package_name = canonicalize_name(package_name)
 
     if package_name == venv.pipx_metadata.main_package.package:
-        logger.warning(
+        return _uninject_failure(
+            venv.name,
+            package_name,
             pipx_wrap(
                 f"""
-            {package_name} is the main package of {venv.root.name}
-            venv. Use `pipx uninstall {venv.root.name}` to uninstall instead of uninject.
-            """,
+                {package_name} is the main package of {venv.root.name}
+                venv. Use `pipx uninstall {venv.root.name}` to uninstall instead of uninject.
+                """,
                 subsequent_indent=" " * 4,
-            )
+            ),
         )
-        return False
 
     if package_name not in venv.pipx_metadata.injected_packages:
-        logger.warning(f"{package_name} is not in the {venv.root.name} venv. Skipping.")
-        return False
+        return _uninject_failure(
+            venv.name,
+            package_name,
+            f"{package_name} is not in the {venv.root.name} venv. Skipping.",
+        )
 
-    need_app_uninstall = venv.package_metadata[package_name].include_apps
+    package: Final[PackageInfo] = venv.package_metadata[package_name]
+    need_app_uninstall: Final[bool] = package.include_apps
 
     new_resource_paths = get_include_resource_paths(package_name, venv, local_bin_dir, local_man_dir)
 
@@ -128,8 +161,42 @@ def uninject_dep(
             else:
                 logger.info(f"removed file {path}")
 
-    print(f"Uninjected package {bold(package_name)}{deps_string} from venv {bold(venv.root.name)} {stars}")
-    return True
+    return OperationResult(
+        command="uninject",
+        data=InjectionData(
+            packages=(
+                InjectionPackage(
+                    environment=venv.name,
+                    package=f"{package.package}{package.suffix}",
+                    version=package.package_version,
+                    status=InjectionStatus.UNINJECTED,
+                    location=str(venv.root),
+                ),
+            ),
+            skipped=(),
+            failures=(),
+        ),
+        messages=(
+            OutputMessage(
+                f"Uninjected package {bold(package_name)}{deps_string} from venv {bold(venv.root.name)} {stars}"
+            ),
+        ),
+    )
+
+
+def _uninject_failure(
+    environment: str,
+    package: str | None,
+    error: str,
+    *,
+    stream: OutputStream = OutputStream.LOG,
+) -> OperationResult[InjectionData]:
+    return OperationResult(
+        command="uninject",
+        data=InjectionData(packages=(), skipped=(), failures=(InjectionFailure(environment, package, error),)),
+        messages=(OutputMessage(error, stream=stream, level=OutputLevel.ERROR),),
+        exit_code=EXIT_CODE_UNINJECT_ERROR,
+    )
 
 
 def get_include_resource_paths(package_name: str, venv: Venv, local_bin_dir: Path, local_man_dir: Path) -> set[Path]:

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -428,6 +428,15 @@ def _add_dependency_app_options(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _add_output_option(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--output",
+        choices=[output.value for output in OutputFormat],
+        default=OutputFormat.HUMAN,
+        help="Select the output format.",
+    )
+
+
 class _DeprecatedFetchMissingPython(argparse.Action):
     def __init__(self, option_strings: list[str], dest: str, **kwargs: Any) -> None:
         super().__init__(option_strings, dest, nargs=0, **kwargs)
@@ -531,12 +540,7 @@ def _add_install(subparsers: argparse._SubParsersAction, shared_parser: argparse
     )
     add_pip_venv_args(p)
     add_backend_arg(p)
-    p.add_argument(
-        "--output",
-        choices=[output.value for output in OutputFormat],
-        default=OutputFormat.HUMAN,
-        help="Select the output format.",
-    )
+    _add_output_option(p)
     p.set_defaults(func=_cmd_install)
 
 
@@ -696,10 +700,11 @@ def _add_inject(subparsers, venv_completer: VenvCompleter, shared_parser: argpar
         help="Add the suffix (if given) of the Virtual Environment to the packages to inject",
     )
     add_backend_arg(p)
+    _add_output_option(p)
     p.set_defaults(func=_cmd_inject)
 
 
-def _cmd_inject(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
+def _cmd_inject(args: argparse.Namespace, ctx: DispatchContext) -> OperationResult[commands.InjectionData]:
     venv_dir = _venv_dir(args, ctx)
     with ctx.venv_container.venv_lock(venv_dir):
         return commands.inject(
@@ -716,6 +721,7 @@ def _cmd_inject(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
             backend=ctx.backend,
             env_backend=ctx.env_backend,
             cooldown_days=ctx.cooldown_days,
+            emit_output=False,
         )
 
 
@@ -740,10 +746,11 @@ def _add_uninject(subparsers, venv_completer: VenvCompleter, shared_parser: argp
         action="store_true",
         help="Only uninstall the main injected package but leave its dependencies installed.",
     )
+    _add_output_option(p)
     p.set_defaults(func=_cmd_uninject)
 
 
-def _cmd_uninject(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
+def _cmd_uninject(args: argparse.Namespace, ctx: DispatchContext) -> OperationResult[commands.InjectionData]:
     venv_dir = _venv_dir(args, ctx)
     with ctx.venv_container.venv_lock(venv_dir):
         return commands.uninject(

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -25,7 +25,8 @@ _LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
 
 class PipxError(Exception):
-    def __init__(self, message: str, wrap_message: bool = True):
+    def __init__(self, message: str, wrap_message: bool = True) -> None:
+        self.raw_message: Final[str] = message
         if wrap_message:
             super().__init__(pipx_wrap(message))
         else:

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -1,12 +1,13 @@
+from __future__ import annotations
+
+import json
 import logging
 import re
 import shutil
 import subprocess
 import sys
 import textwrap
-from collections.abc import Callable
-from pathlib import Path
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 import pytest
 from packaging.utils import canonicalize_name
@@ -15,6 +16,186 @@ from helpers import PIPX_METADATA_LEGACY_VERSIONS, app_name, mock_legacy_venv, r
 from package_info import PKG
 from pipx import paths
 from pipx.pipx_metadata_file import PackageInfo, PipxMetadata
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from _pytest.capture import CaptureResult
+
+
+def test_inject_json(installed_pycowsay: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert not run_pipx_cli(["inject", "--output", "json", "pycowsay", PKG["black"]["spec"]])
+
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
+    assert (json.loads(captured.out), captured.err) == (
+        {
+            "command": "inject",
+            "data": {
+                "failures": [],
+                "packages": [
+                    {
+                        "environment": "pycowsay",
+                        "location": str(paths.ctx.venvs / "pycowsay"),
+                        "package": "black",
+                        "status": "injected",
+                        "version": "22.8.0",
+                    }
+                ],
+                "skipped": [],
+            },
+            "pipx_result_version": "0.1",
+            "status": "success",
+        },
+        "",
+    )
+
+
+def test_inject_json_reports_locked_environment(
+    pipx_temp_env: None,
+    make_pylock: Callable[[str, str], Path],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    lock_file: Final[Path] = make_pylock("pycowsay", "0.0.0.2")
+    assert not run_pipx_cli(["install", "--lock", str(lock_file), "pycowsay"])
+    capsys.readouterr()
+
+    assert run_pipx_cli(["inject", "--output", "json", "pycowsay", "black"])
+
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
+    assert (json.loads(captured.out), captured.err) == (
+        {
+            "command": "inject",
+            "data": {
+                "failures": [
+                    {
+                        "environment": "pycowsay",
+                        "error": f"Cannot inject into locked environment pycowsay. Update {lock_file} and run `pipx reinstall pycowsay`.",
+                        "package": "black",
+                    }
+                ],
+                "packages": [],
+                "skipped": [],
+            },
+            "pipx_result_version": "0.1",
+            "status": "error",
+        },
+        "",
+    )
+
+
+def test_inject_json_reports_already_installed(
+    installed_pycowsay: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert not run_pipx_cli(["inject", "pycowsay", PKG["black"]["spec"]])
+    capsys.readouterr()
+
+    assert not run_pipx_cli(["inject", "--output", "json", "pycowsay", PKG["black"]["spec"]])
+
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
+    assert (json.loads(captured.out), captured.err) == (
+        {
+            "command": "inject",
+            "data": {
+                "failures": [],
+                "packages": [],
+                "skipped": [
+                    {
+                        "environment": "pycowsay",
+                        "package": "black",
+                        "reason": "already-installed",
+                    }
+                ],
+            },
+            "pipx_result_version": "0.1",
+            "status": "success",
+        },
+        "",
+    )
+
+
+def test_inject_json_reports_partial_failure(
+    installed_pycowsay: None,
+    empty_project: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    missing_project: Final[Path] = tmp_path / "missing-project"
+    assert run_pipx_cli(["inject", "--output", "json", "pycowsay", str(empty_project), str(missing_project)])
+
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
+    assert (
+        captured.err,
+        json.loads(captured.out),
+    ) == (
+        "",
+        {
+            "command": "inject",
+            "data": {
+                "failures": [
+                    {
+                        "environment": "pycowsay",
+                        "error": f"Unable to parse package spec: {missing_project}",
+                        "package": str(missing_project),
+                    }
+                ],
+                "packages": [
+                    {
+                        "environment": "pycowsay",
+                        "location": str(paths.ctx.venvs / "pycowsay"),
+                        "package": "empty-project",
+                        "status": "injected",
+                        "version": "0.1.0",
+                    }
+                ],
+                "skipped": [],
+            },
+            "pipx_result_version": "0.1",
+            "status": "error",
+        },
+    )
+
+
+def test_inject_json_reports_no_packages(
+    installed_pycowsay: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert run_pipx_cli(["inject", "--output", "json", "pycowsay"])
+
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
+    assert (json.loads(captured.out), captured.err) == (
+        {
+            "command": "inject",
+            "data": {
+                "failures": [
+                    {
+                        "environment": "pycowsay",
+                        "error": "No packages have been specified.",
+                        "package": None,
+                    }
+                ],
+                "packages": [],
+                "skipped": [],
+            },
+            "pipx_result_version": "0.1",
+            "status": "error",
+        },
+        "",
+    )
+
+
+def test_inject_quiet(installed_pycowsay: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert not run_pipx_cli(["inject", "-qq", "pycowsay", "black"])
+
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
+    assert "injected package" not in captured.out and "done!" not in captured.err
+
+
+@pytest.fixture
+def installed_pycowsay(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    capsys.readouterr()
 
 
 def test_inject_rejects_pylock(

--- a/tests/test_install_all.py
+++ b/tests/test_install_all.py
@@ -91,9 +91,9 @@ def test_install_all_reports_injected_failure(
     capsys.readouterr()
     assert not run_pipx_cli(["list", "--json"])
     spec_file: Final[Path] = tmp_path / "pipx.json"
-    missing: Final[Path] = tmp_path / "missing"
+    missing_spec: Final[str] = (tmp_path / "missing").as_posix()
     spec_file.write_text(
-        capsys.readouterr().out.replace('"package_or_url": "pycowsay"', f'"package_or_url": "{missing}"'),
+        capsys.readouterr().out.replace('"package_or_url": "pycowsay"', f'"package_or_url": "{missing_spec}"'),
         encoding="utf-8",
     )
     assert not run_pipx_cli(["uninstall-all"])
@@ -102,5 +102,5 @@ def test_install_all_reports_injected_failure(
     result: Final[int] = run_pipx_cli(["install-all", str(spec_file)])
 
     error: Final[str] = " ".join(capsys.readouterr().err.split())
-    expected_error: Final[str] = " ".join(pipx_wrap(f"Unable to parse package spec: {missing}").split())
+    expected_error: Final[str] = " ".join(pipx_wrap(f"Unable to parse package spec: {missing_spec}").split())
     assert (result, expected_error in error) == (1, True)

--- a/tests/test_install_all.py
+++ b/tests/test_install_all.py
@@ -10,6 +10,7 @@ from helpers import run_pipx_cli
 from package_info import PKG
 from pipx import paths
 from pipx.pipx_metadata_file import PipxMetadata
+from pipx.util import pipx_wrap
 
 
 @pytest.mark.parametrize(
@@ -78,3 +79,28 @@ def test_install_all_multiple_errors(pipx_temp_env, root, capsys):
             log_contents = log_fh.read()
             assert "dotenv" in log_contents
             assert "weblate" in log_contents
+
+
+def test_install_all_reports_injected_failure(
+    pipx_temp_env: None,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert not run_pipx_cli(["install", "black"])
+    assert not run_pipx_cli(["inject", "black", "pycowsay"])
+    capsys.readouterr()
+    assert not run_pipx_cli(["list", "--json"])
+    spec_file: Final[Path] = tmp_path / "pipx.json"
+    missing: Final[Path] = tmp_path / "missing"
+    spec_file.write_text(
+        capsys.readouterr().out.replace('"package_or_url": "pycowsay"', f'"package_or_url": "{missing}"'),
+        encoding="utf-8",
+    )
+    assert not run_pipx_cli(["uninstall-all"])
+    capsys.readouterr()
+
+    result: Final[int] = run_pipx_cli(["install-all", str(spec_file)])
+
+    error: Final[str] = " ".join(capsys.readouterr().err.split())
+    expected_error: Final[str] = " ".join(pipx_wrap(f"Unable to parse package spec: {missing}").split())
+    assert (result, expected_error in error) == (1, True)

--- a/tests/test_uninject.py
+++ b/tests/test_uninject.py
@@ -1,14 +1,194 @@
+from __future__ import annotations
+
+import json
 import shutil
 import subprocess
-from pathlib import Path
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 import pytest
 
-from helpers import app_name, run_pipx_cli, skip_if_windows
+from helpers import app_name, mock_legacy_venv, run_pipx_cli, skip_if_windows
 from package_info import PKG
 from pipx import paths
 from pipx.constants import WINDOWS
+from pipx.util import pipx_wrap
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.capture import CaptureResult
+
+
+def test_uninject_json(installed_pycowsay: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert not run_pipx_cli(["inject", "pycowsay", PKG["black"]["spec"]])
+    capsys.readouterr()
+
+    assert not run_pipx_cli(["uninject", "--output", "json", "pycowsay", "black"])
+
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
+    assert (json.loads(captured.out), captured.err) == (
+        {
+            "command": "uninject",
+            "data": {
+                "failures": [],
+                "packages": [
+                    {
+                        "environment": "pycowsay",
+                        "location": str(paths.ctx.venvs / "pycowsay"),
+                        "package": "black",
+                        "status": "uninjected",
+                        "version": "22.8.0",
+                    }
+                ],
+                "skipped": [],
+            },
+            "pipx_result_version": "0.1",
+            "status": "success",
+        },
+        "",
+    )
+
+
+def test_uninject_json_reports_unknown_package(
+    installed_pycowsay: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert run_pipx_cli(["uninject", "--output", "json", "pycowsay", "missing"])
+
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
+    assert (json.loads(captured.out), captured.err) == (
+        {
+            "command": "uninject",
+            "data": {
+                "failures": [
+                    {
+                        "environment": "pycowsay",
+                        "error": "missing is not in the pycowsay venv. Skipping.",
+                        "package": "missing",
+                    }
+                ],
+                "packages": [],
+                "skipped": [],
+            },
+            "pipx_result_version": "0.1",
+            "status": "error",
+        },
+        "",
+    )
+
+
+def test_uninject_json_reports_missing_environment(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert run_pipx_cli(["uninject", "--output", "json", "missing", "black"])
+
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
+    assert (json.loads(captured.out), captured.err) == (
+        {
+            "command": "uninject",
+            "data": {
+                "failures": [
+                    {
+                        "environment": "missing",
+                        "error": "Virtual environment missing does not exist.",
+                        "package": None,
+                    }
+                ],
+                "packages": [],
+                "skipped": [],
+            },
+            "pipx_result_version": "0.1",
+            "status": "error",
+        },
+        "",
+    )
+
+
+def test_uninject_json_reports_missing_metadata(
+    installed_pycowsay: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    mock_legacy_venv("pycowsay")
+
+    assert run_pipx_cli(["uninject", "--output", "json", "pycowsay", "black"])
+
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
+    assert (json.loads(captured.out), captured.err) == (
+        {
+            "command": "uninject",
+            "data": {
+                "failures": [
+                    {
+                        "environment": "pycowsay",
+                        "error": pipx_wrap(
+                            """
+                            Can't uninject from Virtual Environment 'pycowsay'.
+                            'pycowsay' has missing internal pipx metadata.
+                            It was likely installed using a pipx version before 0.15.0.0.
+                            Please uninstall and install 'pycowsay' manually to fix.
+                            """
+                        ),
+                        "package": None,
+                    }
+                ],
+                "packages": [],
+                "skipped": [],
+            },
+            "pipx_result_version": "0.1",
+            "status": "error",
+        },
+        "",
+    )
+
+
+def test_uninject_json_reports_main_package(
+    installed_pycowsay: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert run_pipx_cli(["uninject", "--output", "json", "pycowsay", "pycowsay"])
+
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
+    assert (json.loads(captured.out), captured.err) == (
+        {
+            "command": "uninject",
+            "data": {
+                "failures": [
+                    {
+                        "environment": "pycowsay",
+                        "error": pipx_wrap(
+                            """
+                            pycowsay is the main package of pycowsay
+                            venv. Use `pipx uninstall pycowsay` to uninstall instead of uninject.
+                            """,
+                            subsequent_indent=" " * 4,
+                        ),
+                        "package": "pycowsay",
+                    }
+                ],
+                "packages": [],
+                "skipped": [],
+            },
+            "pipx_result_version": "0.1",
+            "status": "error",
+        },
+        "",
+    )
+
+
+def test_uninject_quiet(installed_pycowsay: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert not run_pipx_cli(["inject", "pycowsay", "black"])
+    capsys.readouterr()
+
+    assert not run_pipx_cli(["uninject", "-qq", "pycowsay", "black"])
+
+    assert "Uninjected package" not in capsys.readouterr().out
+
+
+@pytest.fixture
+def installed_pycowsay(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    capsys.readouterr()
 
 
 def file_or_symlink(filepath: Path) -> bool:

--- a/tests/test_unpin.py
+++ b/tests/test_unpin.py
@@ -104,11 +104,11 @@ def test_unpin_injected_packages(pipx_temp_env: None, capsys: pytest.CaptureFixt
 
 def test_unpin_reports_only_changed_packages(
     pipx_temp_env: None,
-    root: Path,
+    empty_project: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     assert not run_pipx_cli(["install", "pycowsay"])
-    assert not run_pipx_cli(["inject", "pycowsay", str(root / "testdata/empty_project")])
+    assert not run_pipx_cli(["inject", "pycowsay", str(empty_project)])
     assert not run_pipx_cli(["pin", "pycowsay", "--injected-only"])
     capsys.readouterr()
 


### PR DESCRIPTION
`pipx inject` and `pipx uninject` return terminal summaries, so scripts must parse prose to learn the result. This advances https://github.com/pypa/pipx/issues/828.

`--output json` selects the shared, versioned operation envelope for both commands. It records each package outcome, including partial runs. The default `human` format preserves existing output and failure semantics for CLI and internal callers.
