### PR TITLE
✨ feat(output): standardize format selection

### DIFF
--- a/changelog.d/828.feature.4.md
+++ b/changelog.d/828.feature.4.md
@@ -1,0 +1,1 @@
+Add `--output` to structured commands.

--- a/docs/explanation/comparisons.md
+++ b/docs/explanation/comparisons.md
@@ -53,7 +53,7 @@ managers writes the same filename. Each manager refuses to overwrite a binary th
 | Remove an injected dep       | `pipx uninject mkdocs mkdocs-material`            | _rebuild without `--with`_                                          |
 | Upgrade one                  | `pipx upgrade ruff`                               | `uv tool upgrade ruff`                                              |
 | Upgrade all                  | `pipx upgrade-all`                                | `uv tool upgrade --all`                                             |
-| List installed or outdated   | `pipx list` (`--outdated`, `--json`)              | `uv tool list` (`--show-with`, `--outdated`, …)                     |
+| List installed or outdated   | `pipx list` (`--outdated`, `--output json`)       | `uv tool list` (`--show-with`, `--outdated`, …)                     |
 | Diagnose broken environments | `pipx health`                                     | _no equivalent_                                                     |
 | Repair broken environments   | `pipx repair ruff` / `repair`                     | `uv tool install ruff` / _no bulk equivalent_                       |
 | Reinstall any environment    | `pipx reinstall ruff` / `reinstall-all`           | `uv tool upgrade --reinstall ruff` / `--all`                        |
@@ -74,7 +74,8 @@ managers writes the same filename. Each manager refuses to overwrite a binary th
 - Manual pages get symlinked under `$PIPX_MAN_DIR`.
 - `pipx sync <manifest>` applies an explicit desired set; `pipx lock <manifest>` writes one PEP 751 lock per selected
     tool.
-- `pipx install-all <spec.json>` rebuilds every venv from a `pipx list --json` snapshot for cross-machine migration.
+- `pipx install-all <spec.json>` rebuilds every venv from a `pipx list --output json` snapshot for cross-machine
+    migration.
 - `[project.entry-points."pipx.run"]` declares pipx-specific runtime extras in the package metadata.
 - `pipx environment` prints every variable and its resolved value in one place.
 - `--cooldown DAYS` provides the same release-age policy through pip and uv.

--- a/docs/how-to/pin-packages.md
+++ b/docs/how-to/pin-packages.md
@@ -11,7 +11,7 @@ versions until you unpin it.
 - `pipx unpin PACKAGE` — re-enables upgrades for the package and anything that was pinned with it.
 - `pipx list --pinned` — shows every pinned environment; add `--include-injected` to see pinned injected packages.
 
-Pass `--json` to read changed and skipped packages in a script, or `--quiet` to omit confirmations.
+Pass `--output json` to read changed and skipped packages in a script, or `--quiet` to omit confirmations.
 
 pipx tracks the main package and any injected packages. It does not record individual transitive dependencies, so there
 is no way to pin a single dependency in isolation. Pinning the main package protects its dependency set because pipx

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -29,7 +29,7 @@ pipx health
 ```
 
 The command exits with status 1 when an environment cannot run its Python interpreter. Pass package names to check a
-subset, or pass `--json` to read the result from a script.
+subset, or pass `--output json` to read the result from a script.
 
 Repair failed environments with the default Python:
 

--- a/docs/reference/examples.md
+++ b/docs/reference/examples.md
@@ -161,7 +161,7 @@ pipx 0.10.0
 ## `pipx install-all` example
 
 ```shell
-> pipx list --json > pipx.json
+> pipx list --output json > pipx.json
 > pipx install-all pipx.json
 'black' already seems to be installed. Not modifying existing installation in '/usr/local/pipx/venvs/black'. Pass '--force' to force installation.
 'pipx' already seems to be installed. Not modifying existing installation in '/usr/local/pipx/venvs/black'. Pass '--force' to force installation.

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -42,7 +42,7 @@ Check available upgrades without changing an environment:
 pipx list --outdated
 ```
 
-The output shows each package's installed and available versions. Pass `--json` to read the same information in a
+The output shows each package's installed and available versions. Pass `--output json` to read the same information in a
 script.
 
 ```
@@ -63,7 +63,13 @@ pipx uninstall pycowsay
 
 pipx deletes the isolated environment and removes the command from your `PATH`.
 
-Pass `--json` to read the removal result in a script, or `--quiet` to omit the confirmation.
+Pass `--output json` to read the removal result in a script, or `--quiet` to omit the confirmation.
+
+### Use pipx from scripts
+
+`install`, `inject`, `uninject`, `expose`, `unexpose`, `pin`, `unpin`, `upgrade`, `upgrade-all`, `uninstall`,
+`uninstall-all`, `health`, `repair`, and `list` accept `--output json`. Commands backed by the result envelope include a
+`pipx_result_version`; `list` retains its environment snapshot. Existing `--json` flags remain aliases.
 
 ### Next steps
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -338,8 +338,6 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:
 
 
 def _output_format(args: argparse.Namespace) -> OutputFormat:
-    if getattr(args, "json", False):
-        return OutputFormat.JSON
     return OutputFormat(getattr(args, "output", OutputFormat.HUMAN))
 
 
@@ -437,13 +435,22 @@ def _add_dependency_app_options(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def _add_output_option(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument(
+def _add_output_option(parser: argparse.ArgumentParser, *, legacy_json: bool = False) -> None:
+    group: Final[argparse._MutuallyExclusiveGroup] = parser.add_mutually_exclusive_group()
+    group.add_argument(
         "--output",
         choices=[output.value for output in OutputFormat],
         default=OutputFormat.HUMAN,
         help="Select the output format.",
     )
+    if legacy_json:
+        group.add_argument(
+            "--json",
+            action="store_const",
+            const=OutputFormat.JSON,
+            dest="output",
+            help="Alias for '--output json'.",
+        )
 
 
 class _DeprecatedFetchMissingPython(argparse.Action):
@@ -590,7 +597,7 @@ def _add_install_all(subparsers: argparse._SubParsersAction, shared_parser: argp
         description="Installs all the packages according to spec metadata file.",
         parents=[shared_parser],
     )
-    p.add_argument("spec_metadata_file", help="Spec metadata file generated from pipx list --json")
+    p.add_argument("spec_metadata_file", help="Spec metadata file generated from pipx list --output json")
     p.add_argument(
         "--force",
         "-f",
@@ -784,7 +791,7 @@ def _add_expose(
         parents=[shared_parser],
     )
     parser.add_argument("package", help="Installed package to expose").completer = venv_completer
-    parser.add_argument("--json", action="store_true", help="Output a machine-readable result.")
+    _add_output_option(parser, legacy_json=True)
     parser.set_defaults(func=_cmd_expose)
 
 
@@ -806,7 +813,7 @@ def _add_unexpose(
         parents=[shared_parser],
     )
     parser.add_argument("package", help="Installed package to hide").completer = venv_completer
-    parser.add_argument("--json", action="store_true", help="Output a machine-readable result.")
+    _add_output_option(parser, legacy_json=True)
     parser.set_defaults(func=_cmd_unexpose)
 
 
@@ -842,7 +849,7 @@ def _add_pin(
         default=[],
         help="Skip these packages. Implies `--injected-only`.",
     )
-    p.add_argument("--json", action="store_true", help="Output a machine-readable result.")
+    _add_output_option(p, legacy_json=True)
     p.set_defaults(func=_cmd_pin)
 
 
@@ -864,7 +871,7 @@ def _add_unpin(
         parents=[shared_parser],
     )
     p.add_argument("package", help="Installed package to unpin")
-    p.add_argument("--json", action="store_true", help="Output a machine-readable result.")
+    _add_output_option(p, legacy_json=True)
     p.set_defaults(func=_cmd_unpin)
 
 
@@ -901,6 +908,7 @@ def _add_upgrade(subparsers, venv_completer: VenvCompleter, shared_parser: argpa
     )
     add_python_options(p)
     add_backend_arg(p)
+    _add_output_option(p)
     p.set_defaults(func=_cmd_upgrade)
 
 
@@ -942,7 +950,7 @@ def _add_upgrade_all(subparsers: argparse._SubParsersAction, shared_parser: argp
     )
     add_pip_venv_args(p)
     add_backend_arg(p)
-    p.add_argument("--json", action="store_true", help="Output a machine-readable result.")
+    _add_output_option(p, legacy_json=True)
     p.set_defaults(func=_cmd_upgrade_all)
 
 
@@ -987,7 +995,7 @@ def _add_uninstall(subparsers, venv_completer: VenvCompleter, shared_parser: arg
         parents=[shared_parser],
     )
     p.add_argument("package").completer = venv_completer
-    p.add_argument("--json", action="store_true", help="Output a machine-readable result.")
+    _add_output_option(p, legacy_json=True)
     p.set_defaults(func=_cmd_uninstall)
 
 
@@ -1004,7 +1012,7 @@ def _add_uninstall_all(subparsers: argparse._SubParsersAction, shared_parser: ar
         description="Uninstall all pipx-managed packages",
         parents=[shared_parser],
     )
-    p.add_argument("--json", action="store_true", help="Output a machine-readable result.")
+    _add_output_option(p, legacy_json=True)
     p.set_defaults(func=_cmd_uninstall_all)
 
 
@@ -1100,7 +1108,7 @@ def _add_health(
         parents=[shared_parser],
     )
     parser.add_argument("packages", nargs="*", help="Installed packages to check").completer = venv_completer
-    parser.add_argument("--json", action="store_true", help="Output a machine-readable result.")
+    _add_output_option(parser, legacy_json=True)
     parser.set_defaults(func=_cmd_health)
 
 
@@ -1122,6 +1130,7 @@ def _add_repair(
     parser.add_argument("packages", nargs="*", help="Installed packages to repair").completer = venv_completer
     add_python_options(parser)
     add_backend_arg(parser)
+    _add_output_option(parser)
     parser.set_defaults(func=_cmd_repair)
 
 
@@ -1159,13 +1168,13 @@ def _add_list(subparsers: argparse._SubParsersAction, shared_parser: argparse.Ar
     )
     p.add_argument("--outdated", action="store_true", help="List packages with an available upgrade.")
     g = p.add_mutually_exclusive_group()
-    g.add_argument("--json", action="store_true", help="Output rich data in json format.")
     g.add_argument("--short", action="store_true", help="List packages only.")
     g.add_argument(
         "--pinned",
         action="store_true",
         help="List pinned packages only. Pass --include-injected at the same time to list injected packages that were pinned.",
     )
+    _add_output_option(p, legacy_json=True)
     p.set_defaults(func=_cmd_list)
 
 
@@ -1174,7 +1183,16 @@ def _cmd_list(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode | Oper
         if args.short or args.pinned:
             raise PipxError("--outdated cannot be combined with --short or --pinned.")
         return commands.list_outdated(ctx.venv_container, include_injected=args.include_injected)
-    return commands.list_packages(ctx.venv_container, args.include_injected, args.json, args.short, args.pinned)
+    output: Final[OutputFormat] = _output_format(args)
+    if output is OutputFormat.JSON and (args.short or args.pinned):
+        raise PipxError("--output json cannot be combined with --short or --pinned.")
+    return commands.list_packages(
+        ctx.venv_container,
+        args.include_injected,
+        output is OutputFormat.JSON,
+        args.short,
+        args.pinned,
+    )
 
 
 def _add_interpreter(

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -43,7 +43,7 @@ def test_environment_maintenance_no_packages(
 
 
 def test_health_json(installed_pycowsay: Path, capsys: CaptureFixture[str]) -> None:
-    assert run_pipx_cli(["health", "pycowsay", "--json"]) == 0
+    assert run_pipx_cli(["health", "pycowsay", "--output", "json"]) == 0
 
     assert json.loads(capsys.readouterr().out) == {
         "command": "health",
@@ -57,6 +57,17 @@ def test_health_json(installed_pycowsay: Path, capsys: CaptureFixture[str]) -> N
                 }
             ]
         },
+        "pipx_result_version": "0.1",
+        "status": "success",
+    }
+
+
+def test_repair_json(pipx_temp_env: None, capsys: CaptureFixture[str]) -> None:
+    assert run_pipx_cli(["repair", "--output", "json"]) == 0
+
+    assert json.loads(capsys.readouterr().out) == {
+        "command": "repair",
+        "data": {"failures": [], "repaired": [], "skipped": []},
         "pipx_result_version": "0.1",
         "status": "success",
     }

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -123,7 +123,7 @@ def test_list_json(pipx_temp_env, capsys):
     assert not run_pipx_cli(["inject", "pylint", PKG["black"]["spec"]])
     captured = capsys.readouterr()
 
-    assert not run_pipx_cli(["list", "--json"])
+    assert not run_pipx_cli(["list", "--output", "json"])
     captured = capsys.readouterr()
 
     assert not re.search(r"\S", captured.err)
@@ -179,6 +179,17 @@ def test_list_short(pipx_temp_env, monkeypatch, capsys):
 
     assert "pycowsay 0.0.0.2" in captured.out
     assert "pylint 3.0.4" in captured.out
+
+
+@pytest.mark.parametrize("option", [pytest.param("--short", id="short"), pytest.param("--pinned", id="pinned")])
+def test_list_json_rejects_human_filter(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    option: str,
+) -> None:
+    assert run_pipx_cli(["list", "--output", "json", option]) == 1
+
+    assert "--output json cannot be combined with --short or --pinned" in capsys.readouterr().err
 
 
 def test_list_injected_apps_without_symlinks(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -81,6 +81,33 @@ def test_all_subcommands_have_func_registered():
                 assert callable(sub_parser._defaults.get("func")), f"{sub_name!r} missing callable func default"
 
 
+@pytest.mark.parametrize(
+    "argv",
+    [
+        pytest.param(["install", "pycowsay"], id="install"),
+        pytest.param(["inject", "pycowsay", "black"], id="inject"),
+        pytest.param(["uninject", "pycowsay", "black"], id="uninject"),
+        pytest.param(["expose", "pycowsay"], id="expose"),
+        pytest.param(["unexpose", "pycowsay"], id="unexpose"),
+        pytest.param(["pin", "pycowsay"], id="pin"),
+        pytest.param(["unpin", "pycowsay"], id="unpin"),
+        pytest.param(["upgrade", "pycowsay"], id="upgrade"),
+        pytest.param(["upgrade-all"], id="upgrade-all"),
+        pytest.param(["uninstall", "pycowsay"], id="uninstall"),
+        pytest.param(["uninstall-all"], id="uninstall-all"),
+        pytest.param(["health"], id="health"),
+        pytest.param(["repair"], id="repair"),
+        pytest.param(["list"], id="list"),
+    ],
+)
+def test_operation_commands_accept_output_format(argv: list[str]) -> None:
+    parser: Final[argparse.ArgumentParser] = main.get_command_parser()[0]
+
+    args: Final[argparse.Namespace] = main.parse_pipx_args(parser, [*argv, "--output", "json"])
+
+    assert args.output == "json"
+
+
 def test_manpage_matches_parser(tmp_path: Path) -> None:
     generated = tmp_path / "pipx.1.rst"
     subprocess.run([sys.executable, str(_ROOT / "scripts" / "generate_man.py"), str(generated)], check=True)

--- a/tests/test_outdated.py
+++ b/tests/test_outdated.py
@@ -97,7 +97,7 @@ def test_list_outdated_text(
 
 
 def test_list_outdated_json(outdated_environment: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
-    assert not run_pipx_cli(["list", "--outdated", "--json"])
+    assert not run_pipx_cli(["list", "--outdated", "--output", "json"])
 
     captured = capsys.readouterr()
     assert (json.loads(captured.out), captured.err) == (

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -40,7 +40,7 @@ def test_uninstall_json(
 ) -> None:
     command, arguments = uninstall_command
 
-    assert not run_pipx_cli([command, *arguments, "--json"])
+    assert not run_pipx_cli([command, *arguments, "--output", "json"])
 
     captured = capsys.readouterr()
     assert (json.loads(captured.out), captured.err) == (

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,9 +1,9 @@
+from __future__ import annotations
+
 import json
 import subprocess
 import sys
-from collections.abc import Callable
-from pathlib import Path
-from typing import Final, cast
+from typing import TYPE_CHECKING, Final, cast
 
 import pytest
 
@@ -19,6 +19,12 @@ from helpers import (
 from package_info import PKG
 from pipx import paths
 from pipx.pipx_metadata_file import PIPX_INFO_FILENAME, PackageInfo, PipxMetadata
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from _pytest.capture import CaptureResult
 
 
 def test_upgrade(pipx_temp_env, capsys):
@@ -51,6 +57,38 @@ def test_upgrade_inline_script(pipx_temp_env: None, inline_script: Path) -> None
         text=True,
     )
     assert process.stdout == "upgraded\n"
+
+
+def test_upgrade_json(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    capsys.readouterr()
+
+    assert not run_pipx_cli(["upgrade", "pycowsay", "--output", "json"])
+
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
+    assert (json.loads(captured.out), captured.err) == (
+        {
+            "command": "upgrade",
+            "data": {
+                "failures": [],
+                "packages": [
+                    {
+                        "environment": "pycowsay",
+                        "injected": False,
+                        "location": str(paths.ctx.venvs / "pycowsay"),
+                        "package": "pycowsay",
+                        "previous_version": "0.0.0.2",
+                        "status": "unchanged",
+                        "version": "0.0.0.2",
+                    }
+                ],
+                "skipped": [],
+            },
+            "pipx_result_version": "0.1",
+            "status": "success",
+        },
+        "",
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`--json` tied machine-readable output to one encoding and left newer structured commands with a separate `--output` spelling. Scripts can use `--output json` across commands that expose structured results.

`--output` selects the `OutputFormat` used by the shared result renderer. Existing `--json` options remain aliases, and `upgrade` and `repair` now expose their result envelopes. Future formats can extend `OutputFormat` and the renderer under the same flag.

Advances #828.
