### PR TITLE
🐛 fix(shared): reject broken pip

### DIFF
--- a/changelog.d/1606.bugfix.md
+++ b/changelog.d/1606.bugfix.md
@@ -1,0 +1,1 @@
+Recreate the shared environment when pip cannot run.

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -154,11 +154,12 @@ class _SharedLibs:
                 and _venv_python_is_valid(self.python_path)
                 and self.pip_path.is_file()
                 and run_subprocess(
-                    [self.python_path, "-c", "import importlib.util; print(importlib.util.find_spec('pip'))"],
-                    capture_stderr=False,
+                    [self.python_path, "-c", "from pip._internal.cli.main import main"],
                     log_cmd_str="<checking pip's availability>",
-                ).stdout.strip()
-                != "None"
+                    log_stdout=False,
+                    log_stderr=False,
+                ).returncode
+                == 0
             )
 
         return self._is_valid

--- a/tests/test_shared_libs.py
+++ b/tests/test_shared_libs.py
@@ -103,17 +103,29 @@ def test_shared_libs_create_without_index_when_auto_upgrade_disabled(
     assert shared_libs.shared_libs.is_valid
 
 
-def test_shared_libs_validity_check_is_cached(pipx_ultra_temp_env: None, mocker: MockerFixture) -> None:
+@pytest.mark.parametrize(
+    ("returncode", "expected"),
+    [
+        pytest.param(0, True, id="valid"),
+        pytest.param(1, False, id="broken-pip"),
+    ],
+)
+def test_shared_libs_validity_check_is_cached(
+    pipx_ultra_temp_env: None,
+    mocker: MockerFixture,
+    returncode: int,
+    expected: bool,
+) -> None:
     shared_libs.shared_libs.python_path.parent.mkdir(parents=True)
     shared_libs.shared_libs.python_path.touch()
     shared_libs.shared_libs.pip_path.touch()
     run_subprocess = mocker.patch(
         "pipx.shared_libs.run_subprocess",
         autospec=True,
-        return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="ModuleSpec", stderr=""),
+        return_value=subprocess.CompletedProcess(args=[], returncode=returncode, stdout="", stderr=""),
     )
 
-    assert (shared_libs.shared_libs.is_valid, shared_libs.shared_libs.is_valid) == (True, True)
+    assert (shared_libs.shared_libs.is_valid, shared_libs.shared_libs.is_valid) == (expected, expected)
     run_subprocess.assert_called_once()
 
 


### PR DESCRIPTION
pipx accepted a shared environment that contained the top-level `pip` package without `pip._internal.cli`. Later commands failed with `ModuleNotFoundError`.

The validity check imports pip's CLI entry point. pipx rebuilds the shared environment under the existing maintenance lock after an import failure.

Closes #1606
