### PR TITLE
✨ feat(list): select installed packages by name

### DIFF
--- a/changelog.d/640.feature.md
+++ b/changelog.d/640.feature.md
@@ -1,0 +1,1 @@
+Allow `pipx list` to select installed packages by name.

--- a/docs/reference/examples.md
+++ b/docs/reference/examples.md
@@ -158,6 +158,15 @@ black 18.9b0
 pipx 0.10.0
 ```
 
+Pass one or more installed package names to limit the output. The same selection also works with formats such as
+`--json`, `--short`, and `--outdated`.
+
+```shell
+> pipx list black
+> pipx list black pipx --short
+> pipx list black --outdated
+```
+
 ## `pipx install-all` example
 
 ```shell

--- a/src/pipx/commands/list_packages.py
+++ b/src/pipx/commands/list_packages.py
@@ -112,9 +112,12 @@ def list_packages(
     json_format: bool,
     short_format: bool,
     pinned_only: bool,
+    *,
+    venv_dirs: Collection[Path] | None = None,
 ) -> ExitCode:
     """Returns pipx exit code."""
-    venv_dirs: Collection[Path] = sorted(venv_container.iter_venv_dirs())
+    if venv_dirs is None:
+        venv_dirs = sorted(venv_container.iter_venv_dirs())
     if not venv_dirs:
         print(f"nothing has been installed with pipx {sleep}", file=sys.stderr)
 

--- a/src/pipx/commands/list_packages.py
+++ b/src/pipx/commands/list_packages.py
@@ -108,16 +108,13 @@ def list_pinned(venv_dirs: Iterable[Path], include_injected: bool) -> VenvProble
 
 def list_packages(
     venv_container: VenvContainer,
+    venv_dirs: Collection[Path],
     include_injected: bool,
     json_format: bool,
     short_format: bool,
     pinned_only: bool,
-    *,
-    venv_dirs: Collection[Path] | None = None,
 ) -> ExitCode:
     """Returns pipx exit code."""
-    if venv_dirs is None:
-        venv_dirs = sorted(venv_container.iter_venv_dirs())
     if not venv_dirs:
         print(f"nothing has been installed with pipx {sleep}", file=sys.stderr)
 

--- a/src/pipx/commands/outdated.py
+++ b/src/pipx/commands/outdated.py
@@ -24,9 +24,9 @@ _MAX_OUTDATED_WORKERS: Final[int] = 8
 
 def list_outdated(
     venv_container: VenvContainer,
+    venv_dirs: Collection[Path],
     *,
     include_injected: bool,
-    venv_dirs: Collection[Path] | None = None,
 ) -> OperationResult[OutdatedData]:
     data: Final[OutdatedData] = inspect_outdated(
         venv_container,

--- a/src/pipx/commands/outdated.py
+++ b/src/pipx/commands/outdated.py
@@ -26,8 +26,13 @@ def list_outdated(
     venv_container: VenvContainer,
     *,
     include_injected: bool,
+    venv_dirs: Collection[Path] | None = None,
 ) -> OperationResult[OutdatedData]:
-    data: Final[OutdatedData] = inspect_outdated(venv_container, include_injected=include_injected)
+    data: Final[OutdatedData] = inspect_outdated(
+        venv_container,
+        include_injected=include_injected,
+        venv_dirs=venv_dirs,
+    )
     messages: Final[list[OutputMessage]] = [
         OutputMessage(
             f"{failure.environment}: {failure.error}",
@@ -62,13 +67,18 @@ def inspect_outdated(
     skip: Collection[str] = (),
     backend: str | None = None,
     env_backend: str | None = None,
+    venv_dirs: Collection[Path] | None = None,
 ) -> OutdatedData:
-    venv_dirs: Final[tuple[Path, ...]] = tuple(
-        sorted(venv_dir for venv_dir in venv_container.iter_venv_dirs() if venv_dir.name not in skip)
+    selected_venv_dirs: Final[tuple[Path, ...]] = tuple(
+        sorted(
+            venv_dir
+            for venv_dir in (venv_container.iter_venv_dirs() if venv_dirs is None else venv_dirs)
+            if venv_dir.name not in skip
+        )
     )
     checks: Final[tuple[_EnvironmentOutdated, ...]] = _list_environments_outdated(
         venv_container,
-        venv_dirs,
+        selected_venv_dirs,
         include_injected=include_injected,
         upgradable_only=upgradable_only,
         pip_args=pip_args,

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -1154,7 +1154,11 @@ def _selected_venv_dirs(args: argparse.Namespace, ctx: DispatchContext) -> tuple
     return tuple(sorted(ctx.venv_container.iter_venv_dirs()))
 
 
-def _add_list(subparsers: argparse._SubParsersAction, shared_parser: argparse.ArgumentParser) -> None:
+def _add_list(
+    subparsers: argparse._SubParsersAction,
+    venv_completer: VenvCompleter,
+    shared_parser: argparse.ArgumentParser,
+) -> None:
     p = subparsers.add_parser(
         "list",
         help="List installed packages",
@@ -1175,14 +1179,28 @@ def _add_list(subparsers: argparse._SubParsersAction, shared_parser: argparse.Ar
         help="List pinned packages only. Pass --include-injected at the same time to list injected packages that were pinned.",
     )
     _add_output_option(p, legacy_json=True)
+    p.add_argument("packages", nargs="*", help="Installed packages to list").completer = venv_completer
     p.set_defaults(func=_cmd_list)
 
 
 def _cmd_list(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode | OperationResult[commands.OutdatedData]:
+    if args.packages:
+        selected_venv_dirs = _venv_dirs(args, ctx)
+        for package, venv_dir in selected_venv_dirs.items():
+            if not venv_dir.is_dir():
+                raise PipxError(f"venv for {package!r} was not found. Was {package!r} installed with pipx?")
+        venv_dirs = tuple(selected_venv_dirs.values())
+    else:
+        venv_dirs = tuple(sorted(ctx.venv_container.iter_venv_dirs()))
+
     if args.outdated:
         if args.short or args.pinned:
             raise PipxError("--outdated cannot be combined with --short or --pinned.")
-        return commands.list_outdated(ctx.venv_container, include_injected=args.include_injected)
+        return commands.list_outdated(
+            ctx.venv_container,
+            include_injected=args.include_injected,
+            venv_dirs=venv_dirs,
+        )
     output: Final[OutputFormat] = _output_format(args)
     if output is OutputFormat.JSON and (args.short or args.pinned):
         raise PipxError("--output json cannot be combined with --short or --pinned.")
@@ -1192,6 +1210,7 @@ def _cmd_list(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode | Oper
         output is OutputFormat.JSON,
         args.short,
         args.pinned,
+        venv_dirs=venv_dirs,
     )
 
 
@@ -1614,7 +1633,7 @@ def get_command_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Ar
     _add_reinstall_all(subparsers, shared_parser)
     _add_health(subparsers, completer_venvs.use, shared_parser)
     _add_repair(subparsers, completer_venvs.use, shared_parser)
-    _add_list(subparsers, shared_parser)
+    _add_list(subparsers, completer_venvs.use, shared_parser)
     subparsers_with_subcommands["interpreter"] = _add_interpreter(subparsers, shared_parser)
     subparsers_with_subcommands["cache"] = _add_cache(subparsers, shared_parser)
     _add_run(subparsers, shared_parser)

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -1150,7 +1150,8 @@ def _cmd_repair(args: argparse.Namespace, ctx: DispatchContext) -> OperationResu
 
 def _selected_venv_dirs(args: argparse.Namespace, ctx: DispatchContext) -> tuple[Path, ...]:
     if args.packages:
-        return tuple(_venv_dirs(args, ctx).values())
+        # spellings such as "black" and "Black" resolve to one venv, so drop the repeats
+        return tuple(dict.fromkeys(_venv_dirs(args, ctx).values()))
     return tuple(sorted(ctx.venv_container.iter_venv_dirs()))
 
 
@@ -1184,34 +1185,31 @@ def _add_list(
 
 
 def _cmd_list(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode | OperationResult[commands.OutdatedData]:
-    if args.packages:
-        selected_venv_dirs = _venv_dirs(args, ctx)
-        for package, venv_dir in selected_venv_dirs.items():
-            if not venv_dir.is_dir():
-                raise PipxError(f"venv for {package!r} was not found. Was {package!r} installed with pipx?")
-        venv_dirs = tuple(selected_venv_dirs.values())
-    else:
-        venv_dirs = tuple(sorted(ctx.venv_container.iter_venv_dirs()))
-
+    venv_dirs: Final[tuple[Path, ...]] = _installed_venv_dirs(args, ctx)
     if args.outdated:
         if args.short or args.pinned:
             raise PipxError("--outdated cannot be combined with --short or --pinned.")
-        return commands.list_outdated(
-            ctx.venv_container,
-            include_injected=args.include_injected,
-            venv_dirs=venv_dirs,
-        )
+        return commands.list_outdated(ctx.venv_container, venv_dirs, include_injected=args.include_injected)
     output: Final[OutputFormat] = _output_format(args)
     if output is OutputFormat.JSON and (args.short or args.pinned):
         raise PipxError("--output json cannot be combined with --short or --pinned.")
     return commands.list_packages(
         ctx.venv_container,
+        venv_dirs,
         args.include_injected,
         output is OutputFormat.JSON,
         args.short,
         args.pinned,
-        venv_dirs=venv_dirs,
     )
+
+
+def _installed_venv_dirs(args: argparse.Namespace, ctx: DispatchContext) -> tuple[Path, ...]:
+    venv_dirs: Final[tuple[Path, ...]] = _selected_venv_dirs(args, ctx)
+    for venv_dir in venv_dirs:
+        if not venv_dir.is_dir():
+            name = venv_dir.name
+            raise PipxError(f"venv for {name!r} was not found. Was {name!r} installed with pipx?")
+    return venv_dirs
 
 
 def _add_interpreter(

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -62,6 +62,13 @@ def test_health_json(installed_pycowsay: Path, capsys: CaptureFixture[str]) -> N
     }
 
 
+def test_health_deduplicates_repeated_package(installed_pycowsay: Path, capsys: CaptureFixture[str]) -> None:
+    assert run_pipx_cli(["health", "pycowsay", "PyCowSay", "--output", "json"]) == 0
+
+    environments = json.loads(capsys.readouterr().out)["data"]["environments"]
+    assert [environment["environment"] for environment in environments] == ["pycowsay"]
+
+
 def test_repair_json(pipx_temp_env: None, capsys: CaptureFixture[str]) -> None:
     assert run_pipx_cli(["repair", "--output", "json"]) == 0
 

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -192,6 +192,33 @@ def test_list_json_rejects_human_filter(
     assert "--output json cannot be combined with --short or --pinned" in capsys.readouterr().err
 
 
+def test_list_selected_packages(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert not run_pipx_cli(["install", PKG["pycowsay"]["spec"]])
+    assert not run_pipx_cli(["install", PKG["pylint"]["spec"]])
+    capsys.readouterr()
+
+    assert not run_pipx_cli(["list", "pycowsay"])
+    captured = capsys.readouterr()
+    assert "package pycowsay 0.0.0.2," in captured.out
+    assert "package pylint" not in captured.out
+
+    assert not run_pipx_cli(["list", "pylint", "--short"])
+    captured = capsys.readouterr()
+    assert captured.out == "pylint 3.0.4\n"
+
+    assert not run_pipx_cli(["list", "pycowsay", "pylint", "--json"])
+    captured = capsys.readouterr()
+    assert sorted(json.loads(captured.out)["venvs"]) == ["pycowsay", "pylint"]
+
+
+def test_list_rejects_missing_selected_package(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert run_pipx_cli(["list", "missing"])
+    assert capsys.readouterr().err.endswith("venv for 'missing' was not found. Was 'missing' installed with pipx?\n")
+
+
 def test_list_injected_apps_without_symlinks(
     pipx_temp_env: None,
     mocker: MockerFixture,

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -192,23 +192,68 @@ def test_list_json_rejects_human_filter(
     assert "--output json cannot be combined with --short or --pinned" in capsys.readouterr().err
 
 
-def test_list_selected_packages(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+def test_list_selected_package_text(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
     assert not run_pipx_cli(["install", PKG["pycowsay"]["spec"]])
     assert not run_pipx_cli(["install", PKG["pylint"]["spec"]])
     capsys.readouterr()
 
     assert not run_pipx_cli(["list", "pycowsay"])
-    captured = capsys.readouterr()
-    assert "package pycowsay 0.0.0.2," in captured.out
-    assert "package pylint" not in captured.out
 
-    assert not run_pipx_cli(["list", "pylint", "--short"])
     captured = capsys.readouterr()
-    assert captured.out == "pylint 3.0.4\n"
+    assert ("package pycowsay 0.0.0.2," in captured.out, "package pylint" in captured.out) == (True, False)
+
+
+def test_list_selected_packages_json(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert not run_pipx_cli(["install", PKG["pycowsay"]["spec"]])
+    assert not run_pipx_cli(["install", PKG["pylint"]["spec"]])
+    capsys.readouterr()
 
     assert not run_pipx_cli(["list", "pycowsay", "pylint", "--json"])
-    captured = capsys.readouterr()
-    assert sorted(json.loads(captured.out)["venvs"]) == ["pycowsay", "pylint"]
+
+    assert sorted(json.loads(capsys.readouterr().out)["venvs"]) == ["pycowsay", "pylint"]
+
+
+@pytest.mark.parametrize(
+    "packages",
+    [
+        pytest.param(["pylint"], id="single"),
+        pytest.param(["pylint", "pylint"], id="repeated"),
+        pytest.param(["pylint", "PyLint"], id="mixed-case"),
+        pytest.param(["pylint", "pylint==3.0.4"], id="with-specifier"),
+    ],
+)
+def test_list_selected_package_short(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    packages: list[str],
+) -> None:
+    assert not run_pipx_cli(["install", PKG["pycowsay"]["spec"]])
+    assert not run_pipx_cli(["install", PKG["pylint"]["spec"]])
+    capsys.readouterr()
+
+    assert not run_pipx_cli(["list", *packages, "--short"])
+
+    assert capsys.readouterr().out == "pylint 3.0.4\n"
+
+
+def test_list_selected_package_with_suffix(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert not run_pipx_cli(["install", PKG["pycowsay"]["spec"], "--suffix=@1"])
+    capsys.readouterr()
+
+    assert not run_pipx_cli(["list", "pycowsay@1", "--short"])
+
+    assert capsys.readouterr().out == "pycowsay 0.0.0.2\n"
+
+
+def test_list_selected_package_pinned(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert not run_pipx_cli(["install", PKG["pycowsay"]["spec"]])
+    assert not run_pipx_cli(["install", PKG["pylint"]["spec"]])
+    assert not run_pipx_cli(["pin", "pylint"])
+    capsys.readouterr()
+
+    assert not run_pipx_cli(["list", "pylint", "--pinned"])
+
+    assert capsys.readouterr().out == "pylint 3.0.4\n"
 
 
 def test_list_rejects_missing_selected_package(

--- a/tests/test_outdated.py
+++ b/tests/test_outdated.py
@@ -51,6 +51,26 @@ def test_list_outdated_backend(
     assert (captured.out, captured.err) == ("pipx found no available upgrades.\n", "")
 
 
+def test_list_outdated_selected_package(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    mocker: MockerFixture,
+) -> None:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    assert not run_pipx_cli(["install", "pylint"])
+    capsys.readouterr()
+    list_outdated = mocker.patch(
+        "pipx.backends.pip.run_subprocess",
+        autospec=True,
+        return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="[]", stderr=""),
+    )
+
+    assert not run_pipx_cli(["list", "pycowsay", "--outdated"])
+
+    captured = capsys.readouterr()
+    assert (captured.out, captured.err, list_outdated.call_count) == ("pipx found no available upgrades.\n", "", 1)
+
+
 def test_list_outdated_skips_removed_environment(
     pipx_temp_env: None,
     capsys: pytest.CaptureFixture[str],


### PR DESCRIPTION
`pipx list` prints every installed environment, so narrowing the output to one package means piping it through `grep`. [Issue #640](https://github.com/pypa/pipx/issues/640) asked for that selection to live in the command itself. `pipx list black` now limits the output to the environments you name, and the same selection applies to `--short`, `--output json`, `--pinned`, and `--outdated`. Naming an environment that pipx has not installed reports an error rather than printing an empty list. ✨

Selection runs through `_selected_venv_dirs`, the helper that `health` and `repair` already use, so `list` resolves a name the way those commands do. A name canonicalizes before lookup, and `--suffix` environments such as `black@1` resolve too. `list_packages` and `list_outdated` take the resolved venv directories as a required argument, which matches `health(venv_container, venv_dirs)`. `inspect_outdated` keeps its optional selection, because `upgrade-all` calls it across every environment.

That shared helper keyed its result by the string the user typed, so `black` and `Black` resolved to a single environment while the caller received it twice. `pipx list black Black` printed the package twice in text and `--short` output, and `pipx health black Black` checked the same environment twice. Deduplicating on the resolved path repairs `health` and `repair` alongside `list`. 🧹

One behavior worth a look during review: `list` raises on a name pipx has not installed, while `health` and `repair` continue to report an unmanaged name as data (`black: pipx does not manage this environment`). The two commands stay as they were.

Closes #640
