### PR TITLE
🐛 fix(paths): preserve home symlinks

### DIFF
--- a/changelog.d/1327.bugfix.md
+++ b/changelog.d/1327.bugfix.md
@@ -1,0 +1,1 @@
+Preserve symlinks in `PIPX_HOME` when creating environments.

--- a/src/pipx/paths.py
+++ b/src/pipx/paths.py
@@ -40,8 +40,7 @@ _LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
 
 def get_expanded_environ(env_name: str) -> Path | None:
-    val = get_environment_value(env_name)
-    return Path(val).expanduser().resolve() if val else None
+    return Path(value).expanduser().absolute() if (value := get_environment_value(env_name)) else None
 
 
 class _PathContext:
@@ -100,7 +99,7 @@ class _PathContext:
             home = self._fallback_home
         else:
             home = self._default_home
-        return home.resolve()
+        return home.absolute()
 
     @cached_property
     def shared_libs(self) -> Path:

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,15 +1,16 @@
 from pathlib import Path
+from typing import Final
 
 import pytest
 from pytest_mock import MockerFixture
 
+from helpers import skip_if_windows
 from pipx import paths
 
 
 @pytest.mark.parametrize(
     ("attribute", "override_name"),
     [
-        pytest.param("home", "OVERRIDE_PIPX_HOME", id="home"),
         pytest.param("bin_dir", "OVERRIDE_PIPX_BIN_DIR", id="bin"),
         pytest.param("man_dir", "OVERRIDE_PIPX_MAN_DIR", id="man"),
         pytest.param("shared_libs", "OVERRIDE_PIPX_SHARED_LIBS", id="shared"),
@@ -28,3 +29,23 @@ def test_context_resolves_base_path_once(
 
     assert (getattr(paths.ctx, attribute), getattr(paths.ctx, attribute)) == (expected, expected)
     assert sum(call.args[0] == expected for call in resolve.call_args_list) == 1
+
+
+@skip_if_windows
+def test_context_preserves_home_symlink(
+    pipx_temp_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    target: Final[Path] = tmp_path / "target"
+    target.mkdir()
+    home: Final[Path] = tmp_path / "home"
+    home.symlink_to(target, target_is_directory=True)
+    with monkeypatch.context() as scoped:
+        scoped.setattr(paths, "OVERRIDE_PIPX_HOME", None)
+        scoped.setenv("PIPX_HOME", str(home))
+        paths.ctx.make_local()
+
+        assert (paths.ctx.home, paths.ctx.venvs) == (home, home / "venvs")
+
+    paths.ctx.make_local()


### PR DESCRIPTION
pipx resolves `PIPX_HOME` and its defaults through symlinks. A space-free configured path can therefore become a target with spaces, defeating the supported symlink workaround for pip's open data-script shebang bug. Fixes https://github.com/pypa/pipx/issues/1327. The upstream shebang limitation remains tracked at https://github.com/pypa/pip/issues/13389.

Home paths now expand `~` and become absolute without resolving symlinks. Bin, manual-page, and shared-library path handling stays unchanged.
