### PR TITLE
✨ feat(install): show the installer download progress bar

### DIFF
--- a/changelog.d/1069.bugfix.md
+++ b/changelog.d/1069.bugfix.md
@@ -1,0 +1,2 @@
+Draw the installer progress bar while the download runs. pipx reads the installer output over a pipe, which hid the
+terminal from `pip`, so `pip` held its bar back and printed a finished one once the download had ended.

--- a/changelog.d/1069.feature.2.md
+++ b/changelog.d/1069.feature.2.md
@@ -1,0 +1,3 @@
+Draw the download progress bar of `pip` and `uv` during a plain `pipx install`, in place of the pipx spinner. pipx hands
+the installer a pseudo-terminal, which is the only way `uv` reports progress, and asks `uv` for its default output
+rather than the quiet one. A redirected stream keeps the previous behaviour.

--- a/src/pipx/backends/_base.py
+++ b/src/pipx/backends/_base.py
@@ -44,6 +44,7 @@ class Backend(ABC):
         upgrade: bool = False,
         log_pip_errors: bool = True,
         verbose: bool = False,
+        progress: bool = False,
     ) -> CompletedProcess[str]: ...
 
     def install_lock(
@@ -54,6 +55,7 @@ class Backend(ABC):
         lock_file: Path,
         pip_args: list[str],
         verbose: bool = False,
+        progress: bool = False,
     ) -> CompletedProcess[str]:
         return self.install(
             venv_root=venv_root,
@@ -61,6 +63,7 @@ class Backend(ABC):
             requirements=["--requirement", str(lock_file)],
             pip_args=pip_args,
             verbose=verbose,
+            progress=progress,
         )
 
     @staticmethod

--- a/src/pipx/backends/pip.py
+++ b/src/pipx/backends/pip.py
@@ -81,13 +81,14 @@ class PipBackend(Backend):
         upgrade: bool = False,
         log_pip_errors: bool = True,
         verbose: bool = False,
+        progress: bool = False,
     ) -> CompletedProcess[str]:
         cmd: list[str] = [str(venv_python), "-m", "pip", "--no-input", "install"]
         if upgrade:
             cmd.append("--upgrade")
         if no_deps:
             cmd.append("--no-dependencies")
-        if verbose:
+        if verbose or progress:
             cmd.append("--progress-bar=on")
         cmd += [*pip_args, *requirements]
         process = run_subprocess(
@@ -95,7 +96,7 @@ class PipBackend(Backend):
             log_stdout=not log_pip_errors,
             log_stderr=not log_pip_errors,
             run_dir=str(venv_root),
-            stream_output=verbose,
+            stream_output=verbose or progress,
         )
         if log_pip_errors:
             subprocess_post_check_handle_pip_error(process)

--- a/src/pipx/backends/uv.py
+++ b/src/pipx/backends/uv.py
@@ -99,8 +99,9 @@ class UvBackend(Backend):
         upgrade: bool = False,
         log_pip_errors: bool = True,
         verbose: bool = False,
+        progress: bool = False,
     ) -> CompletedProcess[str]:
-        cmd = self._uv_pip_command("install", venv_python, verbose=verbose)
+        cmd = self._uv_pip_command("install", venv_python, verbose=verbose, progress=progress)
         if upgrade:
             cmd.append("--upgrade")
         if no_deps:
@@ -112,7 +113,7 @@ class UvBackend(Backend):
             log_stdout=not log_pip_errors,
             log_stderr=not log_pip_errors,
             env_overrides=_UV_ENV_OVERRIDES,
-            stream_output=verbose,
+            stream_output=verbose or progress,
         )
         if log_pip_errors:
             subprocess_post_check_handle_pip_error(process, tool_name="uv")
@@ -195,9 +196,20 @@ class UvBackend(Backend):
             env_overrides=_UV_ENV_OVERRIDES,
         )
 
-    def _uv_pip_command(self, subcommand: str, venv_python: Path, *, verbose: bool) -> list[str | Path]:
+    def _uv_pip_command(
+        self,
+        subcommand: str,
+        venv_python: Path,
+        *,
+        verbose: bool,
+        progress: bool = False,
+    ) -> list[str | Path]:
         cmd: list[str | Path] = [self._binary, "pip", subcommand, "--python", str(venv_python)]
-        cmd.append("--verbose" if verbose else "--quiet")
+        # uv hides its progress bar under both --verbose and --quiet, so drawing one means passing neither
+        if verbose:
+            cmd.append("--verbose")
+        elif not progress:
+            cmd.append("--quiet")
         return cmd
 
 

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -1,4 +1,5 @@
 import codecs
+import errno
 import logging
 import os
 import random
@@ -9,12 +10,12 @@ import subprocess
 import sys
 from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import suppress
 from dataclasses import dataclass
 from itertools import chain
 from pathlib import Path
 from re import Pattern
 from typing import (
-    IO,
     Any,
     Final,
     NoReturn,
@@ -25,6 +26,12 @@ from pipx import paths
 from pipx.animate import show_cursor
 from pipx.constants import MINGW, WINDOWS
 from pipx.wrap import pipx_wrap
+
+if not WINDOWS:
+    import fcntl
+    import pty
+    import struct
+    import termios
 
 _LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 _SUBPROCESS_STREAM_READ_SIZE: Final[int] = 8 * 1024
@@ -206,9 +213,8 @@ def run_subprocess(
         env.setdefault("PYTHONSAFEPATH", "1")
 
     if stream_output:
-        # pip draws its progress bar through rich, which animates only while it believes it writes to a terminal. The
-        # pipe we read it over hides ours, so TTY_COMPATIBLE reports the terminal we forward the output to, and COLUMNS
-        # carries its width because rich cannot measure a pipe.
+        # Windows has no pseudo-terminal to hand the child, so it reads a pipe and rich, which pip draws its bar with,
+        # takes TTY_COMPATIBLE for the terminal we forward the output to and COLUMNS for a width it cannot measure.
         if sys.stdout.isatty():
             env.setdefault("TTY_COMPATIBLE", "1")
             env.setdefault("COLUMNS", str(shutil.get_terminal_size().columns))
@@ -250,26 +256,40 @@ def _run_streaming_subprocess(
 ) -> "subprocess.CompletedProcess[str]":
     stdout_chunks: Final[list[str]] = []
     stderr_chunks: Final[list[str]] = []
-    with (
-        subprocess.Popen(
-            cmd,
-            env=env,
-            stdout=subprocess.PIPE if capture_stdout else None,
-            stderr=subprocess.PIPE if capture_stderr else None,
-            cwd=cwd,
-        ) as process,
-        ThreadPoolExecutor(max_workers=2) as executor,
-    ):
-        for future in [
-            executor.submit(_tee_subprocess_output, source, destination, chunks)
-            for source, destination, chunks in (
-                (process.stdout, sys.stdout, stdout_chunks),
-                (process.stderr, sys.stderr, stderr_chunks),
-            )
-            if source is not None
-        ]:
-            future.result()
-        returncode: Final[int] = process.wait()
+    channels: Final[dict[str, _StreamChannel]] = {
+        name: _open_stream_channel(destination)
+        for name, destination, capture in (
+            ("stdout", sys.stdout, capture_stdout),
+            ("stderr", sys.stderr, capture_stderr),
+        )
+        if capture
+    }
+    try:
+        with (
+            subprocess.Popen(
+                cmd,
+                env=env,
+                stdout=channels["stdout"].child if capture_stdout else None,
+                stderr=channels["stderr"].child if capture_stderr else None,
+                cwd=cwd,
+            ) as process,
+            ThreadPoolExecutor(max_workers=2) as executor,
+        ):
+            for channel in channels.values():
+                channel.close_child()
+            for future in [
+                executor.submit(_tee_subprocess_output, channels[name].reader, destination, chunks)
+                for name, destination, chunks in (
+                    ("stdout", sys.stdout, stdout_chunks),
+                    ("stderr", sys.stderr, stderr_chunks),
+                )
+                if name in channels
+            ]:
+                future.result()
+            returncode: Final[int] = process.wait()
+    finally:
+        for channel in channels.values():
+            channel.close()
     return subprocess.CompletedProcess(
         cmd,
         returncode,
@@ -278,11 +298,55 @@ def _run_streaming_subprocess(
     )
 
 
-def _tee_subprocess_output(source: IO[bytes], destination: TextIO, chunks: list[str]) -> None:
+@dataclass
+class _StreamChannel:
+    reader: int
+    child: int
+
+    def close_child(self) -> None:
+        if self.child != -1:
+            os.close(self.child)
+            self.child = -1
+
+    def close(self) -> None:
+        self.close_child()
+        if self.reader != -1:
+            os.close(self.reader)
+            self.reader = -1
+
+
+def _open_stream_channel(destination: TextIO) -> _StreamChannel:
+    # pip and uv draw a progress bar only onto a terminal, and a pipe hides the one pipx forwards the output to, so
+    # hand the child a pseudo-terminal instead whenever the platform offers one
+    if not WINDOWS and destination.isatty():
+        reader, child = pty.openpty()
+        _match_terminal_size(child)
+        return _StreamChannel(reader, child)
+    reader, child = os.pipe()
+    return _StreamChannel(reader, child)
+
+
+def _match_terminal_size(child: int) -> None:
+    size: Final[os.terminal_size] = shutil.get_terminal_size()
+    with suppress(OSError):
+        fcntl.ioctl(child, termios.TIOCSWINSZ, struct.pack("HHHH", size.lines, size.columns, 0, 0))
+
+
+def _read_stream(source: int) -> bytes:
+    try:
+        return os.read(source, _SUBPROCESS_STREAM_READ_SIZE)
+    except OSError as error:
+        # a pseudo-terminal reports the departed child this way rather than as an end of file
+        if error.errno == errno.EIO:
+            return b""
+        raise
+
+
+def _tee_subprocess_output(source: int, destination: TextIO, chunks: list[str]) -> None:
     write_error: OSError | UnicodeError | None = None
     pending_carriage_return: bool = False
     for decoded in chain(
-        codecs.iterdecode(iter(lambda: os.read(source.fileno(), _SUBPROCESS_STREAM_READ_SIZE), b""), "utf-8"),
+        codecs.iterdecode(iter(lambda: _read_stream(source), b""), "utf-8"),
         (None,),
     ):
         if decoded is None:

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -206,6 +206,12 @@ def run_subprocess(
         env.setdefault("PYTHONSAFEPATH", "1")
 
     if stream_output:
+        # pip draws its progress bar through rich, which animates only while it believes it writes to a terminal. The
+        # pipe we read it over hides ours, so TTY_COMPATIBLE reports the terminal we forward the output to, and COLUMNS
+        # carries its width because rich cannot measure a pipe.
+        if sys.stdout.isatty():
+            env.setdefault("TTY_COMPATIBLE", "1")
+            env.setdefault("COLUMNS", str(shutil.get_terminal_size().columns))
         completed_process = _run_streaming_subprocess(
             cmd_str_list,
             capture_stdout=capture_stdout,

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 from packaging.utils import canonicalize_name
 from packaging.version import Version
 
-from pipx.animate import animate
+from pipx.animate import STDERR_IS_TTY, animate
 from pipx.backends import (
     Backend,
     OutdatedPackage,
@@ -160,7 +160,9 @@ class Venv:
         self.bin_path, self.python_path, self.man_path = get_venv_paths(self.root)
         self.pipx_metadata = PipxMetadata(venv_dir=path)
         self.verbose = verbose
-        self.do_animation = not verbose
+        # a terminal lets pip and uv draw their own download bar, which stands in for the spinner
+        self.show_progress = not verbose and STDERR_IS_TTY
+        self.do_animation = not verbose and not self.show_progress
         try:
             self._existing = self.root.exists() and bool(next(self.root.iterdir()))
         except StopIteration:
@@ -372,6 +374,7 @@ class Venv:
                         requirements=[install_spec],
                         pip_args=install_pip_args,
                         verbose=self.verbose,
+                        progress=self.show_progress,
                     )
                 if process.returncode:
                     raise PipxError(f"Error installing {full_package_description(package_name, package_or_url)}.")
@@ -418,6 +421,7 @@ class Venv:
                 lock_file=lock_file,
                 pip_args=[argument for argument in pip_args if argument != "--editable"],
                 verbose=self.verbose,
+                progress=self.show_progress,
             )
         if process.returncode:
             raise PipxError(f"Error installing packages from {lock_file}.")
@@ -431,6 +435,7 @@ class Venv:
                     pip_args=pip_args,
                     no_deps=True,
                     verbose=self.verbose,
+                    progress=self.show_progress,
                 )
             if process.returncode:
                 raise PipxError(f"Error installing {full_package_description(package_name, package_or_url)}.")
@@ -472,6 +477,7 @@ class Venv:
                 requirements=list(requirements),
                 pip_args=self._with_cooldown(pip_args, cooldown_days),
                 verbose=self.verbose,
+                progress=self.show_progress,
             )
         if process.returncode:
             raise PipxError(f"Error installing {', '.join(requirements)}.")
@@ -492,6 +498,7 @@ class Venv:
                 no_deps=True,
                 log_pip_errors=False,
                 verbose=self.verbose,
+                progress=self.show_progress,
             )
         if process.returncode:
             error_output = (process.stderr or process.stdout or "").strip()
@@ -682,6 +689,7 @@ class Venv:
                 upgrade=True,
                 log_pip_errors=False,
                 verbose=self.verbose,
+                progress=self.show_progress,
             )
         subprocess_post_check(process)
 
@@ -710,6 +718,7 @@ class Venv:
                     upgrade=True,
                     log_pip_errors=False,
                     verbose=self.verbose,
+                    progress=self.show_progress,
                 )
         subprocess_post_check(process)
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -254,6 +254,57 @@ def test_backend_verbose_install_streams_output(backend_name: str, tmp_path: Pat
 
 
 @pytest.mark.parametrize(
+    ("backend_name", "progress", "flags", "streams"),
+    [
+        pytest.param(PIP, True, ["--progress-bar=on"], True, id="pip-progress"),
+        pytest.param(PIP, False, [], False, id="pip-plain"),
+        # uv hides its bar under --verbose and under --quiet, so progress mode passes neither
+        pytest.param(UV, True, [], True, id="uv-progress"),
+        pytest.param(UV, False, ["--quiet"], False, id="uv-plain"),
+    ],
+)
+def test_backend_install_draws_progress_without_verbose(
+    backend_name: str,
+    progress: bool,
+    flags: list[str],
+    streams: bool,
+    tmp_path: Path,
+    mocker: MockerFixture,
+) -> None:
+    binary: Final[Path] = tmp_path / "uv"
+    mocker.patch("pipx.backends.uv.resolve_uv_binary", return_value=binary)
+    mocker.patch("pipx.backends.uv.find_uv_binary", return_value=(binary, "path"))
+    mocker.patch(
+        "pipx.backends.uv.subprocess.run",
+        return_value=subprocess.CompletedProcess([str(binary), "--version"], 0, stdout="uv 0.11.28", stderr=""),
+    )
+    run_subprocess: Final[MagicMock] = mocker.patch(
+        f"pipx.backends.{backend_name}.run_subprocess",
+        autospec=True,
+        return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+    )
+    venv_python: Final[Path] = tmp_path / "bin" / "python"
+
+    (UvBackend() if backend_name == UV else PipBackend()).install(
+        venv_root=tmp_path,
+        venv_python=venv_python,
+        requirements=["demo"],
+        pip_args=[],
+        progress=progress,
+    )
+
+    expected_command: Final[list[str | Path]] = (
+        [str(venv_python), "-m", "pip", "--no-input", "install", *flags, "demo"]
+        if backend_name == PIP
+        else [binary, "pip", "install", "--python", str(venv_python), *flags, "demo"]
+    )
+    assert (run_subprocess.call_args.args[0], run_subprocess.call_args.kwargs["stream_output"]) == (
+        expected_command,
+        streams,
+    )
+
+
+@pytest.mark.parametrize(
     ("pip_args", "expected"),
     [
         pytest.param([], [], id="empty"),

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import sys
 from io import BytesIO, StringIO, TextIOWrapper
 from pathlib import Path
@@ -150,6 +151,35 @@ def test_subprocess_streams_and_captures_output(capsys: pytest.CaptureFixture[st
         "stdøut 1\rstdøut 2\r",
         "stdërr 1\rstdërr 2\n",
     )
+
+
+@pytest.mark.parametrize(
+    ("stdout_is_a_terminal", "expected"),
+    [
+        pytest.param(True, "1 120", id="terminal"),
+        pytest.param(False, "unset unset", id="pipe"),
+    ],
+)
+def test_subprocess_stream_reports_the_terminal_to_the_child(
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    stdout_is_a_terminal: bool,
+    expected: str,
+) -> None:
+    monkeypatch.delenv("TTY_COMPATIBLE", raising=False)
+    monkeypatch.delenv("COLUMNS", raising=False)
+    mocker.patch("pipx.util.sys.stdout.isatty", return_value=stdout_is_a_terminal)
+    mocker.patch("pipx.util.shutil.get_terminal_size", return_value=os.terminal_size((120, 40)))
+    result: Final[subprocess.CompletedProcess[str]] = run_subprocess(
+        [
+            sys.executable,
+            "-c",
+            "import os; print(os.environ.get('TTY_COMPATIBLE', 'unset'), os.environ.get('COLUMNS', 'unset'))",
+        ],
+        stream_output=True,
+    )
+
+    assert result.stdout.strip() == expected
 
 
 def test_subprocess_stream_normalizes_split_crlf(mocker: MockerFixture) -> None:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Final
 
 import pytest
 
+from helpers import skip_if_windows
 from pipx import paths
 from pipx.util import exec_app, rmdir, run_subprocess, safe_unlink
 
@@ -180,6 +181,32 @@ def test_subprocess_stream_reports_the_terminal_to_the_child(
     )
 
     assert result.stdout.strip() == expected
+
+
+@skip_if_windows
+def test_subprocess_stream_hands_a_terminal_to_the_child(mocker: MockerFixture) -> None:
+    destination: Final[StringIO] = StringIO()
+    mocker.patch.object(destination, "isatty", return_value=True)
+    mocker.patch("pipx.util.sys.stdout", destination)
+    result: Final[subprocess.CompletedProcess[str]] = run_subprocess(
+        [sys.executable, "-c", "import sys; print(sys.stdout.isatty())"],
+        capture_stderr=False,
+        stream_output=True,
+    )
+
+    assert result.stdout.strip() == "True"
+
+
+def test_subprocess_stream_leaves_a_pipe_to_the_child_without_a_terminal(mocker: MockerFixture) -> None:
+    destination: Final[StringIO] = StringIO()
+    mocker.patch("pipx.util.sys.stdout", destination)
+    result: Final[subprocess.CompletedProcess[str]] = run_subprocess(
+        [sys.executable, "-c", "import sys; print(sys.stdout.isatty())"],
+        capture_stderr=False,
+        stream_output=True,
+    )
+
+    assert result.stdout.strip() == "False"
 
 
 def test_subprocess_stream_normalizes_split_crlf(mocker: MockerFixture) -> None:


### PR DESCRIPTION
`pip` and `uv` each draw a download bar, and pipx covered both with its own spinner, which is what [issue #1069](https://github.com/pypa/pipx/issues/1069) asks it to stop doing. A plain `pipx install` now streams the installer and lets that bar through, and the spinner it stands in for goes away. 📊

Two things stood between pipx and the bar. The first is the pipe: a child that writes to one sees no terminal and holds its bar back. `rich`, which `pip` draws with, accepts `TTY_COMPATIBLE` in place of a terminal, but `indicatif`, which `uv` draws with, calls `libc::isatty` and consults nothing else, so no environment variable reaches it. The streamed child therefore receives a pseudo-terminal on any platform that has one. Windows keeps the pipe along with the environment hint, which carries `pip` and leaves `uv` as it was.

The second is `uv` itself. It hides the bar under `--verbose`, [to keep it clear of the debug lines](https://github.com/astral-sh/uv/blob/main/crates/uv/src/printer.rs), and under `--quiet`, which pipx passed for every plain install, so `uv` drew a bar in neither mode. That places the bar in the default install rather than the verbose one: `pipx install` now asks `uv` for neither flag and hands `pip` a `--progress-bar=on`, while `pipx install --verbose` keeps the logs, where `uv` still holds its bar back by its own choice. ✨

A redirected stream, a pipe or a CI log gets the quiet install it has today, since the bar is drawn only into a terminal.

Driving pipx under a pseudo-terminal, `pip` reports `0.0/1.8 MB` climbing to `1.8/1.8 MB` with a rate and an eta, and `uv` reports `Downloading black (1.7MiB)`, `Downloaded black` and `Resolved 7 packages`. `uv` printed none of those lines before this, because `--quiet` suppresses each one.

Closes #1069
