### PR TITLE
🐛 fix(tests): isolate local_extras builds from the shared checkout

### DIFF
--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -255,17 +255,16 @@ def test_inject_single_package(pipx_temp_env, capsys, caplog, pkg_spec):
 )
 def test_inject_main_package_extra(
     pipx_temp_env: None,
-    root: Path,
+    local_extras_project: Path,
     capsys: pytest.CaptureFixture[str],
     backend: str,
     suffix: str,
 ) -> None:
-    package = root / "testdata/test_package_specifier/local_extras"
-    assert not run_pipx_cli(["install", str(package), "--backend", backend, f"--suffix={suffix}"])
+    assert not run_pipx_cli(["install", str(local_extras_project), "--backend", backend, f"--suffix={suffix}"])
     venv_dir = paths.ctx.venvs / canonicalize_name(f"repeatme{suffix}")
     environment = PipxMetadata(venv_dir).environment
     assert environment is not None
-    assert not run_pipx_cli(["inject", environment, f"{package}[cow]", "--backend", backend])
+    assert not run_pipx_cli(["inject", environment, f"{local_extras_project}[cow]", "--backend", backend])
     assert not run_pipx_cli(["reinstall", environment])
 
     output = subprocess.run(

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -545,10 +545,8 @@ def test_install_upgrade_records_expected_app_without_package_change(
     assert PipxMetadata(paths.ctx.venvs / "pycowsay").main_package.expected_apps == ["pycowsay"]
 
 
-def test_install_accepts_expected_dependency_app(pipx_temp_env: None, root: Path) -> None:
-    package = f"{root / TEST_DATA_PATH / 'local_extras'}[cow]"
-
-    assert not run_pipx_cli(["install", "--include-deps", "--app", "pycowsay", package])
+def test_install_accepts_expected_dependency_app(pipx_temp_env: None, local_extras_project: Path) -> None:
+    assert not run_pipx_cli(["install", "--include-deps", "--app", "pycowsay", f"{local_extras_project}[cow]"])
 
     assert PipxMetadata(paths.ctx.venvs / "repeatme").main_package.expected_apps == ["pycowsay"]
 
@@ -859,8 +857,12 @@ def test_extra(pipx_temp_env, capsys):
     assert f"- {app_name('tox')}\n" in captured.out
 
 
-def test_install_local_extra(pipx_temp_env, capsys, monkeypatch, root):
-    assert not run_pipx_cli(["install", str(root / f"{TEST_DATA_PATH}/local_extras[cow]"), "--include-deps"])
+def test_install_local_extra(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    local_extras_project: Path,
+) -> None:
+    assert not run_pipx_cli(["install", f"{local_extras_project}[cow]", "--include-deps"])
     captured = capsys.readouterr()
     assert f"- {app_name('pycowsay')}\n" in captured.out
     assert f"- {Path('man6/pycowsay.6')}\n" in captured.out
@@ -1086,8 +1088,13 @@ def test_install_pip_failure(pipx_temp_env, capsys):
     assert re.search(r"pip (failed|seemed to fail) to build package", captured.err)
 
 
-def test_install_local_archive(pipx_temp_env, monkeypatch, capsys, root):
-    monkeypatch.chdir(root / TEST_DATA_PATH / "local_extras")
+def test_install_local_archive(
+    pipx_temp_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    local_extras_project: Path,
+) -> None:
+    monkeypatch.chdir(local_extras_project)
 
     subprocess.run([sys.executable, "-m", "pip", "wheel", "."], check=True)
     assert not run_pipx_cli(["install", "repeatme-0.1-py3-none-any.whl"])

--- a/tests/test_pin.py
+++ b/tests/test_pin.py
@@ -17,12 +17,11 @@ def test_pin(pipx_temp_env: None, caplog: pytest.LogCaptureFixture) -> None:
     assert "Not upgrading pinned package pycowsay" in caplog.text
 
 
-def test_pin_survives_main_package_extra_injection(pipx_temp_env: None, root: Path) -> None:
-    package = root / "testdata/test_package_specifier/local_extras"
-    assert not run_pipx_cli(["install", str(package)])
+def test_pin_survives_main_package_extra_injection(pipx_temp_env: None, local_extras_project: Path) -> None:
+    assert not run_pipx_cli(["install", str(local_extras_project)])
     assert not run_pipx_cli(["pin", "repeatme"])
 
-    assert not run_pipx_cli(["inject", "repeatme", f"{package}[cow]"])
+    assert not run_pipx_cli(["inject", "repeatme", f"{local_extras_project}[cow]"])
 
     assert PipxMetadata(paths.ctx.venvs / "repeatme").main_package.pinned
 

--- a/tests/test_uninject.py
+++ b/tests/test_uninject.py
@@ -246,21 +246,24 @@ def test_uninject_running_app(pipx_temp_env: None) -> None:
         process.wait(timeout=10)
 
 
-def test_uninject_with_suffix_removes_apps(pipx_temp_env: None, root: Path, tmp_path: Path) -> None:
+def test_uninject_with_suffix_removes_apps(
+    pipx_temp_env: None,
+    root: Path,
+    tmp_path: Path,
+    local_extras_project: Path,
+) -> None:
     suffix = "@1"
-    ignore_generated = shutil.ignore_patterns("build", "*.egg-info")
-    project = shutil.copytree(root / "testdata/empty_project", tmp_path / "empty_project", ignore=ignore_generated)
-    assert not run_pipx_cli(["install", str(project), f"--suffix={suffix}"])
-    injected_project = shutil.copytree(
-        root / "testdata/test_package_specifier/local_extras",
-        tmp_path / "local_extras",
-        ignore=ignore_generated,
+    project = shutil.copytree(
+        root / "testdata/empty_project",
+        tmp_path / "empty_project",
+        ignore=shutil.ignore_patterns("build", "*.egg-info"),
     )
+    assert not run_pipx_cli(["install", str(project), f"--suffix={suffix}"])
     assert not run_pipx_cli(
         [
             "inject",
             f"empty-project{suffix}",
-            f"{injected_project}[cow]",
+            f"{local_extras_project}[cow]",
             "--include-deps",
             "--with-suffix",
         ]


### PR DESCRIPTION
Several tests install `testdata/test_package_specifier/local_extras` straight from the shared source tree, so `setuptools` writes `build/` and `repeatme.egg-info` into the checkout. Those tests sit in different files, so `--dist loadfile` hands them to different `xdist` workers, which build the same tree at the same time and collide on the same paths:

```
error: [Errno 17] File exists: 'build/bdist.linux-x86_64/wheel/repeatme-0.1.dist-info'
ERROR: Failed building wheel for repeatme
error: failed-wheel-build-for-install
```

`test_install_local_archive` runs `pip wheel .` inside the checkout and leaves the wheel next to the sources. Git ignores all of these paths, so the shared state does not show up in `git status`. 🧹

Which test loses the race depends on how the workers interleave, so one bug reads as a series of unrelated flakes. It failed `test_install_local_extra` on #1945 and `test_pin_survives_main_package_extra_injection` on #1943.

The `local_extras_project` fixture already copies the project into `tmp_path` and drops build output, and this routes the remaining call sites through it so each test builds its own tree. ✨ `test_uninject_with_suffix_removes_apps` carried a second copy of that same logic and now takes the fixture too.

One thing worth a look during review: `test_install_local_archive` still runs `pip wheel .`, now against the copy under `tmp_path` instead of the checkout.
