### PR TITLE
✨ feat(run): normalize inferred names

### DIFF
--- a/changelog.d/618.feature.md
+++ b/changelog.d/618.feature.md
@@ -1,0 +1,1 @@
+Normalize inferred `pipx run` package names.

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -13,6 +13,7 @@ from shutil import which
 from typing import Final, NoReturn
 
 from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
 
 from pipx import paths
 from pipx.backends import UV, resolve_backend_name
@@ -291,6 +292,14 @@ def run_package(
         venv.run_app(app, app_filename, app_args)
 
 
+def _package_name_from_app(app: str, *, inferred: bool) -> str:
+    try:
+        package_name = Requirement(app).name
+    except InvalidRequirement:
+        return app
+    return canonicalize_name(package_name) if inferred else package_name
+
+
 def run(
     app: str,
     spec: str | None,
@@ -314,11 +323,7 @@ def run(
     package
     """
 
-    try:
-        package_name = Requirement(app).name
-    except InvalidRequirement:
-        # Raw script URLs are not valid package requirements.
-        package_name = app
+    package_name: Final[str] = _package_name_from_app(app, inferred=spec is None)
 
     # ``resolved_backend`` only decides ROUTING (uv tool run vs Venv); cli/env
     # stay separate when we hand off so the Venv's source-attribution stays right.
@@ -346,7 +351,7 @@ def run(
 
     elif use_uvx:
         run_via_uv_tool_run(
-            app=app,
+            app=package_name if spec is None else app,
             package_or_url=spec if spec is not None else app,
             dependencies=dependencies,
             app_args=app_args,

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -292,14 +292,6 @@ def run_package(
         venv.run_app(app, app_filename, app_args)
 
 
-def _package_name_from_app(app: str, *, inferred: bool) -> str:
-    try:
-        package_name = Requirement(app).name
-    except InvalidRequirement:
-        return app
-    return canonicalize_name(package_name) if inferred else package_name
-
-
 def run(
     app: str,
     spec: str | None,
@@ -385,6 +377,14 @@ def run(
             no_path_check=no_path_check,
             cooldown_days=cooldown_days,
         )
+
+
+def _package_name_from_app(app: str, *, inferred: bool) -> str:
+    try:
+        package_name = Requirement(app).name
+    except InvalidRequirement:
+        return app
+    return canonicalize_name(package_name) if inferred else package_name
 
 
 def _prepare_venv(

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -74,8 +74,8 @@ def test_run_preserves_explicit_app_name(
     pipx_temp_env: None,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    assert run_pipx_cli(["run", "--spec", "black", "bLaCk"]) == 1
-    assert "'bLaCk' executable script not found in package 'black'." in capsys.readouterr().err
+    assert run_pipx_cli(["run", "--spec", "black", "bLaCk.app"]) == 1
+    assert "'bLaCk.app' executable script not found in package 'black'." in capsys.readouterr().err
 
 
 @mock.patch("os.execvpe", new=execvpe_mock)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -57,6 +57,27 @@ def test_simple_run(pipx_temp_env, monkeypatch, capsys, package_name):
     assert "Download the latest version of a package" not in captured.out
 
 
+@pytest.mark.parametrize("backend", ["pip", "uv"])
+def test_run_normalizes_inferred_package_name(
+    pipx_temp_env: None,
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    backend: str,
+) -> None:
+    mocker.patch("os.execvpe", new=execvpe_mock)
+    monkeypatch.setenv("PATH", f"{os.environ['PATH']}{os.pathsep}{os.defpath}")
+
+    run_pipx_cli_exit(["run", "--backend", backend, "bLaCk", "--version"], assert_exit=0)
+
+
+def test_run_preserves_explicit_app_name(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert run_pipx_cli(["run", "--spec", "black", "bLaCk"]) == 1
+    assert "'bLaCk' executable script not found in package 'black'." in capsys.readouterr().err
+
+
 @mock.patch("os.execvpe", new=execvpe_mock)
 def test_cache(pipx_temp_env, monkeypatch, capsys, caplog):
     run_pipx_cli_exit(["run", "pycowsay", "cowsay", "args"])


### PR DESCRIPTION
`pipx run bLaCk` installs `black` but searches for the mixed-case executable because package indexes normalize distribution names while console-script names remain case-sensitive. Fixes [#618](https://github.com/pypa/pipx/issues/618).

When pipx infers the package, it now applies package-name canonicalization before selecting the inferred application for both pip and uv. An application supplied with `--spec` remains exact.
