### PR TITLE
🐛 fix(expose): preserve colliding resources

### DIFF
--- a/changelog.d/540.bugfix.md
+++ b/changelog.d/540.bugfix.md
@@ -1,0 +1,1 @@
+Keep existing exposed files when copy-based environments provide the same resource name.

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -1,11 +1,10 @@
 import filecmp
 import logging
-import os
 import shlex
 import shutil
 import tempfile
 import time
-from collections.abc import Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
 from shutil import which
 from tempfile import TemporaryDirectory
@@ -71,7 +70,7 @@ def expose_resources_globally(
         if not dest_dir.is_dir():
             mkdir(dest_dir)
         if not can_symlink(dest_dir):
-            _copy_package_resource(dest_dir, path, suffix=suffix)
+            _copy_package_resource(dest_dir, path, force=force, suffix=suffix)
         else:
             _symlink_package_resource(
                 dest_dir,
@@ -148,7 +147,7 @@ def _add_ignore_environment_to_python_shebang(path: Path) -> None:
     path.write_bytes(first_line + b" -E" + separator + rest)
 
 
-def _copy_package_resource(dest_dir: Path, path: Path, suffix: str = "") -> None:
+def _copy_package_resource(dest_dir: Path, path: Path, *, force: bool, suffix: str = "") -> None:
     src = path.resolve()
     name = src.name
     dest = Path(dest_dir / add_suffix(name, suffix))
@@ -156,6 +155,9 @@ def _copy_package_resource(dest_dir: Path, path: Path, suffix: str = "") -> None
         mkdir(dest.parent)
     if dest.exists():
         if filecmp.cmp(dest, src, shallow=False):
+            return
+        if not force:
+            _LOGGER.warning(f"{hazard}  File exists at {dest!s} and does not match {src!s}. Not modifying.")
             return
         _LOGGER.warning(f"{hazard}  Overwriting file {dest!s} with {src!s}")
         safe_unlink(dest)
@@ -282,24 +284,23 @@ def get_venv_summary(
             if new_install
             else tuple(metadata for metadata in venv.package_metadata.values() if metadata.include_apps)
         )
-        exposed_app_paths = get_exposed_paths_for_package(
-            venv.bin_path,
-            paths.ctx.bin_dir,
-            [add_suffix(app, metadata.suffix) for metadata in resource_packages for app in metadata.apps_to_expose],
+        app_paths: Final[dict[str, list[Path]]] = group_resource_paths(
+            (add_suffix(path.name, metadata.suffix), path)
+            for metadata in resource_packages
+            for path in metadata.app_paths_to_expose
         )
+        exposed_app_paths = get_exposed_paths_for_package(venv.bin_path, paths.ctx.bin_dir, app_paths)
         exposed_binary_names = sorted(path.name for path in exposed_app_paths)
         unavailable_binary_names = sorted(
             {add_suffix(name, package_metadata.suffix) for name in package_metadata.apps} - set(exposed_binary_names)
         )
         exposed_man_paths = set()
-        man_pages: Final[list[str]] = [
-            man_page for metadata in resource_packages for man_page in metadata.man_pages_to_expose
-        ]
+        man_paths: Final[list[Path]] = [path for metadata in resource_packages for path in metadata.man_paths_to_expose]
         for man_section in MAN_SECTIONS:
             exposed_man_paths |= get_exposed_man_paths_for_package(
                 venv.man_path / man_section,
                 paths.ctx.man_dir / man_section,
-                man_pages,
+                man_paths,
             )
         exposed_man_pages = sorted(str(Path(path.parent.name) / path.name) for path in exposed_man_paths)
         unavailable_man_pages = sorted(set(package_metadata.man_pages) - set(exposed_man_pages))
@@ -334,29 +335,29 @@ def get_venv_summary(
 def get_exposed_paths_for_package(
     venv_resource_path: Path,
     local_resource_dir: Path,
-    package_resource_names: list[str] | None = None,
+    package_resource_paths: Mapping[str, Sequence[Path]] | None = None,
 ) -> set[Path]:
-    # package_binary_names is used only if local_bin_path cannot use symlinks.
-    # It is necessary for non-symlink systems to return valid app_paths.
-    if package_resource_names is None:
-        package_resource_names = []
-
     if not local_resource_dir.exists():
         return set()
 
     symlinks = set()
-    for b in local_resource_dir.iterdir():
+    for resource_path in local_resource_dir.iterdir():
         try:
             # Some apps expose symlinks whose names differ from their targets, so resolved paths cannot identify them.
             # Windows setups without symlink support fall back to package resource names.
             is_same_file = False
-            if can_symlink(local_resource_dir) and b.is_symlink():
-                is_same_file = b.resolve().parent.samefile(venv_resource_path)
+            if can_symlink(local_resource_dir) and resource_path.is_symlink():
+                is_same_file = resource_path.resolve().parent.samefile(venv_resource_path)
             elif not can_symlink(local_resource_dir):
-                is_same_file = b.name in package_resource_names
+                sources = (
+                    package_resource_paths.get(resource_path.name, ()) if package_resource_paths is not None else ()
+                )
+                is_same_file = any(
+                    source.is_file() and filecmp.cmp(resource_path, source, shallow=False) for source in sources
+                )
 
             if is_same_file:
-                symlinks.add(b)
+                symlinks.add(resource_path)
 
         except (FileNotFoundError, RuntimeError):
             pass
@@ -366,15 +367,21 @@ def get_exposed_paths_for_package(
 def get_exposed_man_paths_for_package(
     venv_man_path: Path,
     local_man_dir: Path,
-    package_man_pages: list[str] | None = None,
+    package_man_paths: Sequence[Path] = (),
 ) -> set[Path]:
     man_section = venv_man_path.name
-    prefix = man_section + os.sep
     return get_exposed_paths_for_package(
         venv_man_path,
         local_man_dir,
-        [name.removeprefix(prefix) for name in package_man_pages or [] if name.startswith(prefix)],
+        group_resource_paths((path.name, path) for path in package_man_paths if path.parent.name == man_section),
     )
+
+
+def group_resource_paths(resource_paths: Iterable[tuple[str, Path]]) -> dict[str, list[Path]]:
+    grouped: dict[str, list[Path]] = {}
+    for name, path in resource_paths:
+        grouped.setdefault(name, []).append(path)
+    return grouped
 
 
 def _get_list_output(
@@ -607,6 +614,7 @@ __all__ = [
     "get_exposed_man_paths_for_package",
     "get_exposed_paths_for_package",
     "get_venv_summary",
+    "group_resource_paths",
     "locked_package_message",
     "package_name_from_spec",
     "run_post_install_actions",

--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -16,6 +16,7 @@ from pipx.commands.common import (
     can_symlink,
     get_exposed_man_paths_for_package,
     get_exposed_paths_for_package,
+    group_resource_paths,
 )
 from pipx.constants import (
     EXIT_CODE_OK,
@@ -201,12 +202,14 @@ def _get_package_bin_dir_app_paths(package_info: PackageInfo, venv_bin_path: Pat
     return get_exposed_paths_for_package(
         venv_bin_path,
         local_bin_dir,
-        [add_suffix(app, package_info.suffix) for app in package_info.apps_to_expose],
+        group_resource_paths(
+            (add_suffix(path.name, package_info.suffix), path) for path in package_info.app_paths_to_expose
+        ),
     )
 
 
 def _get_package_man_paths(package_info: PackageInfo, venv_man_path: Path, local_man_dir: Path) -> set[Path]:
-    return get_exposed_man_paths_for_package(venv_man_path, local_man_dir, package_info.man_pages_to_expose)
+    return get_exposed_man_paths_for_package(venv_man_path, local_man_dir, package_info.man_paths_to_expose)
 
 
 __all__ = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,13 +15,15 @@ from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 
 import pytest
+from pytest_mock import MockerFixture
 
-from helpers import WIN
+from helpers import WIN, app_name, run_pipx_cli
 from pipx import commands, interpreter, paths, shared_libs, standalone_python, venv
 from pipx.backends import get_backend
 from pipx.backends import pip as _pip_backend_module
 from pipx.backends import uv as _uv_backend_module
 from pipx.backends.uv import find_uv_binary
+from pipx.commands import common
 from pipx.venv import reset_backend_override_warnings
 
 # ``pipx.commands.__init__`` re-exports ``upgrade`` (the function), which
@@ -93,6 +95,19 @@ def local_extras_project(root: Path, tmp_path: Path) -> Path:
     project: Final[Path] = tmp_path / "local_extras"
     shutil.copytree(root / "testdata/test_package_specifier/local_extras", project, ignore=_IGNORE_PROJECT_OUTPUT)
     return project
+
+
+@pytest.fixture()
+def copied_dependency_resource(
+    pipx_temp_env: None,
+    make_project_with_dependency: Callable[[str], Path],
+    mocker: MockerFixture,
+) -> tuple[Path, bytes]:
+    mocker.patch.object(common, "can_symlink", autospec=True, return_value=False)
+    first_project: Final[Path] = make_project_with_dependency("pycowsay==0.0.0.2")
+    exposed_app: Final[Path] = paths.ctx.bin_dir / app_name("pycowsay")
+    assert not run_pipx_cli(["install", str(first_project), "--include-deps"])
+    return exposed_app, exposed_app.read_bytes()
 
 
 @pytest.fixture()

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -812,6 +812,17 @@ def test_install_force_replaces_included_dependency_resources(
     ) == (["black"], False, False, True)
 
 
+def test_install_preserves_colliding_dependency_resource(
+    copied_dependency_resource: tuple[Path, bytes],
+    local_extras_project: Path,
+) -> None:
+    exposed_app: Final[Path] = copied_dependency_resource[0]
+    first_contents: Final[bytes] = copied_dependency_resource[1]
+    assert not run_pipx_cli(["install", f"{local_extras_project}[cow]", "--include-deps"])
+
+    assert exposed_app.read_bytes() == first_contents
+
+
 def test_install_include_apps_from_missing_dependency_rolls_back(
     pipx_temp_env: None,
     local_extras_project: Path,

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -211,6 +211,19 @@ def test_uninstall_removes_selected_dependency_resources(pipx_temp_env: None, lo
     assert not any(file_or_symlink(path) for path in exposed_paths)
 
 
+def test_uninstall_preserves_colliding_dependency_resource(
+    copied_dependency_resource: tuple[Path, bytes],
+    local_extras_project: Path,
+) -> None:
+    exposed_app: Final[Path] = copied_dependency_resource[0]
+    first_contents: Final[bytes] = copied_dependency_resource[1]
+    assert not run_pipx_cli(["install", f"{local_extras_project}[cow]", "--include-deps"])
+
+    assert not run_pipx_cli(["uninstall", "repeatme"])
+
+    assert exposed_app.read_bytes() == first_contents
+
+
 def test_uninstall_injected(pipx_temp_env):
     pycowsay_app_paths = [paths.ctx.bin_dir / app for app in PKG["pycowsay"]["apps"]]
     pycowsay_man_page_paths = [paths.ctx.man_dir / man_page for man_page in PKG["pycowsay"]["man_pages"]]


### PR DESCRIPTION
Copy-based environments overwrite an existing app or manual page when another environment exposes the same name. Uninstall can then remove the remaining environment's resource. Fixes https://github.com/pypa/pipx/issues/540.

Copy exposure now follows the symlink path's first-wins behavior unless `--force` is explicit. Listing and uninstalling compare a copied file against every recorded source, so pipx reports and removes only the environment that owns the copy.
