### PR TITLE
✨ feat(install): persist PEP 723 scripts

### DIFF
--- a/changelog.d/1388.feature.md
+++ b/changelog.d/1388.feature.md
@@ -1,0 +1,1 @@
+Install PEP 723 scripts as persistent applications.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -97,8 +97,8 @@ venv managed by `shared_libs.py`.
 [python-build-standalone](https://github.com/astral-sh/python-build-standalone/releases) and caches it locally. The
 `pipx interpreter` subcommands (list, prune, upgrade) manage these cached interpreters.
 
-`commands/run.py` includes PEP 723 inline script metadata parsing. When you run a `.py` file, pipx scans for a
-`# /// script` block, extracts TOML-declared dependencies, and installs them into a cached temporary venv.
+`script.py` parses PEP 723 inline metadata. `run` installs the declared dependencies in a cached temporary venv.
+`install` sends both backends the same generated wheel and records the source path or URL.
 
 ## Running pipx For Development
 

--- a/docs/explanation/how-pipx-works.md
+++ b/docs/explanation/how-pipx-works.md
@@ -12,6 +12,10 @@ Once the package is installed, pipx exposes its console scripts and GUI scripts 
 into `~/.local/share/man/man[1-9]`. As long as `~/.local/bin/` is on your `PATH`, the new commands are available
 globally, and on systems with `man` support the pages are accessible too.
 
+For a `.py` source with PEP 723 metadata, pipx builds a temporary wheel containing the script and its declared
+dependencies. Both the pip and uv backends install it into a normal managed environment. pipx then discards the wheel
+and records the original file path or URL so reinstall and upgrade can rebuild it.
+
 Adding the `--global` flag to any `pipx` command executes the action in global scope, exposing the app to all system
 users. See the [configuration reference](../how-to/configure-paths.md#-global-argument) for details. Note that this is
 not available on Windows.

--- a/docs/reference/examples.md
+++ b/docs/reference/examples.md
@@ -23,6 +23,8 @@ pipx install --pip-args='--index-url=<private-repo-host>:<private-repo-port> --t
 pipx install --index-url https://test.pypi.org/simple/ --pip-args='--extra-index-url https://pypi.org/simple/' some-package
 pipx install --global pycowsay
 pipx install --lock pylock.toml .
+pipx install ./script.py
+pipx install --app command https://example.com/script.py
 pipx install .
 pipx install path/to/some-project
 ```

--- a/docs/tutorial/install-applications.md
+++ b/docs/tutorial/install-applications.md
@@ -97,6 +97,30 @@ entry point, pipx restores the existing environment.
 Use one package spec with `--app`. Repeat the option to require more than one entry point. `--include-apps-from` can
 select dependency entry points; `--include-deps` selects all dependency entry points.
 
+### Installing a PEP 723 script
+
+Install a local script with
+[PEP 723 inline metadata](https://packaging.python.org/en/latest/specifications/inline-script-metadata/) when it should
+remain available instead of using a temporary `pipx run` environment:
+
+```
+pipx install ./hello.py
+```
+
+pipx uses the filename without `.py` as the application and environment name. Pass `--app` to choose another name:
+
+```
+pipx install --app greet ./hello.py
+```
+
+The script must contain a `# /// script` metadata block. pipx installs its declared dependencies and exposes the script
+through the same metadata and environment lifecycle as a package. `list`, `uninstall`, `inject`, `reinstall`, and
+`upgrade` therefore work without script-specific commands. Reinstall and upgrade read the source again.
+
+HTTP and HTTPS script URLs work too. Treat a mutable URL like any other unpinned source. To make dependency artifacts
+reproducible, pass an explicit `pylock.toml` with `--lock`; pipx installs the locked environment before installing the
+script without dependency resolution.
+
 ### Installing from a lock file
 
 Use a [PEP 751 lock file](https://packaging.python.org/en/latest/specifications/pylock-toml/) when a resolver must

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -37,6 +37,7 @@ from pipx.result import (
     render_messages,
     render_result,
 )
+from pipx.script import script_name_from_spec
 from pipx.util import PipxError, pipx_wrap, rmdir
 from pipx.venv import Venv, VenvContainer
 
@@ -105,6 +106,7 @@ def install(
         python,
         pip_args,
         verbose,
+        tuple(expected_apps),
         backend=backend,
         env_backend=env_backend,
         cooldown_days=cooldown_days,
@@ -283,6 +285,7 @@ def _resolve_package_names(
     python: str,
     pip_args: list[str],
     verbose: bool,
+    expected_apps: tuple[str, ...],
     *,
     backend: str | None,
     env_backend: str | None,
@@ -294,6 +297,9 @@ def _resolve_package_names(
     resolved: Final[list[str]] = []
     for package_spec in package_specs:
         try:
+            if (script_name := script_name_from_spec(package_spec, expected_apps)) is not None:
+                resolved.append(script_name)
+                continue
             resolved.append(
                 package_name_from_spec(
                     package_spec,

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -1,8 +1,6 @@
 import datetime
 import hashlib
 import logging
-import re
-import sys
 import time
 import urllib.parse
 import urllib.request
@@ -22,6 +20,7 @@ from pipx.commands.inject import inject_dep
 from pipx.commands.run_uv import run_script_via_uv_run, run_via_uv_tool_run
 from pipx.constants import TEMP_VENV_EXPIRATION_THRESHOLD_DAYS, WINDOWS
 from pipx.emojis import hazard
+from pipx.script import ScriptMetadata, read_script_metadata
 from pipx.util import (
     PipxError,
     exec_app,
@@ -31,11 +30,6 @@ from pipx.util import (
     run_pypackage_bin,
 )
 from pipx.venv import Venv, VenvContainer
-
-if sys.version_info < (3, 11):
-    import tomli as tomllib
-else:
-    import tomllib
 
 _LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
@@ -101,7 +95,8 @@ def run_script(
     dependencies: list[str] | None = None,
     cooldown_days: int | None = None,
 ) -> NoReturn:
-    requirements = _get_requirements_from_script(content)
+    metadata: Final[ScriptMetadata | None] = read_script_metadata(content)
+    requirements = None if metadata is None else list(metadata.dependencies)
 
     if dependencies:
         if requirements is None:
@@ -150,9 +145,8 @@ def run_script(
     # requirements, and *not* on the script name. This is deliberate, as
     # it ensures that two scripts with the same requirements can use the
     # same environment, which means fewer environments need to be
-    # managed. The requirements are normalised (in
-    # _get_requirements_from_script), so that irrelevant differences in
-    # whitespace, and similar, don't prevent environment sharing.
+    # managed. The requirements are normalised so that irrelevant differences
+    # in whitespace, and similar, don't prevent environment sharing.
     venv_dir = _get_temporary_venv_path(
         requirements,
         python,
@@ -552,71 +546,6 @@ def _http_get_request(url: str) -> str:
     except Exception as e:
         _LOGGER.debug("Uncaught Exception:", exc_info=True)
         raise PipxError(str(e)) from e
-
-
-# Pattern from PEP 723 / inline script metadata spec.
-_INLINE_SCRIPT_METADATA: Final[re.Pattern[str]] = re.compile(
-    r"""
-    ^\#\ ///\ (?P<type>[a-zA-Z0-9-]+)$ \s   # opening fence: ``# /// <type>``
-    (?P<content> (^\#(|\ .*)$ \s)+ )        # body: lines starting with ``#`` or ``# ``
-    ^\#\ ///$                               # closing fence: ``# ///``
-    """,
-    re.VERBOSE | re.MULTILINE,
-)
-
-
-def _get_requirements_from_script(content: str | Path) -> list[str] | None:
-    """
-    Supports inline script metadata.
-    """
-
-    if isinstance(content, Path):
-        content = content.read_text(encoding="utf-8")
-
-    name = "script"
-
-    # Windows is currently getting un-normalized line endings, so normalize
-    content = content.replace("\r\n", "\n")
-
-    matches = [m for m in _INLINE_SCRIPT_METADATA.finditer(content) if m.group("type") == name]
-
-    if not matches:
-        pyproject_matches = [m for m in _INLINE_SCRIPT_METADATA.finditer(content) if m.group("type") == "pyproject"]
-        if pyproject_matches:
-            _LOGGER.error(
-                pipx_wrap(
-                    f"""
-                    {hazard}  Using old form of requirements table. Use updated PEP
-                    723 syntax by replacing `# /// pyproject` with `# /// script`
-                    and `run.dependencies` (or `run.requirements`) with
-                    `dependencies`.
-                    """,
-                    subsequent_indent=" " * 4,
-                )
-            )
-            raise ValueError("Old 'pyproject' table found")
-        return None
-
-    if len(matches) > 1:
-        raise ValueError(f"Multiple {name} blocks found")
-
-    content = "".join(
-        line[2:] if line.startswith("# ") else line[1:] for line in matches[0].group("content").splitlines(keepends=True)
-    )
-
-    pyproject = tomllib.loads(content)
-
-    requirements = []
-    for requirement in pyproject.get("dependencies", []):
-        try:
-            parsed_requirement = Requirement(requirement)
-        except InvalidRequirement as exc:
-            raise PipxError(f"Invalid requirement {requirement}: {exc}") from exc
-
-        # Use the normalised form of the requirement
-        requirements.append(str(parsed_requirement))
-
-    return requirements
 
 
 __all__ = [

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -383,6 +383,7 @@ def _upgrade_package(
         include_apps=package_metadata.include_apps,
         is_main_package=is_main_package,
         suffix=package_metadata.suffix,
+        expected_apps=package_metadata.expected_apps,
         cooldown_days=cooldown_days if cooldown_days is not None else package_metadata.cooldown_days,
     )
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -125,8 +125,8 @@ DOC_DEFAULT_PYTHON = os.getenv("PIPX__DOC_DEFAULT_PYTHON", get_default_python_sp
 INSTALL_DESCRIPTION = textwrap.dedent(
     f"""
     The install command is the preferred way to globally install apps
-    from python packages on your system. It creates an isolated virtual
-    environment for the package, then ensures the package's apps are
+    from Python packages and PEP 723 scripts. It creates an isolated virtual
+    environment for the source, then ensures its apps are
     accessible on your $PATH. The package's manual pages installed in
     share/man/man[1-9] can be viewed with man on an operating system where
     it is available and the path in the environment variable `PIPX_MAN_DIR`
@@ -142,10 +142,12 @@ INSTALL_DESCRIPTION = textwrap.dedent(
     pipx install --python PYTHON PACKAGE_SPEC
     pipx install VCS_URL
     pipx install ./LOCAL_PATH
+    pipx install ./SCRIPT.py
     pipx install ZIP_FILE
     pipx install TAR_GZ_FILE
 
-    The PACKAGE_SPEC argument is passed directly to `pip install`.
+    Package specs are passed to the selected backend. PEP 723 scripts are
+    installed with their declared dependencies.
 
     Virtual Environments will be installed to `$PIPX_HOME/venvs`.
     The default pipx home location is {paths.DEFAULT_PIPX_HOME} and can
@@ -502,7 +504,7 @@ def _add_install(subparsers: argparse._SubParsersAction, shared_parser: argparse
         description=INSTALL_DESCRIPTION,
         parents=[shared_parser],
     )
-    p.add_argument("package_spec", help="package name(s) or pip installation spec(s)", nargs="+")
+    p.add_argument("package_spec", help="package name(s), PEP 723 script(s), or installation spec(s)", nargs="+")
     _add_dependency_app_options(p)
     p.add_argument(
         "--force",

--- a/src/pipx/script.py
+++ b/src/pipx/script.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import re
+import stat
+import sys
+import urllib.parse
+import urllib.request
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING, Final, cast
+from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
+
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.utils import canonicalize_name
+
+from pipx.util import PipxError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+if sys.version_info < (3, 11):
+    import tomli as tomllib
+else:
+    import tomllib
+
+_APP_NAME: Final[re.Pattern[str]] = re.compile(r"[A-Za-z0-9_][A-Za-z0-9._-]*")
+_INLINE_METADATA: Final[re.Pattern[str]] = re.compile(
+    r"""
+    ^\#\ ///\ (?P<type>[a-zA-Z0-9-]+)$ \s
+    (?P<content> (^\#(|\ .*)$ \s)+? )
+    ^\#\ ///$
+    """,
+    re.VERBOSE | re.MULTILINE,
+)
+
+
+@dataclass(frozen=True)
+class ScriptMetadata:
+    dependencies: tuple[str, ...]
+    requires_python: str | None
+
+
+@dataclass(frozen=True)
+class _Script:
+    app: str
+    content: str
+    metadata: ScriptMetadata
+
+
+def read_script_metadata(content: str | Path) -> ScriptMetadata | None:
+    text: Final[str] = (content.read_text(encoding="utf-8") if isinstance(content, Path) else content).removeprefix(
+        "\ufeff"
+    )
+    normalized_text: Final[str] = text.replace("\r\n", "\n")
+    matches: Final[list[re.Match[str]]] = [
+        match for match in _INLINE_METADATA.finditer(normalized_text) if match.group("type") == "script"
+    ]
+    if not matches:
+        if any(match.group("type") == "pyproject" for match in _INLINE_METADATA.finditer(normalized_text)):
+            raise ValueError("Use `# /// script` instead of the obsolete `# /// pyproject` metadata block")
+        return None
+    if len(matches) > 1:
+        raise ValueError("Multiple `# /// script` metadata blocks found")
+
+    raw: Final[dict[str, str | list[str]]] = cast(
+        "dict[str, str | list[str]]",
+        tomllib.loads(
+            "".join(
+                line[2:] if line.startswith("# ") else line[1:]
+                for line in matches[0].group("content").splitlines(keepends=True)
+            )
+        ),
+    )
+    dependencies: Final[str | list[str]] = raw.get("dependencies", [])
+    if not isinstance(dependencies, list) or not all(isinstance(dependency, str) for dependency in dependencies):
+        raise PipxError("Inline script `dependencies` must be an array of strings.")
+    normalized: Final[list[str]] = []
+    for dependency in dependencies:
+        try:
+            normalized.append(str(Requirement(dependency)))
+        except InvalidRequirement as error:
+            raise PipxError(f"Invalid requirement {dependency}: {error}") from error
+
+    requires_python: Final[str | None] = _normalize_requires_python(raw.get("requires-python"))
+    return ScriptMetadata(tuple(normalized), requires_python)
+
+
+def script_name_from_spec(package_spec: str, expected_apps: tuple[str, ...]) -> str | None:
+    if not _is_script_spec(package_spec):
+        return None
+    if len(expected_apps) > 1:
+        raise PipxError("A script can provide one --app name.")
+    app: Final[str] = _script_app(package_spec, expected_apps)
+    if _APP_NAME.fullmatch(app) is None:
+        raise PipxError(f"Invalid script app name {app!r}. Pass --app with a portable command name.")
+    return canonicalize_name(app)
+
+
+@contextmanager
+def installable_script(package_name: str, package_or_url: str, expected_apps: tuple[str, ...]) -> Iterator[str]:
+    if (resolved_name := script_name_from_spec(package_or_url, expected_apps)) is None:
+        yield package_or_url
+        return
+    if canonicalize_name(package_name) != resolved_name:
+        raise PipxError(f"Script app {resolved_name!r} does not match package name {package_name!r}.")
+
+    script: Final[_Script] = _read_script(package_or_url, expected_apps)
+    with TemporaryDirectory(prefix="pipx-script-") as directory:
+        yield str(_write_wheel(Path(directory), package_name, script))
+
+
+def _is_script_spec(package_spec: str) -> bool:
+    path: Final[Path] = Path(package_spec).expanduser()
+    if path.is_file():
+        return path.suffix.lower() == ".py" or (not path.suffix and _has_inline_script_metadata(path))
+    parsed: Final[urllib.parse.SplitResult] = urllib.parse.urlsplit(package_spec)
+    return parsed.scheme in {"http", "https"} and parsed.path.lower().endswith(".py")
+
+
+def _has_inline_script_metadata(path: Path) -> bool:
+    try:
+        content: Final[str] = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return False
+    return any(match.group("type") == "script" for match in _INLINE_METADATA.finditer(content.removeprefix("\ufeff")))
+
+
+def _script_app(package_spec: str, expected_apps: tuple[str, ...]) -> str:
+    return expected_apps[0] if expected_apps else Path(urllib.parse.urlsplit(package_spec).path).stem
+
+
+def _read_script(package_or_url: str, expected_apps: tuple[str, ...]) -> _Script:
+    path: Final[Path] = Path(package_or_url).expanduser()
+    content: Final[str] = (
+        path.read_text(encoding="utf-8") if path.is_file() else _read_url(package_or_url)
+    ).removeprefix("\ufeff")
+    try:
+        metadata: Final[ScriptMetadata | None] = read_script_metadata(content)
+    except ValueError as error:
+        raise PipxError(f"Invalid inline metadata in script {package_or_url}: {error}.") from error
+    if metadata is None:
+        raise PipxError(f"Script {package_or_url} has no PEP 723 inline metadata block.")
+    return _Script(_script_app(package_or_url, expected_apps), content, metadata)
+
+
+def _read_url(url: str) -> str:
+    try:
+        with urllib.request.urlopen(url) as response:
+            return response.read().decode(response.headers.get_content_charset() or "utf-8")
+    except OSError as error:
+        raise PipxError(f"Unable to read script {url}: {error}") from error
+
+
+def _normalize_requires_python(value: str | list[str] | None) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise PipxError("Inline script `requires-python` must be a string.")
+    try:
+        return str(SpecifierSet(value))
+    except InvalidSpecifier as error:
+        raise PipxError(f"Invalid `requires-python` value {value}: {error}") from error
+
+
+def _write_wheel(directory: Path, package_name: str, script: _Script) -> Path:
+    version: Final[str] = f"0+{hashlib.sha256(script.content.encode()).hexdigest()[:12]}"
+    distribution: Final[str] = re.sub(r"[-_.]+", "_", package_name)
+    stem: Final[str] = f"{distribution}-{version}"
+    dist_info: Final[str] = f"{stem}.dist-info"
+    members: Final[dict[str, bytes]] = {
+        f"{stem}.data/scripts/{script.app}": _script_bytes(script.content),
+        f"{dist_info}/METADATA": _metadata(package_name, version, script.metadata),
+        f"{dist_info}/WHEEL": b"Wheel-Version: 1.0\nGenerator: pipx\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+    }
+    record: Final[str] = f"{dist_info}/RECORD"
+    wheel: Final[Path] = directory / f"{stem}-py3-none-any.whl"
+    with ZipFile(wheel, "w", compression=ZIP_DEFLATED) as archive:
+        for name, data in members.items():
+            _write_member(archive, name, data, executable=".data/scripts/" in name)
+        archive.writestr(
+            record,
+            "".join(f"{name},sha256={_digest(data)},{len(data)}\n" for name, data in members.items()) + f"{record},,\n",
+        )
+    return wheel
+
+
+def _metadata(package_name: str, version: str, metadata: ScriptMetadata) -> bytes:
+    lines: Final[list[str]] = ["Metadata-Version: 2.3", f"Name: {package_name}", f"Version: {version}"]
+    if metadata.requires_python is not None:
+        lines.append(f"Requires-Python: {metadata.requires_python}")
+    lines.extend(f"Requires-Dist: {dependency}" for dependency in metadata.dependencies)
+    return ("\n".join(lines) + "\n\n").encode()
+
+
+def _script_bytes(content: str) -> bytes:
+    return ("#!python\n" + (content.partition("\n")[2] if content.startswith("#!") else content)).encode()
+
+
+def _write_member(archive: ZipFile, name: str, data: bytes, *, executable: bool) -> None:
+    info: Final[ZipInfo] = ZipInfo(name)
+    info.create_system = 3
+    info.external_attr = (stat.S_IFREG | (0o755 if executable else 0o644)) << 16
+    archive.writestr(info, data, compress_type=ZIP_DEFLATED)
+
+
+def _digest(data: bytes) -> str:
+    return base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=").decode()
+
+
+__all__ = [
+    "ScriptMetadata",
+    "installable_script",
+    "read_script_metadata",
+    "script_name_from_spec",
+]

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -35,6 +35,7 @@ from pipx.package_specifier import (
     valid_pypi_name,
 )
 from pipx.pipx_metadata_file import PackageInfo, PipxMetadata
+from pipx.script import installable_script
 from pipx.shared_libs import (
     DISABLE_SHARED_LIBS_AUTO_UPGRADE,
     shared_libs,
@@ -361,20 +362,21 @@ class Venv:
             [*(install_only_pip_args or []), *pip_args], cooldown_days
         )
 
-        if lock_file is None:
-            _LOGGER.info("Installing %s", package_descr := full_package_description(package_name, package_or_url))
-            with animate(f"installing {package_descr}", self.do_animation):
-                process = self.backend.install(
-                    venv_root=self.root,
-                    venv_python=self.python_path,
-                    requirements=[package_or_url],
-                    pip_args=install_pip_args,
-                    verbose=self.verbose,
-                )
-            if process.returncode:
-                raise PipxError(f"Error installing {full_package_description(package_name, package_or_url)}.")
-        else:
-            self._install_locked_package(package_name, package_or_url, lock_file, install_pip_args)
+        with installable_script(package_name, package_or_url, tuple(expected_apps or ())) as install_spec:
+            if lock_file is None:
+                _LOGGER.info("Installing %s", package_descr := full_package_description(package_name, package_or_url))
+                with animate(f"installing {package_descr}", self.do_animation):
+                    process = self.backend.install(
+                        venv_root=self.root,
+                        venv_python=self.python_path,
+                        requirements=[install_spec],
+                        pip_args=install_pip_args,
+                        verbose=self.verbose,
+                    )
+                if process.returncode:
+                    raise PipxError(f"Error installing {full_package_description(package_name, package_or_url)}.")
+            else:
+                self._install_locked_package(package_name, install_spec, lock_file, install_pip_args)
 
         self.update_package_metadata(
             package_name=package_name,
@@ -698,16 +700,17 @@ class Venv:
         cooldown_days: int | None = None,
     ) -> None:
         _LOGGER.info("Upgrading %s", package_descr := full_package_description(package_name, package_or_url))
-        with animate(f"upgrading {package_descr}", self.do_animation):
-            process = self.backend.install(
-                venv_root=self.root,
-                venv_python=self.python_path,
-                requirements=[package_or_url],
-                pip_args=self._with_cooldown([*(upgrade_only_pip_args or []), *pip_args], cooldown_days),
-                upgrade=True,
-                log_pip_errors=False,
-                verbose=self.verbose,
-            )
+        with installable_script(package_name, package_or_url, tuple(expected_apps or ())) as install_spec:
+            with animate(f"upgrading {package_descr}", self.do_animation):
+                process = self.backend.install(
+                    venv_root=self.root,
+                    venv_python=self.python_path,
+                    requirements=[install_spec],
+                    pip_args=self._with_cooldown([*(upgrade_only_pip_args or []), *pip_args], cooldown_days),
+                    upgrade=True,
+                    log_pip_errors=False,
+                    verbose=self.verbose,
+                )
         subprocess_post_check(process)
 
         self.update_package_metadata(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,6 +90,23 @@ def make_project_with_dependency(root: Path, tmp_path: Path) -> Callable[[str], 
     return create
 
 
+@pytest.fixture
+def inline_script(tmp_path: Path) -> Path:
+    script: Final[Path] = tmp_path / "hello.py"
+    script.write_text(
+        """# /// script
+# dependencies = ["pycowsay"]
+# requires-python = ">=3.10"
+# ///
+import pycowsay
+
+print("installed")
+""",
+        encoding="utf-8",
+    )
+    return script
+
+
 @pytest.fixture()
 def local_extras_project(root: Path, tmp_path: Path) -> Path:
     project: Final[Path] = tmp_path / "local_extras"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1095,6 +1095,100 @@ def test_install_local_archive(pipx_temp_env, monkeypatch, capsys, root):
     assert f"- {app_name('repeatme')}\n" in captured.out
 
 
+@pytest.mark.parametrize("backend", [pytest.param("pip", id="pip"), pytest.param("uv", id="uv")])
+def test_install_inline_script(pipx_temp_env: None, inline_script: Path, backend: str) -> None:
+    if backend == "uv" and shutil.which("uv") is None:
+        pytest.skip("uv is not installed")
+    assert not run_pipx_cli(["install", "--backend", backend, str(inline_script)])
+
+    app: Final[Path] = paths.ctx.bin_dir / app_name("hello")
+    process: Final[subprocess.CompletedProcess[str]] = subprocess.run(
+        [app],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert (process.stdout, run_pipx_cli(["uninstall", "hello"]), app.exists()) == ("installed\n", 0, False)
+
+
+def test_install_inline_script_app_override(pipx_temp_env: None, inline_script: Path) -> None:
+    assert not run_pipx_cli(["install", "--app", "greet", str(inline_script)])
+
+    assert (paths.ctx.bin_dir / app_name("greet")).is_file()
+
+
+def test_install_inline_script_url(pipx_temp_env: None, inline_script: Path, mocker: MockerFixture) -> None:
+    response: Final[MagicMock] = mocker.MagicMock()
+    response.read.return_value = inline_script.read_bytes()
+    response.headers.get_content_charset.return_value = "utf-8"
+    response.__enter__.return_value = response
+    mocker.patch("pipx.script.urllib.request.urlopen", autospec=True, return_value=response)
+
+    assert not run_pipx_cli(["install", "https://example.invalid/hello.py"])
+
+    assert (paths.ctx.bin_dir / app_name("hello")).is_file()
+
+
+def test_install_inline_script_url_error(
+    pipx_temp_env: None,
+    mocker: MockerFixture,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    mocker.patch("pipx.script.urllib.request.urlopen", autospec=True, side_effect=OSError("unavailable"))
+
+    assert run_pipx_cli(["install", "--output", "json", "https://example.invalid/hello.py"])
+
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
+    failure: Final[str] = json.loads(captured.out)["data"]["failures"][0]["error"]
+    assert ("Unable to read script" in " ".join(failure.split()), (paths.ctx.venvs / "hello").exists()) == (
+        True,
+        False,
+    )
+
+
+def test_install_inline_script_rolls_back_without_metadata(
+    pipx_temp_env: None,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    script: Final[Path] = tmp_path / "plain.py"
+    script.write_text("print('hello')\n", encoding="utf-8")
+
+    assert run_pipx_cli(["install", "--output", "json", str(script)])
+
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
+    failure: Final[str] = json.loads(captured.out)["data"]["failures"][0]["error"]
+    assert ("has no PEP 723" in " ".join(failure.split()), (paths.ctx.venvs / "plain").exists()) == (True, False)
+
+
+def test_install_inline_script_rolls_back_obsolete_metadata(
+    pipx_temp_env: None,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    script: Final[Path] = tmp_path / "obsolete.py"
+    script.write_text("# /// pyproject\n# dependencies = []\n# ///\n", encoding="utf-8")
+
+    assert run_pipx_cli(["install", "--output", "json", str(script)])
+
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
+    failure: Final[str] = json.loads(captured.out)["data"]["failures"][0]["error"]
+    assert ("obsolete" in failure, (paths.ctx.venvs / "obsolete").exists()) == (True, False)
+
+
+def test_install_inline_script_from_pylock(
+    pipx_temp_env: None,
+    inline_script: Path,
+    make_pylock: Callable[[str, str], Path],
+) -> None:
+    lock_file: Final[Path] = make_pylock("pycowsay", "0.0.0.2")
+
+    assert not run_pipx_cli(["install", "--lock", str(lock_file), str(inline_script)])
+
+    metadata: Final[PackageInfo] = PipxMetadata(paths.ctx.venvs / "hello").main_package
+    assert (metadata.lock_file, (paths.ctx.bin_dir / app_name("hello")).is_file()) == (lock_file.resolve(), True)
+
+
 def test_force_install_changes(pipx_temp_env, capsys):
     assert not run_pipx_cli(["install", "https://github.com/wntrblm/nox/archive/2022.1.7.zip"])
     captured = capsys.readouterr()

--- a/tests/test_reinstall.py
+++ b/tests/test_reinstall.py
@@ -1,3 +1,4 @@
+import subprocess
 import sys
 from collections.abc import Callable
 from dataclasses import replace
@@ -15,6 +16,24 @@ from pipx.pipx_metadata_file import PackageInfo, PipxMetadata
 def test_reinstall(pipx_temp_env, capsys):
     assert not run_pipx_cli(["install", "pycowsay"])
     assert not run_pipx_cli(["reinstall", "--python", sys.executable, "pycowsay"])
+
+
+def test_reinstall_inline_script(pipx_temp_env: None, inline_script: Path) -> None:
+    assert not run_pipx_cli(["install", str(inline_script)])
+    inline_script.write_text(
+        inline_script.read_text(encoding="utf-8").replace("installed", "reinstalled"),
+        encoding="utf-8",
+    )
+
+    assert not run_pipx_cli(["reinstall", "--python", sys.executable, "hello"])
+
+    process: Final[subprocess.CompletedProcess[str]] = subprocess.run(
+        [paths.ctx.bin_dir / app_name("hello")],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert process.stdout == "reinstalled\n"
 
 
 def test_reinstall_preserves_cooldowns(

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+import pytest
+
+from pipx.script import ScriptMetadata, installable_script, read_script_metadata, script_name_from_spec
+from pipx.util import PipxError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_read_script_metadata() -> None:
+    metadata: Final[ScriptMetadata | None] = read_script_metadata(
+        """# /// script
+# dependencies = ["requests >= 2"]
+# requires-python = ">=3.10"
+# ///
+"""
+    )
+
+    assert metadata == ScriptMetadata(("requests>=2",), ">=3.10")
+
+
+def test_read_script_metadata_path(tmp_path: Path) -> None:
+    script: Final[Path] = tmp_path / "app.py"
+    script.write_text("# /// script\n# dependencies = []\n# ///\n", encoding="utf-8-sig", newline="\r\n")
+
+    assert read_script_metadata(script) == ScriptMetadata((), None)
+
+
+def test_read_script_metadata_missing() -> None:
+    assert read_script_metadata("print('hello')\n") is None
+
+
+@pytest.mark.parametrize(
+    ("content", "message", "error_type"),
+    [
+        (
+            "# /// script\n# dependencies = [1]\n# ///\n",
+            "dependencies.*array of strings",
+            PipxError,
+        ),
+        (
+            '# /// script\n# dependencies = ["???"]\n# ///\n',
+            "Invalid requirement",
+            PipxError,
+        ),
+        (
+            "# /// script\n# dependencies = []\n# requires-python = []\n# ///\n",
+            "requires-python.*string",
+            PipxError,
+        ),
+        (
+            '# /// script\n# dependencies = []\n# requires-python = "invalid"\n# ///\n',
+            "Invalid.*requires-python",
+            PipxError,
+        ),
+        (
+            "# /// pyproject\n# dependencies = []\n# ///\n",
+            "obsolete.*pyproject",
+            ValueError,
+        ),
+        (
+            "# /// script\n# dependencies = []\n# ///\n# /// script\n# dependencies = []\n# ///\n",
+            "Multiple",
+            ValueError,
+        ),
+    ],
+    ids=("dependencies", "requirement", "requires-python-type", "requires-python-value", "obsolete", "multiple"),
+)
+def test_read_script_metadata_invalid(content: str, message: str, error_type: type[Exception]) -> None:
+    with pytest.raises(error_type, match=message):
+        read_script_metadata(content)
+
+
+@pytest.mark.parametrize(
+    ("spec", "expected_apps", "name"),
+    [
+        ("https://example.invalid/My_App.py", (), "my-app"),
+        ("https://example.invalid/app.py?version=1", ("Other_App",), "other-app"),
+        ("https://example.invalid/app.whl", (), None),
+    ],
+    ids=("url", "override", "package"),
+)
+def test_script_name_from_spec(spec: str, expected_apps: tuple[str, ...], name: str | None) -> None:
+    assert script_name_from_spec(spec, expected_apps) == name
+
+
+def test_script_name_from_spec_path(tmp_path: Path) -> None:
+    script: Final[Path] = tmp_path / "My_App.py"
+    script.touch()
+
+    assert script_name_from_spec(str(script), ()) == "my-app"
+
+
+def test_script_name_from_spec_path_without_suffix(tmp_path: Path) -> None:
+    script: Final[Path] = tmp_path / "My_App"
+    script.write_text("# /// script\n# dependencies = []\n# ///\n", encoding="utf-8")
+
+    assert script_name_from_spec(str(script), ()) == "my-app"
+
+
+def test_script_name_from_spec_binary_without_suffix(tmp_path: Path) -> None:
+    binary: Final[Path] = tmp_path / "binary"
+    binary.write_bytes(b"\xff\xfe")
+
+    assert script_name_from_spec(str(binary), ()) is None
+
+
+def test_installable_script_rejects_name_mismatch() -> None:
+    with pytest.raises(PipxError, match="does not match"):
+        with installable_script("other", "https://example.invalid/app.py", ()):
+            pass
+
+
+@pytest.mark.parametrize(
+    ("expected_apps", "message"),
+    [
+        (("first", "second"), "one --app"),
+        (("bad/app",), "portable command name"),
+    ],
+    ids=("multiple", "invalid"),
+)
+def test_script_name_from_spec_invalid(expected_apps: tuple[str, ...], message: str) -> None:
+    with pytest.raises(PipxError, match=message):
+        script_name_from_spec("https://example.invalid/app.py", expected_apps)

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -32,6 +33,24 @@ def test_upgrade(pipx_temp_env, capsys):
     assert not run_pipx_cli(["upgrade", "pycowsay"])
     captured = capsys.readouterr()
     assert "pycowsay is already at latest version" in captured.out
+
+
+def test_upgrade_inline_script(pipx_temp_env: None, inline_script: Path) -> None:
+    assert not run_pipx_cli(["install", "--app", "greet", str(inline_script)])
+    inline_script.write_text(
+        inline_script.read_text(encoding="utf-8").replace("installed", "upgraded"),
+        encoding="utf-8",
+    )
+
+    assert not run_pipx_cli(["upgrade", "greet"])
+
+    process: Final[subprocess.CompletedProcess[str]] = subprocess.run(
+        [paths.ctx.bin_dir / app_name("greet")],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert process.stdout == "upgraded\n"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`pipx install` now accepts local and HTTP(S) PEP 723 scripts, using the filename or `--app` value as the command name. Users can keep a script on `PATH` without wrapping it in a package.

pipx builds a temporary wheel and passes it to pip or uv. It records the original path or URL so `reinstall` and `upgrade` rebuild from source. `--lock` installs dependencies declared by the script from `pylock.toml`, then installs the script without dependency resolution.

Closes #1388.
