### PR TITLE
🐛 fix(paths): use the platform directories for home and cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /src/pipx/version.py
 /noxfile.py
 /.nox
+/.tox
 *.py[co]
 __pycache__
 /site
@@ -16,3 +17,4 @@ build
 *.whl
 /pipx.1
 /docs/_draft_changelog.md
+/.vscode/

--- a/changelog.d/1946.bugfix.md
+++ b/changelog.d/1946.bugfix.md
@@ -1,0 +1,2 @@
+Store the venv cache and the logs in the platform cache and log directories on every platform, and keep them out of a
+pipx home that only exists for backwards compatibility. Setting `PIPX_HOME` still keeps both inside it.

--- a/changelog.d/1946.feature.md
+++ b/changelog.d/1946.feature.md
@@ -1,0 +1,3 @@
+Default `PIPX_HOME` to the platform data directory on macOS and Windows again, which restores
+`~/Library/Application Support/pipx` on macOS. `platformdirs` reads `XDG_DATA_HOME` and `XDG_CACHE_HOME` on macOS, so
+exporting those moves the pipx directories. A pipx home from an earlier release keeps working as a fallback.

--- a/changelog.d/1946.removal.md
+++ b/changelog.d/1946.removal.md
@@ -1,0 +1,3 @@
+Remove the `PIPX_HOME_ALLOW_SPACE` environment variable and the warning about spaces in the pipx home path. `pip` and
+`uv` both write a `/bin/sh` wrapper as the shebang when the interpreter path contains a space, so applications installed
+into such a path run.

--- a/docs/how-to/configure-paths.md
+++ b/docs/how-to/configure-paths.md
@@ -7,10 +7,10 @@ overridden with the environment variable `PIPX_MAN_DIR`. If the `--global` optio
 `PIPX_GLOBAL_MAN_DIR`.
 
 pipx's default virtual environment location is typically `~/.local/share/pipx` on Linux/Unix,
-`~/Library/Application Support/pipx` on macOS and `~\pipx` on Windows. For compatibility reasons, if `~/.local/pipx`
-exists or `%USERPROFILE%\AppData\Local\pipx` exists on Windows, it will be used as the default location instead. This
-can be overridden with the `PIPX_HOME` environment variable. If the `--global` option is used, the default location is
-always `/opt/pipx` and can be overridden with `PIPX_GLOBAL_HOME`.
+`~/Library/Application Support/pipx` on macOS and `%USERPROFILE%\AppData\Local\pipx` on Windows. For compatibility
+reasons, if `~/.local/pipx` exists, or `~\pipx` exists on Windows, that location is used instead. This can be overridden
+with the `PIPX_HOME` environment variable. If the `--global` option is used, the default location is always `/opt/pipx`
+and can be overridden with `PIPX_GLOBAL_HOME`.
 
 In case one of these fallback locations exist, we recommend either manually moving the pipx files to the new default
 location (see the [Moving your pipx installation](move-installation.md) section of the docs), or setting the `PIPX_HOME`
@@ -40,6 +40,9 @@ sudo pipx install --global <PACKAGE>
 > `user_data_dir()`, `user_cache_dir()` and `user_log_dir()` resolve to appropriate platform-specific user data, cache
 > and log directories. See the
 > [platformdirs documentation](https://platformdirs.readthedocs.io/en/latest/api.html#platforms) for details.
+>
+> `platformdirs` reads `XDG_DATA_HOME` and `XDG_CACHE_HOME` on Linux and on macOS, so exporting either one moves the
+> matching pipx directory. Leave them unset to get the platform default.
 >
 > This was originally introduced in 1.2.0 and temporarily reverted between 1.5.0 and 1.16.0 for Windows and macOS.
 

--- a/docs/how-to/configure-paths.md
+++ b/docs/how-to/configure-paths.md
@@ -6,11 +6,11 @@ overridden with the environment variable `PIPX_MAN_DIR`. If the `--global` optio
 `/usr/local/bin` and `/usr/local/share/man` respectively and can be overridden with `PIPX_GLOBAL_BIN_DIR` and
 `PIPX_GLOBAL_MAN_DIR`.
 
-pipx's default virtual environment location is typically `~/.local/share/pipx` on Linux/Unix, `~/.local/pipx` on macOS
-and `~\pipx` on Windows. For compatibility reasons, if `~/.local/pipx` on Linux, `%USERPROFILE%\AppData\Local\pipx` or
-`~\.local\pipx` on Windows or `~/Library/Application Support/pipx` on macOS exists, it will be used as the default
-location instead. This can be overridden with the `PIPX_HOME` environment variable. If the `--global` option is used,
-the default location is always `/opt/pipx` and can be overridden with `PIPX_GLOBAL_HOME`.
+pipx's default virtual environment location is typically `~/.local/share/pipx` on Linux/Unix,
+`~/Library/Application Support/pipx` on macOS and `~\pipx` on Windows. For compatibility reasons, if `~/.local/pipx`
+exists or `%USERPROFILE%\AppData\Local\pipx` exists on Windows, it will be used as the default location instead. This
+can be overridden with the `PIPX_HOME` environment variable. If the `--global` option is used, the default location is
+always `/opt/pipx` and can be overridden with `PIPX_GLOBAL_HOME`.
 
 In case one of these fallback locations exist, we recommend either manually moving the pipx files to the new default
 location (see the [Moving your pipx installation](move-installation.md) section of the docs), or setting the `PIPX_HOME`
@@ -26,7 +26,7 @@ sudo pipx install --global <PACKAGE>
 ```
 
 > [!NOTE]
-> After version 1.2.0, the default pipx paths have been moved from `~/.local/pipx` to specific user data directories on
+> After version 1.16.0, the default pipx paths have been moved from `~/.local/pipx` to specific user data directories on
 > each platform using [platformdirs](https://pypi.org/project/platformdirs/) library
 >
 > | Old Path               | New Path                                   |
@@ -41,9 +41,7 @@ sudo pipx install --global <PACKAGE>
 > and log directories. See the
 > [platformdirs documentation](https://platformdirs.readthedocs.io/en/latest/api.html#platforms) for details.
 >
-> This was reverted in 1.5.0 for Windows and macOS. We heavily recommend not using these locations on Windows and macOS
-> anymore, due to multiple incompatibilities discovered with these locations, documented
-> [here](troubleshoot.md#why-are-spaces-in-the-pipx_home-path-bad).
+> This was originally introduced in 1.2.0 and temporarily reverted between 1.5.0 and 1.16.0 for Windows and macOS.
 
 ### Customising your installation
 

--- a/docs/how-to/move-installation.md
+++ b/docs/how-to/move-installation.md
@@ -6,16 +6,16 @@ non-default location to the current default locations. If you wish to move to a 
 
 ### MacOS
 
-Current default location: `~/.local`
+Current default location: `~/Library/Application Support/pipx`
 
 ```bash
-NEW_LOCATION=~/.local
 cache_dir=$(pipx environment --value PIPX_VENV_CACHEDIR)
 logs_dir=$(pipx environment --value PIPX_LOG_DIR)
 trash_dir=$(pipx environment --value PIPX_TRASH_DIR)
 home_dir=$(pipx environment --value PIPX_HOME)
+NEW_LOCATION='~/Library/Application Support/pipx'
 rm -rf "$cache_dir" "$logs_dir" "$trash_dir"
-mkdir -p $NEW_LOCATION && mv "$home_dir" $NEW_LOCATION
+mkdir -p "$NEW_LOCATION" && mv "$home_dir" "$NEW_LOCATION"
 pipx reinstall-all
 ```
 
@@ -32,7 +32,7 @@ home_dir=$(pipx environment --value PIPX_HOME)
 # and set `NEW_LOCATION` explicitly
 NEW_LOCATION="${XDG_DATA_HOME:-$HOME/.local/share}"
 rm -rf "$cache_dir" "$logs_dir" "$trash_dir"
-mkdir -p $NEW_LOCATION && mv "$home_dir" $NEW_LOCATION
+mkdir -p "$NEW_LOCATION" && mv "$home_dir" "$NEW_LOCATION"
 pipx reinstall-all
 ```
 

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -161,18 +161,6 @@ sudo apt install python3-venv python3-pip
 Reference:
 [Python Packaging User Guide: Installing pip/setuptools/wheel with Linux Package Managers](https://packaging.python.org/guides/installing-using-linux-tools)
 
-## macOS issues
-
-If you want to use a pipx-installed package in a shebang (a common example is the AWS CLI), you will likely not be able
-to, because the binary will be stored under `~/Library/Application Support/pipx/`. The space in the path is not
-supported in a shebang. A simple solution is symlinking `~/Library/Application Support/pipx` to
-`~/Library/ApplicationSupport/pipx`, and using that as the path in the shebang instead.
-
-```
-mkdir $HOME/Library/ApplicationSupport
-ln -s $HOME/Library/Application\ Support/pipx $HOME/Library/ApplicationSupport/pipx
-```
-
 ## Does it work to install your package with `pip`?
 
 This is a tip for advanced users. An easy way to check if pipx is the problem or a package you're trying to install is
@@ -203,48 +191,15 @@ rm -rf test_venv
 
 ## pipx files not in expected locations according to documentation
 
-pipx versions after 1.2.0 adopt the XDG base directory specification for the location of `PIPX_HOME` and the data,
-cache, and log directories. Version 1.2.0 and earlier use `~/.local/pipx` as the default `PIPX_HOME` and install the
-data, cache, and log directories under it. To maintain compatibility with older versions, pipx will automatically use
-this old `PIPX_HOME` path if it exists. For a map of old and new paths, see [Installation Options](configure-paths.md).
+pipx versions after 1.16.0 adopt the XDG base directory specification for the location of `PIPX_HOME` and the data,
+cache, and log directories. Before, the default `PIPX_HOME` path was use `~/.local/pipx` (or `~/pipx` on Windows). To
+maintain compatibility with older versions, pipx will automatically use this old `PIPX_HOME` path if it exists. For a
+map of old and new paths, see [Installation Options](configure-paths.md).
 
-In pipx version 1.5.0, this was reverted for Windows and macOS. It defaults again to `~/.local/pipx` on macOS and to
-`~\pipx` on Windows.
-
-If you have a `pipx` version later than 1.2.0 and want to migrate from the old path to the new paths, you can move the
+If you have a `pipx` version later than 1.16.0 and want to migrate from the old path to the new paths, you can move the
 `~/.local/pipx` directory to the new location (after removing cache, log, and trash directories which will get recreated
 automatically) and then reinstall all packages.
 
 Please refer to [Moving your pipx installation](move-installation.md) on how to move it.
 
-## Warning: Found a space in the pipx home path
-
-In pipx version 1.5, we introduced the warning you're seeing, as multiple incompatibilities with spaces in the pipx home
-path were discovered. You may see this for the following reasons:
-
-1. From pipx version 1.3 to 1.5, we were by default using a path with a space on it on macOS. This unfortunately means
-    that all users who installed pipx in this time frame and were using the default behavior are seeing this warning
-    now.
-1. You set your `PIPX_HOME` to a path with spaces in it explicitly or because your `$HOME` path contains a space.
-
-### Why are spaces in the `PIPX_HOME` path bad
-
-The main reason we can't support paths with spaces is that shebangs don't support spaces in the interpreter path. All
-applications installed via `pipx` are installed via `pip`, which creates a script with a shebang at the top, defining
-the interpreter of the `venv` to use.
-
-`pip` does some magic to the shebang for scripts defined as a `script`, that resolves this issue. Unfortunately, many
-libraries define their scripts as `console_scripts`, where `pip` does not perform this logic. Therefore, these scripts
-cannot be run if installed with `pipx` in a path with spaces because the path to the `venv` (and therefore the
-interpreter) will contain spaces.
-
-If you want to use a script installed via pipx in a shebang itself (common for example for the AWS CLI), you run into a
-similar problem, as the path to the installed script will contain a space.
-
-### How to fix
-
-You can generally fix this by using our default locations, as long as your `$HOME` path does not contain spaces. Please
-refer to our [Moving your pipx installation](move-installation.md) docs on how to move the `pipx` installation.
-
-If you're really sure you want to stick to your path with spaces, to suppress the warning set the
-`PIPX_HOME_ALLOW_SPACE` environment variable to `true`.
+Standard paths were introduced in pipx versions 1.2.0, and reverted between 1.5.0, and 1.16.0 for Windows and macOS.

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -161,6 +161,15 @@ sudo apt install python3-venv python3-pip
 Reference:
 [Python Packaging User Guide: Installing pip/setuptools/wheel with Linux Package Managers](https://packaging.python.org/guides/installing-using-linux-tools)
 
+## Naming a pipx application in your own shebang
+
+The default pipx home on macOS is `~/Library/Application Support/pipx`, which contains a space. Applications installed
+there run, because `pip` and `uv` write a `/bin/sh` wrapper as the shebang whenever the interpreter path holds a space.
+
+A shebang you write yourself has no such wrapper. `#!/Users/you/.local/bin/aws` works, while a shebang that names a path
+with a space in it does not, because the kernel reads the first space as the end of the interpreter path. Point your
+shebang at `PIPX_BIN_DIR` (`~/.local/bin` by default, which has no space), or set `PIPX_HOME` to a path without spaces.
+
 ## Does it work to install your package with `pip`?
 
 This is a tip for advanced users. An easy way to check if pipx is the problem or a package you're trying to install is
@@ -191,15 +200,15 @@ rm -rf test_venv
 
 ## pipx files not in expected locations according to documentation
 
-pipx versions after 1.16.0 adopt the XDG base directory specification for the location of `PIPX_HOME` and the data,
-cache, and log directories. Before, the default `PIPX_HOME` path was use `~/.local/pipx` (or `~/pipx` on Windows). To
-maintain compatibility with older versions, pipx will automatically use this old `PIPX_HOME` path if it exists. For a
-map of old and new paths, see [Installation Options](configure-paths.md).
+pipx versions after 1.16.0 place `PIPX_HOME` and the data, cache and log directories in the platform locations that
+[platformdirs](https://pypi.org/project/platformdirs/) reports. Earlier versions defaulted `PIPX_HOME` to
+`~/.local/pipx`, or to `~/pipx` on Windows. pipx picks up such a directory when it exists, so an installation from an
+earlier release keeps working. For a map of old and new paths, see [Installation Options](configure-paths.md).
 
-If you have a `pipx` version later than 1.16.0 and want to migrate from the old path to the new paths, you can move the
-`~/.local/pipx` directory to the new location (after removing cache, log, and trash directories which will get recreated
-automatically) and then reinstall all packages.
+The venv cache and the logs move to the platform cache and log directories even when pipx falls back to an older home,
+because both are disposable and pipx recreates them. Setting `PIPX_HOME` yourself keeps them inside it.
 
+To migrate an older installation, move the `~/.local/pipx` directory to the new location and reinstall your packages.
 Please refer to [Moving your pipx installation](move-installation.md) on how to move it.
 
-Standard paths were introduced in pipx versions 1.2.0, and reverted between 1.5.0, and 1.16.0 for Windows and macOS.
+pipx adopted these paths in 1.2.0 and reverted them for macOS and Windows between 1.5.0 and 1.16.0.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -16,7 +16,6 @@ pipx reads the following environment variables. All are optional.
 | `PIPX_FETCH_PYTHON`                     | When to fetch a standalone Python build: `always`, `missing`, or `never`. | `never`                                                                    |
 | `PIPX_FETCH_MISSING_PYTHON`             | Deprecated, alias for `PIPX_FETCH_PYTHON=missing`.                        | _(unset)_                                                                  |
 | `PIPX_DISABLE_SHARED_LIBS_AUTO_UPGRADE` | Set to `1` to skip automatic shared library upgrades.                     | _(unset)_                                                                  |
-| `PIPX_HOME_ALLOW_SPACE`                 | Set to `true` to suppress the "space in PIPX_HOME" warning.               | _(unset)_                                                                  |
 | `PIPX_USE_EMOJI`                        | Set to `0` to disable emoji output.                                       | `1`                                                                        |
 | `PIPX_MAX_LOGS`                         | Maximum number of log files to keep in the logs directory.                | `10`                                                                       |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
   "colorama>=0.4.4; sys_platform=='win32'",
   "filelock>=3.16",
   "packaging>=20",
-  "platformdirs>=2.1",
+  "platformdirs>=4.6",
   "tomli; python_version<'3.11'",
   "userpath>=1.6,!=1.9",
 ]

--- a/src/pipx/commands/environment.py
+++ b/src/pipx/commands/environment.py
@@ -28,7 +28,6 @@ ENVIRONMENT_VARIABLES: Final = [
     "PIPX_FETCH_PYTHON",
     DISABLE_SHARED_LIBS_AUTO_UPGRADE,
     "PIPX_USE_EMOJI",
-    "PIPX_HOME_ALLOW_SPACE",
 ]
 DERIVED_ENVIRONMENT_VARIABLES: Final = [
     "PIPX_LOCAL_VENVS",
@@ -66,7 +65,6 @@ def _get_derived_values() -> dict[str, Callable[[], object]]:
         "UV_CACHE_DIR": lambda: os.environ.get("UV_CACHE_DIR", ""),
         DISABLE_SHARED_LIBS_AUTO_UPGRADE: lambda: str(shared_libs_auto_upgrade_disabled()).lower(),
         "PIPX_USE_EMOJI": lambda: str(EMOJI_SUPPORT).lower(),
-        "PIPX_HOME_ALLOW_SPACE": lambda: str(paths.ctx.allow_spaces_in_home_path).lower(),
     }
 
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -114,7 +114,6 @@ PIPX_DESCRIPTION += pipx_wrap(
       PIPX_DISABLE_SHARED_LIBS_AUTO_UPGRADE
                             Skips automatic shared library upgrades.
       PIPX_USE_EMOJI         Overrides emoji behavior. Default value varies based on platform.
-      PIPX_HOME_ALLOW_SPACE  Overrides default warning on spaces in the home path
     """,
     subsequent_indent=" " * 24,  # match the indent of argparse options
     keep_newlines=True,

--- a/src/pipx/paths.py
+++ b/src/pipx/paths.py
@@ -1,25 +1,18 @@
 import logging
-import os
 from functools import cached_property
 from pathlib import Path
 from typing import Final
 
 from platformdirs import user_cache_path, user_data_path, user_log_path
 
-from pipx.constants import LINUX, WINDOWS
-from pipx.emojis import hazard, strtobool
+from pipx.constants import WINDOWS
 from pipx.self_install import get_environment_value
 from pipx.wrap import pipx_wrap
 
-if LINUX:
-    DEFAULT_PIPX_HOME = Path(user_data_path("pipx"))
-    FALLBACK_PIPX_HOMES = [Path.home() / ".local/pipx"]
-elif WINDOWS:
-    DEFAULT_PIPX_HOME = Path.home() / "pipx"
-    FALLBACK_PIPX_HOMES = [Path.home() / ".local/pipx", Path(user_data_path("pipx"))]
-else:
-    DEFAULT_PIPX_HOME = Path.home() / ".local/pipx"
-    FALLBACK_PIPX_HOMES = [Path(user_data_path("pipx"))]
+DEFAULT_PIPX_HOME = Path(user_data_path("pipx"))
+FALLBACK_PIPX_HOMES = [Path.home() / ".local/pipx"]
+if WINDOWS:
+    FALLBACK_PIPX_HOMES += [Path.home() / "pipx"]
 
 DEFAULT_PIPX_BIN_DIR: Final[Path] = Path.home() / ".local/bin"
 DEFAULT_PIPX_MAN_DIR: Final[Path] = Path.home() / ".local/share/man"
@@ -67,7 +60,7 @@ class _PathContext:
 
     @property
     def logs(self) -> Path:
-        if self._home_exists or not LINUX:
+        if self._home_exists:
             return self.home / "logs"
         return self._default_log
 
@@ -79,7 +72,7 @@ class _PathContext:
 
     @property
     def venv_cache(self) -> Path:
-        if self._home_exists or not LINUX:
+        if self._home_exists:
             return self.home / ".cache"
         return self._default_cache
 
@@ -143,35 +136,7 @@ class _PathContext:
     def standalone_python_cachedir(self) -> Path:
         return self.home / "py"
 
-    @property
-    def allow_spaces_in_home_path(self) -> bool:
-        return strtobool(os.getenv("PIPX_HOME_ALLOW_SPACE", "0"))
-
     def log_warnings(self) -> None:
-        if " " in str(self.home) and not self.allow_spaces_in_home_path:
-            _LOGGER.warning(
-                pipx_wrap(
-                    (
-                        f"{hazard} Found a space in the pipx home path. We heavily discourage this, due to "
-                        "multiple incompatibilities. Please check our docs for more information on this, "
-                        "as well as some pointers on how to migrate to a different home path."
-                    ),
-                    subsequent_indent=" " * 4,
-                )
-            )
-            _LOGGER.warning(
-                pipx_wrap(
-                    (f"{hazard} To see your PIPX_HOME dir: pipx environment --value PIPX_HOME"),
-                    subsequent_indent=" " * 4,
-                )
-            )
-            _LOGGER.warning(
-                pipx_wrap(
-                    (f"{hazard} Most likely fix on macOS: mv ~/Library/Application\\ Support/pipx ~/.local/"),
-                    subsequent_indent=" " * 4,
-                )
-            )
-
         fallback_home_exists = self._fallback_home is not None and self._fallback_home.exists()
         specific_home_exists = self.home != self._fallback_home
         if fallback_home_exists and specific_home_exists:

--- a/src/pipx/paths.py
+++ b/src/pipx/paths.py
@@ -60,21 +60,20 @@ class _PathContext:
 
     @property
     def logs(self) -> Path:
-        if self._home_exists:
-            return self.home / "logs"
-        return self._default_log
-
-    @property
-    def trash(self) -> Path:
-        if self._home_exists:
-            return self.home / ".trash"
-        return self._default_trash
+        # a legacy home keeps holding the venvs, yet its logs and cache belong in the platform locations, so only an
+        # explicit PIPX_HOME pulls them back under the home
+        return self.home / "logs" if self._base_home else self._default_log
 
     @property
     def venv_cache(self) -> Path:
+        return self.home / ".cache" if self._base_home else self._default_cache
+
+    @property
+    def trash(self) -> Path:
+        # renaming into the trash has to stay on one filesystem, so it follows the venvs under the home
         if self._home_exists:
-            return self.home / ".cache"
-        return self._default_cache
+            return self.home / ".trash"
+        return self._default_trash
 
     @cached_property
     def bin_dir(self) -> Path:

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -67,7 +67,6 @@ def test_cli_with_args(monkeypatch, capsys):
     assert not run_pipx_cli(["environment", "--value", "PIPX_DEFAULT_PYTHON"])
     assert not run_pipx_cli(["environment", "--value", "PIPX_DISABLE_SHARED_LIBS_AUTO_UPGRADE"])
     assert not run_pipx_cli(["environment", "--value", "PIPX_USE_EMOJI"])
-    assert not run_pipx_cli(["environment", "--value", "PIPX_HOME_ALLOW_SPACE"])
 
     with pytest.raises(SystemExit) as excinfo:
         run_pipx_cli(["environment", "--value", "SSS"])
@@ -128,39 +127,6 @@ def test_resolve_empty_env_paths(monkeypatch: pytest.MonkeyPatch, env_name: str)
     assert get_expanded_environ(env_name) is None
 
 
-def test_allow_space_in_pipx_home(
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-    tmp_path: Path,
-) -> None:
-    home_dir = tmp_path / "path with space"
-    monkeypatch.setattr(paths.ctx, "_base_home", home_dir)
-    assert not run_pipx_cli(["environment", "--value", "PIPX_HOME_ALLOW_SPACE"])
-    captured = capsys.readouterr()
-    assert "Found a space" in captured.err
-    assert "false" in captured.out
-
-    monkeypatch.setenv("PIPX_HOME_ALLOW_SPACE", "1")
-    assert not run_pipx_cli(["environment", "--value", "PIPX_HOME_ALLOW_SPACE"])
-    captured = capsys.readouterr()
-    assert "Found a space" not in captured.err
-    assert "true" in captured.out
-
-    paths.ctx.make_local()
-
-
-def test_cli_space_warning_respects_quiet(
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-    tmp_path: Path,
-) -> None:
-    monkeypatch.setattr(paths.ctx, "_base_home", tmp_path / "path with space")
-
-    assert not run_pipx_cli(["environment", "--value", "PIPX_HOME_ALLOW_SPACE", "--quiet"])
-
-    assert "Found a space" not in capsys.readouterr().err
-
-
 def test_cli_logs_fallback_home(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -174,20 +140,6 @@ def test_cli_logs_fallback_home(
     assert not run_pipx_cli(["environment", "--verbose"])
 
     assert "Both a specific pipx home folder" in capsys.readouterr().err
-
-
-@skip_if_windows
-def test_cli_global_warns_for_active_home(
-    pipx_temp_env: None,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-    tmp_path: Path,
-) -> None:
-    monkeypatch.setattr(paths, "OVERRIDE_PIPX_GLOBAL_HOME", tmp_path / "global home")
-
-    assert not run_pipx_cli(["environment", "--global"])
-
-    assert "Found a space" in capsys.readouterr().err
 
 
 @skip_if_windows

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Final
 
 import pytest
+from platformdirs import user_cache_path, user_log_path
 from pytest_mock import MockerFixture
 
 from helpers import skip_if_windows
@@ -47,5 +48,85 @@ def test_context_preserves_home_symlink(
         paths.ctx.make_local()
 
         assert (paths.ctx.home, paths.ctx.venvs) == (home, home / "venvs")
+
+    paths.ctx.make_local()
+
+
+def test_context_keeps_cache_and_logs_out_of_fallback_home(
+    pipx_temp_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fallback: Final[Path] = tmp_path / "legacy"
+    fallback.mkdir()
+    with monkeypatch.context() as scoped:
+        scoped.setattr(paths, "OVERRIDE_PIPX_HOME", None)
+        scoped.delenv("PIPX_HOME", raising=False)
+        scoped.setattr(paths, "FALLBACK_PIPX_HOMES", [fallback])
+        paths.ctx.make_local()
+
+        assert (paths.ctx.home, paths.ctx.venv_cache, paths.ctx.logs, paths.ctx.trash) == (
+            fallback,
+            Path(user_cache_path("pipx")),
+            Path(user_log_path("pipx")),
+            fallback / ".trash",
+        )
+
+    paths.ctx.make_local()
+
+
+def test_context_keeps_cache_and_logs_inside_explicit_home(
+    pipx_temp_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    home: Final[Path] = tmp_path / "home"
+    with monkeypatch.context() as scoped:
+        scoped.setattr(paths, "OVERRIDE_PIPX_HOME", None)
+        scoped.setenv("PIPX_HOME", str(home))
+        paths.ctx.make_local()
+
+        assert (paths.ctx.venv_cache, paths.ctx.logs) == (home / ".cache", home / "logs")
+
+    paths.ctx.make_local()
+
+
+def test_context_uses_platform_dirs_without_any_home(
+    pipx_temp_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    default: Final[Path] = tmp_path / "default"
+    with monkeypatch.context() as scoped:
+        scoped.setattr(paths, "OVERRIDE_PIPX_HOME", None)
+        scoped.delenv("PIPX_HOME", raising=False)
+        scoped.setattr(paths, "FALLBACK_PIPX_HOMES", [tmp_path / "absent"])
+        scoped.setattr(paths, "DEFAULT_PIPX_HOME", default)
+        paths.ctx.make_local()
+
+        assert (paths.ctx.home, paths.ctx.venv_cache, paths.ctx.logs) == (
+            default,
+            Path(user_cache_path("pipx")),
+            Path(user_log_path("pipx")),
+        )
+
+    paths.ctx.make_local()
+
+
+@skip_if_windows
+def test_context_honors_xdg_cache_home(
+    pipx_temp_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    cache: Final[Path] = tmp_path / "xdg-cache"
+    with monkeypatch.context() as scoped:
+        scoped.setattr(paths, "OVERRIDE_PIPX_HOME", None)
+        scoped.delenv("PIPX_HOME", raising=False)
+        scoped.setattr(paths, "FALLBACK_PIPX_HOMES", [tmp_path / "absent"])
+        scoped.setenv("XDG_CACHE_HOME", str(cache))
+        paths.ctx.make_local()
+
+        assert paths.ctx.venv_cache == cache / "pipx"
 
     paths.ctx.make_local()


### PR DESCRIPTION
pipx moved to the platform directories in 1.2.0 and reverted that for macOS and Windows in 1.5.0, because a home such as `~/Library/Application Support/pipx` holds a space and the shebang of an installed application could not carry one. [Issue #1946](https://github.com/pypa/pipx/issues/1946) asks for those locations back. Both `pip` and `uv` now write a `/bin/sh` wrapper as the shebang whenever the interpreter path holds a space, and an application installed under such a path runs, so the reason for the revert is gone. 📁

Reverting [9679124](https://github.com/pypa/pipx/commit/9679124635bc15a46a026974d10efe343c7549c4) restores the default home on its own, and it leaves the venv cache where #1946 reports it. `logs` and `venv_cache` fell back to the platform directories only when no pipx home existed at all, and a home from an older release counts, so anyone carrying `~/.local/pipx` kept reading `PIPX_VENV_CACHEDIR=~/.local/pipx/.cache`. Both now key off a `PIPX_HOME` that the user sets: an older home goes on holding the venvs for compatibility, while the cache and the logs sit in the platform locations, and setting `PIPX_HOME` still keeps everything inside it. The trash stays with the venvs, since moving a directory into it has to stay on one filesystem.

`platformdirs` reads `XDG_DATA_HOME` and `XDG_CACHE_HOME` on macOS as of 4.6, so the Apple locations apply on a machine that exports neither, and a user who exports one moves the matching pipx directory. This raises the floor to that release. Logs keep to `~/Library/Logs/pipx` on macOS, which `XDG_STATE_HOME` does not move. ✨

`PIPX_HOME_ALLOW_SPACE` and the warning about spaces in the home path go away with the problem they described. A shebang that a user writes gets no `/bin/sh` wrapper, so it still cannot name a path with a space in it, and the troubleshooting page now says so on its own rather than as a reason to avoid the default home.

Closes #1946
