### PR TITLE
✨ feat(install): stream verbose installer output

### DIFF
--- a/changelog.d/1069.feature.md
+++ b/changelog.d/1069.feature.md
@@ -1,0 +1,1 @@
+Stream installer output during verbose installs.

--- a/docs/explanation/how-pipx-works.md
+++ b/docs/explanation/how-pipx-works.md
@@ -88,7 +88,7 @@ flowchart TD
     style V1BIN fill:#7c4dff,color:#fff
 ```
 
-You can do all of this yourself. pipx automates it. Pass `--verbose` to see every command and argument pipx runs.
+You can do all of this yourself. pipx automates it. Pass `--verbose` to see each command and stream installer output.
 
 ### Resolving the Python interpreter
 

--- a/src/pipx/backends/pip.py
+++ b/src/pipx/backends/pip.py
@@ -87,12 +87,15 @@ class PipBackend(Backend):
             cmd.append("--upgrade")
         if no_deps:
             cmd.append("--no-dependencies")
+        if verbose:
+            cmd.append("--progress-bar=on")
         cmd += [*pip_args, *requirements]
         process = run_subprocess(
             cmd,
             log_stdout=not log_pip_errors,
             log_stderr=not log_pip_errors,
             run_dir=str(venv_root),
+            stream_output=verbose,
         )
         if log_pip_errors:
             subprocess_post_check_handle_pip_error(process)

--- a/src/pipx/backends/uv.py
+++ b/src/pipx/backends/uv.py
@@ -112,6 +112,7 @@ class UvBackend(Backend):
             log_stdout=not log_pip_errors,
             log_stderr=not log_pip_errors,
             env_overrides=_UV_ENV_OVERRIDES,
+            stream_output=verbose,
         )
         if log_pip_errors:
             subprocess_post_check_handle_pip_error(process, tool_name="uv")

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -1,3 +1,4 @@
+import codecs
 import logging
 import os
 import random
@@ -7,13 +8,17 @@ import string
 import subprocess
 import sys
 from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+from itertools import chain
 from pathlib import Path
 from re import Pattern
 from typing import (
+    IO,
     Any,
     Final,
     NoReturn,
+    TextIO,
 )
 
 from pipx import paths
@@ -22,6 +27,7 @@ from pipx.constants import MINGW, WINDOWS
 from pipx.wrap import pipx_wrap
 
 _LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
+_SUBPROCESS_STREAM_READ_SIZE: Final[int] = 8 * 1024
 
 
 class PipxError(Exception):
@@ -170,6 +176,7 @@ def run_subprocess(
     log_stderr: bool = True,
     run_dir: str | None = None,
     env_overrides: dict[str, str | None] | None = None,
+    stream_output: bool = False,
 ) -> "subprocess.CompletedProcess[str]":
     """Run a command as a subprocess, capturing stderr and stdout.
 
@@ -198,24 +205,99 @@ def run_subprocess(
     if len(cmd_str_list) > 0 and "python" in Path(cmd_str_list[0]).name.lower():
         env.setdefault("PYTHONSAFEPATH", "1")
 
-    completed_process = subprocess.run(
-        cmd_str_list,
-        env=env,
-        stdout=subprocess.PIPE if capture_stdout else None,
-        stderr=subprocess.PIPE if capture_stderr else None,
-        encoding="utf-8",
-        text=True,
-        check=False,
-        cwd=run_dir,
-    )
+    if stream_output:
+        completed_process = _run_streaming_subprocess(
+            cmd_str_list,
+            capture_stdout=capture_stdout,
+            capture_stderr=capture_stderr,
+            cwd=run_dir,
+            env=env,
+        )
+    else:
+        completed_process = subprocess.run(
+            cmd_str_list,
+            env=env,
+            stdout=subprocess.PIPE if capture_stdout else None,
+            stderr=subprocess.PIPE if capture_stderr else None,
+            encoding="utf-8",
+            text=True,
+            check=False,
+            cwd=run_dir,
+        )
 
-    if capture_stdout and log_stdout:
+    if capture_stdout and log_stdout and not stream_output:
         _LOGGER.debug(f"stdout: {completed_process.stdout}".rstrip())
-    if capture_stderr and log_stderr:
+    if capture_stderr and log_stderr and not stream_output:
         _LOGGER.debug(f"stderr: {completed_process.stderr}".rstrip())
     _LOGGER.debug(f"returncode: {completed_process.returncode}")
 
     return completed_process
+
+
+def _run_streaming_subprocess(
+    cmd: list[str],
+    *,
+    capture_stdout: bool,
+    capture_stderr: bool,
+    cwd: str | None,
+    env: dict[str, str],
+) -> "subprocess.CompletedProcess[str]":
+    stdout_chunks: Final[list[str]] = []
+    stderr_chunks: Final[list[str]] = []
+    with (
+        subprocess.Popen(
+            cmd,
+            env=env,
+            stdout=subprocess.PIPE if capture_stdout else None,
+            stderr=subprocess.PIPE if capture_stderr else None,
+            cwd=cwd,
+        ) as process,
+        ThreadPoolExecutor(max_workers=2) as executor,
+    ):
+        for future in [
+            executor.submit(_tee_subprocess_output, source, destination, chunks)
+            for source, destination, chunks in (
+                (process.stdout, sys.stdout, stdout_chunks),
+                (process.stderr, sys.stderr, stderr_chunks),
+            )
+            if source is not None
+        ]:
+            future.result()
+        returncode: Final[int] = process.wait()
+    return subprocess.CompletedProcess(
+        cmd,
+        returncode,
+        "".join(stdout_chunks) if capture_stdout else None,
+        "".join(stderr_chunks) if capture_stderr else None,
+    )
+
+
+def _tee_subprocess_output(source: IO[bytes], destination: TextIO, chunks: list[str]) -> None:
+    write_error: OSError | UnicodeError | None = None
+    pending_carriage_return: bool = False
+    for decoded in chain(
+        codecs.iterdecode(iter(lambda: os.read(source.fileno(), _SUBPROCESS_STREAM_READ_SIZE), b""), "utf-8"),
+        (None,),
+    ):
+        if decoded is None:
+            chunk = "\r" if pending_carriage_return else ""
+        else:
+            chunk = ("\r" if pending_carriage_return else "") + decoded
+            pending_carriage_return = chunk.endswith("\r")
+            if pending_carriage_return:
+                chunk = chunk[:-1]
+            chunk = chunk.replace("\r\n", "\n")
+        if not chunk:
+            continue
+        chunks.append(chunk)
+        if write_error is None:
+            try:
+                destination.write(chunk)
+                destination.flush()
+            except (OSError, UnicodeError) as error:
+                write_error = error
+    if write_error is not None:
+        raise write_error
 
 
 def subprocess_post_check(completed_process: "subprocess.CompletedProcess[str]", raise_error: bool = True) -> None:

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -28,6 +28,8 @@ from pipx.venv import Venv, reset_backend_override_warnings
 from pipx.venv_inspect import list_not_required_packages
 
 if TYPE_CHECKING:
+    from unittest.mock import MagicMock
+
     from pytest_mock import MockerFixture
 
 
@@ -214,6 +216,41 @@ def test_uv_backend_rejects_pre_cooldown_version(mocker: MockerFixture) -> None:
 
     with pytest.raises(PipxError, match=r"uv>=0\.9\.17"):
         UvBackend()
+
+
+@pytest.mark.parametrize("backend_name", [pytest.param(PIP, id="pip"), pytest.param(UV, id="uv")])
+def test_backend_verbose_install_streams_output(backend_name: str, tmp_path: Path, mocker: MockerFixture) -> None:
+    binary: Final[Path] = tmp_path / "uv"
+    mocker.patch("pipx.backends.uv.resolve_uv_binary", return_value=binary)
+    mocker.patch("pipx.backends.uv.find_uv_binary", return_value=(binary, "path"))
+    mocker.patch(
+        "pipx.backends.uv.subprocess.run",
+        return_value=subprocess.CompletedProcess([str(binary), "--version"], 0, stdout="uv 0.11.28", stderr=""),
+    )
+    run_subprocess: Final[MagicMock] = mocker.patch(
+        f"pipx.backends.{backend_name}.run_subprocess",
+        autospec=True,
+        return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+    )
+    venv_python: Final[Path] = tmp_path / "bin" / "python"
+
+    (UvBackend() if backend_name == UV else PipBackend()).install(
+        venv_root=tmp_path,
+        venv_python=venv_python,
+        requirements=["demo"],
+        pip_args=[],
+        verbose=True,
+    )
+
+    expected_command: Final[list[str | Path]] = (
+        [str(venv_python), "-m", "pip", "--no-input", "install", "--progress-bar=on", "demo"]
+        if backend_name == PIP
+        else [binary, "pip", "install", "--python", str(venv_python), "--verbose", "demo"]
+    )
+    assert (run_subprocess.call_args.args[0], run_subprocess.call_args.kwargs["stream_output"]) == (
+        expected_command,
+        True,
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import logging
 import sys
+from io import BytesIO, StringIO, TextIOWrapper
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 import pytest
 
@@ -11,6 +12,9 @@ from pipx import paths
 from pipx.util import exec_app, rmdir, run_subprocess, safe_unlink
 
 if TYPE_CHECKING:
+    import subprocess
+
+    from _pytest.capture import CaptureResult
     from pytest_mock import MockerFixture
 
 
@@ -126,3 +130,73 @@ def test_subprocess_pythonsafepath_set_for_python_commands() -> None:
     )
 
     assert result.stdout == "1"
+
+
+def test_subprocess_streams_and_captures_output(capsys: pytest.CaptureFixture[str]) -> None:
+    result: Final[subprocess.CompletedProcess[str]] = run_subprocess(
+        [
+            sys.executable,
+            "-c",
+            "import sys; sys.stdout.buffer.write('stdøut 1\\rstdøut 2\\r'.encode()); sys.stdout.flush(); "
+            "sys.stderr.buffer.write('stdërr 1\\rstdërr 2\\r\\n'.encode()); sys.stderr.flush()",
+        ],
+        stream_output=True,
+    )
+
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
+    assert (captured.out, captured.err, result.stdout, result.stderr) == (
+        "stdøut 1\rstdøut 2\r",
+        "stdërr 1\rstdërr 2\n",
+        "stdøut 1\rstdøut 2\r",
+        "stdërr 1\rstdërr 2\n",
+    )
+
+
+def test_subprocess_stream_normalizes_split_crlf(mocker: MockerFixture) -> None:
+    destination: Final[StringIO] = StringIO()
+    mocker.patch("pipx.util.sys.stdout", destination)
+    read_size: Final[int] = 8 * 1024
+    result: Final[subprocess.CompletedProcess[str]] = run_subprocess(
+        [
+            sys.executable,
+            "-c",
+            f"import os, sys; os.write(sys.stdout.fileno(), b'x' * {read_size - 1} + b'\\r\\n')",
+        ],
+        capture_stderr=False,
+        stream_output=True,
+    )
+    expected: Final[str] = "x" * (read_size - 1) + "\n"
+
+    assert (destination.getvalue(), result.stdout) == (expected, expected)
+
+
+@pytest.mark.parametrize(
+    "statement",
+    [
+        pytest.param("print('stdout')", id="stdout"),
+        pytest.param("print('stderr', file=sys.stderr)", id="stderr"),
+    ],
+)
+def test_subprocess_stream_does_not_log_capture(
+    caplog: pytest.LogCaptureFixture,
+    statement: str,
+) -> None:
+    with caplog.at_level(logging.DEBUG, logger="pipx.util"):
+        run_subprocess(
+            [sys.executable, "-c", f"import sys; {statement}"],
+            stream_output=True,
+        )
+
+    assert [record.getMessage() for record in caplog.records if record.levelno == logging.DEBUG] == ["returncode: 0"]
+
+
+def test_subprocess_stream_drains_before_output_error(mocker: MockerFixture) -> None:
+    destination: Final[TextIOWrapper] = TextIOWrapper(BytesIO(), encoding="ascii")
+    mocker.patch("pipx.util.sys.stdout", destination)
+
+    with pytest.raises(UnicodeEncodeError):
+        run_subprocess(
+            [sys.executable, "-c", "print('ø' * 100_000)"],
+            capture_stderr=False,
+            stream_output=True,
+        )


### PR DESCRIPTION
[#1069](https://github.com/pypa/pipx/issues/1069) reports that users running `pipx install --verbose` saw no pipx spinner or installer output during large downloads.

pipx tees installer stdout and stderr to the terminal and retains the captured text for error logs and pip diagnostics; the tee normalizes Windows CRLF while preserving standalone `\r` progress updates and does not log captured output again after the process exits. The pip backend forces its progress renderer because pip disables automatic progress when a caller captures its output; the uv backend streams its verbose output under `--verbose`.

pipx keeps the existing spinner for non-verbose installs.
