### PR TITLE
✨ feat(run): pass Python interpreter args

### DIFF
--- a/changelog.d/1613.feature.md
+++ b/changelog.d/1613.feature.md
@@ -1,0 +1,1 @@
+Add Python interpreter arguments to `pipx run`.

--- a/docs/tutorial/run-applications.md
+++ b/docs/tutorial/run-applications.md
@@ -43,6 +43,21 @@ Arguments after the application name pass straight through:
 
 ```
 
+### Pass arguments to Python
+
+Use `--python-args` before the application to configure its Python interpreter:
+
+```
+pipx run --python-args="-X dev -b" APP
+pipx run --python-args=-i script.py
+```
+
+These arguments affect only the application process and reuse the same cached environment. Package applications must be
+Python entry points. Legacy scripts and applications from `__pypackages__` do not support this option.
+
+With `--backend uv`, this option uses a pipx-managed uv environment because `uv tool run` cannot pass arguments to the
+application's interpreter. The environment therefore appears under `pipx cache` rather than `uv cache`.
+
 pipx caches virtual environments per app for a few days. After they expire, pipx fetches the latest version.
 
 ### Refresh or clear cached runs
@@ -74,11 +89,14 @@ pipx can consume arguments meant for the application:
 ```
 > pipx run pycowsay --py
 
-usage: pipx run [-h] [--no-cache | --refresh] [--pypackages] [--spec SPEC] [--verbose] [--python PYTHON]
-                [--system-site-packages] [--index-url INDEX_URL] [--editable] [--pip-args PIP_ARGS]
-                [--cooldown DAYS]
+usage: pipx run [-h] [--quiet] [--verbose] [--skip-maintenance] [--global]
+                [--no-cache | --refresh] [--no-path-check] [--python-args ARGS]
+                [--path] [--pypackages] [--with WITH_] [--spec SPEC] [--python PYTHON]
+                [--fetch-python {always,missing,never} | --fetch-missing-python]
+                [--system-site-packages] [--index-url INDEX_URL] [--editable]
+                [--pip-args PIP_ARGS] [--cooldown DAYS] [--backend {pip,uv}]
                 app ...
-pipx run: error: ambiguous option: --py could match --pypackages, --python
+pipx run: error: ambiguous option: --py could match --python-args, --pypackages, --python
 ```
 
 Place `--` before the app name to forward all arguments verbatim:

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -91,6 +91,7 @@ def run_script(
     verbose: bool,
     use_cache: bool,
     *,
+    python_args: list[str],
     refresh: bool = False,
     backend: str | None = None,
     env_backend: str | None = None,
@@ -112,7 +113,7 @@ def run_script(
             )
         requirements = [*requirements, *dependencies]
 
-    if resolved_backend == UV and requirements is not None:
+    if resolved_backend == UV and requirements is not None and not python_args:
         if script_source is not None:
             run_script_via_uv_run(
                 script_path=script_source,
@@ -142,7 +143,7 @@ def run_script(
         )
 
     if not requirements:
-        _exec_script(Path(python), content, app_args)
+        _exec_script(Path(python), content, app_args, python_args)
 
     # Note that the environment name is based on the identified
     # requirements, and *not* on the script name. This is deliberate, as
@@ -176,14 +177,19 @@ def run_script(
                 # when `pipx run` is next executed, rather than just failing.
                 (venv_dir / _VENV_EXPIRED_FILENAME).touch()
                 raise
-        _exec_script(venv.python_path, content, app_args)
+        _exec_script(venv.python_path, content, app_args, python_args)
 
 
-def _exec_script(python_path: Path, content: str | Path, app_args: list[str]) -> NoReturn:
+def _exec_script(
+    python_path: Path,
+    content: str | Path,
+    app_args: list[str],
+    python_args: list[str],
+) -> NoReturn:
     if isinstance(content, Path):
-        exec_app([python_path, content, *app_args])
+        exec_app([python_path, *python_args, content, *app_args])
     else:
-        exec_app([python_path, "-c", content, *app_args])
+        exec_app([python_path, *python_args, "-c", content, *app_args])
 
 
 def run_package(
@@ -198,6 +204,7 @@ def run_package(
     verbose: bool,
     use_cache: bool,
     *,
+    python_args: list[str],
     refresh: bool = False,
     infer_app_name: bool = False,
     backend: str | None = None,
@@ -225,6 +232,8 @@ def run_package(
 
     pypackage_bin_path = get_pypackage_bin_path(app)
     if pypackage_bin_path.exists():
+        if python_args:
+            raise PipxError("--python-args cannot run applications from __pypackages__.")
         _LOGGER.info(f"Using app in local __pypackages__ directory at '{pypackage_bin_path}'")
         run_pypackage_bin(pypackage_bin_path, app_args)
     if pypackages:
@@ -288,7 +297,7 @@ def run_package(
                 env_backend=env_backend,
                 cooldown_days=cooldown_days,
             )
-        venv.run_app(app, app_filename, app_args)
+        venv.run_app(app, app_filename, app_args, python_args=python_args)
 
 
 def run(
@@ -304,6 +313,7 @@ def run(
     verbose: bool,
     use_cache: bool,
     *,
+    python_args: list[str],
     refresh: bool = False,
     no_path_check: bool = False,
     backend: str | None = None,
@@ -323,7 +333,7 @@ def run(
     # ``resolved_backend`` only decides ROUTING (uv tool run vs Venv); cli/env
     # stay separate when we hand off so the Venv's source-attribution stays right.
     resolved_backend, _ = resolve_backend_name(cli_value=backend, env_value=env_backend)
-    use_uvx = resolved_backend == UV and not pypackages
+    use_uvx = resolved_backend == UV and not pypackages and not python_args
 
     content = None if spec is not None else maybe_script_content(app, is_path)
     if content is not None:
@@ -342,6 +352,7 @@ def run(
             script_source=Path(app) if isinstance(content, Path) else None,
             dependencies=dependencies,
             cooldown_days=cooldown_days,
+            python_args=python_args,
         )
 
     elif use_uvx:
@@ -379,6 +390,7 @@ def run(
             resolved_backend=resolved_backend,
             no_path_check=no_path_check,
             cooldown_days=cooldown_days,
+            python_args=python_args,
         )
 
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -233,6 +233,13 @@ def get_runpip_args(pip_args: list[str]) -> list[str]:
     return split_args or pip_args
 
 
+def _split_python_args(python_args: str) -> list[str]:
+    try:
+        return shlex.split(python_args, posix=not WINDOWS)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid Python arguments: {exc}") from exc
+
+
 def get_venv_args(parsed_args: dict[str, str]) -> list[str]:
     venv_args: list[str] = []
     if parsed_args.get("system_site_packages"):
@@ -1281,6 +1288,13 @@ def _add_run(subparsers: argparse._SubParsersAction, shared_parser: argparse.Arg
         help="Do not check whether the app is already on PATH",
     )
     p.add_argument(
+        "--python-args",
+        metavar="ARGS",
+        type=_split_python_args,
+        default=[],
+        help="Arguments to pass to the Python interpreter that runs the application",
+    )
+    p.add_argument(
         "app_with_args",
         metavar="app ...",
         nargs=argparse.REMAINDER,
@@ -1330,6 +1344,7 @@ def _cmd_run(args: argparse.Namespace, ctx: DispatchContext) -> NoReturn:
         backend=ctx.backend,
         env_backend=ctx.env_backend,
         cooldown_days=ctx.cooldown_days,
+        python_args=args.python_args,
     )
 
 

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -616,36 +616,48 @@ class Venv:
             self._site_packages = get_site_packages(self.python_path)
         return self._site_packages
 
-    def _find_entry_point(self, app: str) -> EntryPoint | None:
+    def _find_entry_point(self, app: str, group: str) -> EntryPoint | None:
         if not self.python_path.exists():
             return None
         dists = Distribution.discover(name=self.main_package_name, path=[str(self.site_packages)])
         for dist in dists:
             for ep in dist.entry_points:
-                if ep.group == "pipx.run":
+                if ep.group == group:
                     if ep.name == app:
                         return ep
-                    # Try to infer app name from dist's metadata if given
-                    # local path
-                    if Path(app).exists() and dist.metadata["Name"] == ep.name:
+                    # Local project paths do not identify an app, so accept their matching pipx.run entry point.
+                    if group == "pipx.run" and Path(app).exists() and dist.metadata["Name"] == ep.name:
                         return ep
         return None
 
-    def run_app(self, app: str, filename: str, app_args: list[str]) -> NoReturn:
-        entry_point = self._find_entry_point(app)
+    def run_app(
+        self,
+        app: str,
+        filename: str,
+        app_args: list[str],
+        *,
+        python_args: list[str],
+    ) -> NoReturn:
+        entry_point = self._find_entry_point(app, "pipx.run")
+        if entry_point is None and python_args:
+            entry_point = self._find_entry_point(app, "console_scripts")
 
-        # No [pipx.run] entry point; default to run console script.
         if entry_point is None:
+            if python_args:
+                raise PipxError(f"Cannot pass Python arguments because {app!r} is not a Python entry point.")
             exec_app([str(self.bin_path / filename)] + app_args)
 
-        # Evaluate and execute the entry point.
         _LOGGER.info("Using discovered entry point for 'pipx run'")
-        module, attr = entry_point.module, entry_point.attr
-        code = f"import sys, {module}\nsys.argv[0] = {entry_point.name!r}\nsys.exit({module}.{attr}())\n"
-        exec_app([str(self.python_path), "-c", code] + app_args)
+        code = (
+            "import sys\nfrom importlib.metadata import EntryPoint\n"
+            f"sys.argv[0] = {entry_point.name!r}\n"
+            f"sys.exit(EntryPoint(name={entry_point.name!r}, value={entry_point.value!r}, "
+            f"group={entry_point.group!r}).load()())\n"
+        )
+        exec_app([str(self.python_path), *python_args, "-c", code, *app_args])
 
     def has_app(self, app: str, filename: str) -> bool:
-        if self._find_entry_point(app) is not None:
+        if self._find_entry_point(app, "pipx.run") is not None:
             return True
         return (self.bin_path / filename).is_file()
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -314,6 +314,100 @@ def test_run_without_requirements(caplog, pipx_temp_env, tmp_path):
     assert out.read_text() == test_str
 
 
+def test_run_passes_python_args_to_script(
+    pipx_temp_env: None,
+    tmp_path: Path,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("os.execvpe", new=execvpe_mock)
+    output: Final[Path] = tmp_path / "flags.txt"
+    script: Final[Path] = tmp_path / "flags.py"
+    script.write_text(
+        f"import sys\nfrom pathlib import Path\nPath({str(output)!r}).write_text(str(sys.flags.bytes_warning))",
+        encoding="utf-8",
+    )
+
+    run_pipx_cli_exit(["run", "--python-args=-bb", str(script)], assert_exit=0)
+
+    assert output.read_text(encoding="utf-8") == "2"
+
+
+def test_run_rejects_invalid_python_args(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit, match="2"):
+        run_pipx_cli(["run", '--python-args="', "demo"])
+
+    assert "invalid Python arguments: No closing quotation" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("backend", ["pip", "uv"])
+def test_run_passes_python_args_to_app(
+    pipx_temp_env: None,
+    mocker: MockerFixture,
+    tmp_path: Path,
+    backend: str,
+) -> None:
+    mocker.patch("os.execvpe", new=execvpe_mock)
+    project: Final[Path] = tmp_path / "flags-app"
+    project.mkdir()
+    (project / "pyproject.toml").write_text(
+        """\
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "flags-app"
+version = "1"
+
+[project.scripts]
+flags-app = "flags_app:main"
+
+[tool.setuptools]
+py-modules = ["flags_app"]
+""",
+        encoding="utf-8",
+    )
+    output: Final[Path] = tmp_path / "flags.txt"
+    (project / "flags_app.py").write_text(
+        "import sys\nfrom pathlib import Path\n\ndef main() -> None:\n    Path(sys.argv[1]).write_text(str(sys.flags.bytes_warning))",
+        encoding="utf-8",
+    )
+
+    run_pipx_cli_exit(
+        [
+            "run",
+            "--backend",
+            backend,
+            "--python-args=-X dev -bb",
+            "--spec",
+            str(project),
+            "flags-app",
+            str(output),
+        ],
+        assert_exit=0,
+    )
+
+    assert output.read_text(encoding="utf-8") == "2"
+
+
+def test_run_rejects_python_args_for_pypackages(
+    pipx_temp_env: None,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    app: Final[Path] = (
+        tmp_path / "__pypackages__" / f"{sys.version_info.major}.{sys.version_info.minor}" / "lib" / "bin" / "demo"
+    )
+    app.parent.mkdir(parents=True)
+    app.touch()
+    monkeypatch.chdir(tmp_path)
+
+    assert run_pipx_cli(["run", "--python-args=-b", "demo"]) == 1
+
+    assert capsys.readouterr().err == "--python-args cannot run applications from __pypackages__.\n"
+
+
 @pytest.mark.parametrize(
     ("encoding", "script_text"),
     [

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -1,25 +1,44 @@
 import subprocess
 from pathlib import Path
+from typing import Final
+from unittest.mock import MagicMock
 
+import pytest
 from pytest_mock import MockerFixture
 
+from pipx.util import PipxError
 from pipx.venv import Venv
 
 
-def test_has_app_caches_site_packages(tmp_path: Path, mocker: MockerFixture) -> None:
-    venv = Venv(tmp_path / "demo")
+@pytest.fixture
+def venv_with_site_packages(tmp_path: Path, mocker: MockerFixture) -> tuple[Venv, Path, MagicMock]:
+    venv: Final[Venv] = Venv(tmp_path / "demo")
     venv.python_path.parent.mkdir(parents=True)
     venv.python_path.touch()
-    site_packages = tmp_path / "site-packages"
-    dist_info = site_packages / "demo-1.0.dist-info"
+    site_packages: Final[Path] = tmp_path / "site-packages"
+    dist_info: Final[Path] = site_packages / "demo-1.0.dist-info"
     dist_info.mkdir(parents=True)
-    (dist_info / "METADATA").write_text("Name: demo\nVersion: 1.0\n")
-    (dist_info / "entry_points.txt").write_text("[pipx.run]\ndemo = demo:main\n")
-    run_subprocess = mocker.patch(
+    (dist_info / "METADATA").write_text("Name: demo\nVersion: 1.0\n", encoding="utf-8")
+    run_subprocess: Final[MagicMock] = mocker.patch(
         "pipx.util.run_subprocess",
         autospec=True,
         return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout=f"{site_packages}\n", stderr=""),
     )
+    return venv, dist_info, run_subprocess
+
+
+def test_has_app_caches_site_packages(venv_with_site_packages: tuple[Venv, Path, MagicMock]) -> None:
+    venv, dist_info, run_subprocess = venv_with_site_packages
+    (dist_info / "entry_points.txt").write_text("[pipx.run]\ndemo = demo:main\n", encoding="utf-8")
 
     assert (venv.has_app("demo", "demo"), venv.has_app("demo", "demo")) == (True, True)
     run_subprocess.assert_called_once()
+
+
+def test_run_app_rejects_python_args_without_entry_point(
+    venv_with_site_packages: tuple[Venv, Path, MagicMock],
+) -> None:
+    venv, _, _ = venv_with_site_packages
+
+    with pytest.raises(PipxError, match="'demo' is not a Python entry point"):
+        venv.run_app("demo", "demo", [], python_args=["-b"])


### PR DESCRIPTION
`pipx run` can select an interpreter but cannot pass runtime options such as `-b`, `-i`, or `-X dev` to the application process. Closes https://github.com/pypa/pipx/issues/1613.

`--python-args` parses a quoted option string and applies it to Python files, inline-metadata scripts, `pipx.run` entry points, and console entry points. The pip and uv backends share this behavior; uv requests use a pipx-managed uv environment because `uv tool run` has no interpreter-option channel.

Interpreter options reuse the same cached environment. Legacy scripts and `__pypackages__` applications return an error because pipx cannot identify a Python entry point for those launchers.
