### PR TITLE
✨ feat(reset): add pipx reset to start over from a fresh install

### DIFF
--- a/changelog.d/1606.feature.md
+++ b/changelog.d/1606.feature.md
@@ -1,0 +1,3 @@
+Add `pipx reset`, which uninstalls every pipx-managed package and removes the shared libraries, the caches, the
+standalone interpreters, the logs and the trash, so pipx starts over from a fresh install. It asks before it removes
+anything, `--force` answers for a script, and `--dry-run` lists what would go.

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -58,6 +58,25 @@ pipx uninstall <mypackage>
 pipx install <mypackage>
 ```
 
+## Start over from a fresh install
+
+An interrupted install or shared-library upgrade can leave state that `pipx repair` cannot mend, such as a shared
+environment whose pip no longer imports. Reset pipx to the state it had when you installed it:
+
+```
+pipx reset
+```
+
+It uninstalls every package it manages, which unlinks their apps and man pages, and it removes the shared libraries, the
+caches, the standalone interpreters, the logs and the trash. Because it asks first, `--force` answers the question for a
+script, and `--dry-run` lists what it would remove without touching anything.
+
+```
+pipx reset --dry-run
+```
+
+Reinstall your packages afterwards. `pipx list --short` before the reset records what you had.
+
 ## Inspect package details with `list`
 
 ```

--- a/docs/man/pipx.1.rst
+++ b/docs/man/pipx.1.rst
@@ -16,8 +16,9 @@ SYNOPSIS
 
 **pipx** [*global-options*] [**install** | **install-all** | **lock** | **sync** | **uninject** | **inject** |
 **expose** | **unexpose** | **pin** | **unpin** | **upgrade** | **upgrade-all** | **upgrade-shared** | **uninstall** |
-**uninstall-all** | **reinstall** | **reinstall-all** | **health** | **repair** | **list** | **interpreter** | **cache**
-| **run** | **exec** | **runpip** | **ensurepath** | **environment** | **completions** | **help**] [*command-options*]
+**uninstall-all** | **reset** | **reinstall** | **reinstall-all** | **health** | **repair** | **list** | **interpreter**
+| **cache** | **run** | **exec** | **runpip** | **ensurepath** | **environment** | **completions** | **help**]
+[*command-options*]
 
 DESCRIPTION
 -----------
@@ -72,6 +73,9 @@ COMMANDS
 
 **uninstall-all**
     Uninstall all packages
+
+**reset**
+    Return pipx to a fresh install
 
 **reinstall**
     Reinstall a package

--- a/src/pipx/commands/__init__.py
+++ b/src/pipx/commands/__init__.py
@@ -12,6 +12,7 @@ from pipx.commands.manifest import lock_manifest, sync_manifest
 from pipx.commands.outdated import OutdatedData, list_outdated
 from pipx.commands.pin import PinData, pin, unpin
 from pipx.commands.reinstall import reinstall, reinstall_all
+from pipx.commands.reset import ResetData, reset
 from pipx.commands.run import run
 from pipx.commands.run_pip import run_pip
 from pipx.commands.uninject import uninject
@@ -26,6 +27,7 @@ __all__ = [
     "OutdatedData",
     "PinData",
     "RepairData",
+    "ResetData",
     "UninstallData",
     "ensure_pipx_paths",
     "environment",
@@ -46,6 +48,7 @@ __all__ = [
     "reinstall",
     "reinstall_all",
     "repair",
+    "reset",
     "run",
     "run_pip",
     "sync_manifest",

--- a/src/pipx/commands/reset.py
+++ b/src/pipx/commands/reset.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Final
+
+from pipx import paths
+from pipx.commands.uninstall import UninstallData, uninstall_all
+from pipx.result import OperationData, OperationResult, OutputMessage, OutputStream
+from pipx.util import rmdir
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pipx.venv import VenvContainer
+
+
+@dataclass(frozen=True)
+class ResetData(OperationData):
+    packages: tuple[str, ...]
+    removed: tuple[str, ...]
+
+
+def reset(
+    venv_container: VenvContainer,
+    local_bin_dir: Path,
+    local_man_dir: Path,
+    verbose: bool,
+    *,
+    dry_run: bool = False,
+) -> OperationResult[ResetData]:
+    targets: Final[tuple[Path, ...]] = _reset_targets()
+    if dry_run:
+        return OperationResult(
+            command="reset",
+            data=ResetData(
+                packages=tuple(sorted(venv_dir.name for venv_dir in venv_container.iter_venv_dirs())),
+                removed=tuple(str(target) for target in targets),
+            ),
+            messages=tuple(OutputMessage(f"Would remove {target}", stream=OutputStream.STDOUT) for target in targets),
+        )
+
+    # uninstalling is what unlinks the apps and the man pages, which live outside the pipx home
+    uninstalled: Final[OperationResult[UninstallData]] = uninstall_all(
+        venv_container, local_bin_dir, local_man_dir, verbose
+    )
+    removed: Final[tuple[str, ...]] = tuple(str(target) for target in targets if _remove(target))
+    return OperationResult(
+        command="reset",
+        data=ResetData(
+            packages=tuple(package.environment for package in uninstalled.data.packages),
+            removed=removed,
+        ),
+        messages=(
+            *uninstalled.messages,
+            OutputMessage(f"pipx is back to a fresh install under {paths.ctx.home}.", stream=OutputStream.STDOUT),
+        ),
+        exit_code=uninstalled.exit_code,
+    )
+
+
+def _reset_targets() -> tuple[Path, ...]:
+    return tuple(
+        target
+        for target in (
+            paths.ctx.venvs,
+            paths.ctx.shared_libs,
+            paths.ctx.venv_cache,
+            paths.ctx.standalone_python_cachedir,
+            paths.ctx.logs,
+            paths.ctx.trash,
+        )
+        if target.is_dir()
+    )
+
+
+def _remove(target: Path) -> bool:
+    if target == paths.ctx.logs:
+        _clear_logs(target)
+        return True
+    rmdir(target, safe_rm=False)
+    return not target.is_dir()
+
+
+def _clear_logs(logs: Path) -> None:
+    # this very command logs into one of these files, and Windows refuses to unlink a file it holds open
+    for entry in logs.iterdir():
+        if entry == paths.ctx.log_file:
+            continue
+        if entry.is_dir():
+            rmdir(entry, safe_rm=False)
+        else:
+            with suppress(OSError):
+                entry.unlink()
+
+
+__all__ = [
+    "ResetData",
+    "reset",
+]

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -1020,6 +1020,41 @@ def _cmd_uninstall_all(args: argparse.Namespace, ctx: DispatchContext) -> Operat
     return commands.uninstall_all(ctx.venv_container, paths.ctx.bin_dir, paths.ctx.man_dir, ctx.verbose)
 
 
+def _add_reset(subparsers: argparse._SubParsersAction, shared_parser: argparse.ArgumentParser) -> None:
+    parser: Final[argparse.ArgumentParser] = subparsers.add_parser(
+        "reset",
+        help="Return pipx to a fresh install",
+        description=(
+            "Uninstall every pipx-managed package and remove the shared libraries, the caches, the standalone "
+            "interpreters, the logs and the trash, which returns pipx to the state it had when it was installed."
+        ),
+        parents=[shared_parser],
+    )
+    parser.add_argument("--force", action="store_true", help="Reset without asking for confirmation")
+    parser.add_argument("--dry-run", action="store_true", help="Report what a reset would remove and stop")
+    _add_output_option(parser)
+    parser.set_defaults(func=_cmd_reset)
+
+
+def _cmd_reset(args: argparse.Namespace, ctx: DispatchContext) -> OperationResult[commands.ResetData]:
+    if not args.dry_run and not args.force and not _confirmed_reset():
+        raise PipxError("Reset cancelled.")
+    return commands.reset(
+        ctx.venv_container,
+        paths.ctx.bin_dir,
+        paths.ctx.man_dir,
+        ctx.verbose,
+        dry_run=args.dry_run,
+    )
+
+
+def _confirmed_reset() -> bool:
+    if not sys.stdin or not sys.stdin.isatty():
+        raise PipxError("Pass --force to reset when no terminal can confirm it.")
+    answer: Final[str] = input(f"Remove every package pipx installed, along with {paths.ctx.home}? [y/N] ")
+    return answer.strip().casefold() in {"y", "yes"}
+
+
 def _add_reinstall(subparsers, venv_completer: VenvCompleter, shared_parser: argparse.ArgumentParser) -> None:
     p = subparsers.add_parser(
         "reinstall",
@@ -1627,6 +1662,7 @@ def get_command_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Ar
     _add_upgrade_shared(subparsers, shared_parser)
     _add_uninstall(subparsers, completer_venvs.use, shared_parser)
     _add_uninstall_all(subparsers, shared_parser)
+    _add_reset(subparsers, shared_parser)
     _add_reinstall(subparsers, completer_venvs.use, shared_parser)
     _add_reinstall_all(subparsers, shared_parser)
     _add_health(subparsers, completer_venvs.use, shared_parser)

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Final
+
+import pytest
+
+from helpers import app_name, run_pipx_cli
+from pipx import paths
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
+
+
+@pytest.fixture
+def installed_pycowsay(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    capsys.readouterr()
+
+
+def test_reset_removes_the_installed_packages(
+    installed_pycowsay: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert not run_pipx_cli(["reset", "--force"])
+    capsys.readouterr()
+
+    assert not run_pipx_cli(["list", "--short"])
+
+    assert capsys.readouterr().out == ""
+
+
+def test_reset_unlinks_the_apps(installed_pycowsay: None) -> None:
+    app: Final[Path] = paths.ctx.bin_dir / app_name("pycowsay")
+    assert app.exists() or app.is_symlink()
+
+    assert not run_pipx_cli(["reset", "--force"])
+
+    assert not app.exists() and not app.is_symlink()
+
+
+@pytest.mark.parametrize(
+    "location",
+    [
+        pytest.param("venvs", id="venvs"),
+        pytest.param("venv_cache", id="cache"),
+        pytest.param("standalone_python_cachedir", id="interpreters"),
+    ],
+)
+def test_reset_removes_the_pipx_state(installed_pycowsay: None, location: str) -> None:
+    target: Final[Path] = getattr(paths.ctx, location)
+    target.mkdir(parents=True, exist_ok=True)
+
+    assert not run_pipx_cli(["reset", "--force"])
+
+    assert not target.is_dir()
+
+
+def test_reset_keeps_the_log_it_writes(installed_pycowsay: None) -> None:
+    stale: Final[Path] = paths.ctx.logs / "cmd_stale.log"
+    stale.parent.mkdir(parents=True, exist_ok=True)
+    stale.touch()
+
+    assert not run_pipx_cli(["reset", "--force"])
+
+    assert list(paths.ctx.logs.iterdir()) == [paths.ctx.log_file]
+
+
+def test_reset_dry_run_keeps_everything(
+    installed_pycowsay: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert not run_pipx_cli(["reset", "--dry-run"])
+    assert f"Would remove {paths.ctx.venvs}" in capsys.readouterr().out
+
+    assert not run_pipx_cli(["list", "--short"])
+
+    assert capsys.readouterr().out == "pycowsay 0.0.0.2\n"
+
+
+def test_reset_json_reports_what_it_removed(
+    installed_pycowsay: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert not run_pipx_cli(["reset", "--force", "--output", "json"])
+
+    assert json.loads(capsys.readouterr().out) == {
+        "command": "reset",
+        "data": {
+            "packages": ["pycowsay"],
+            "removed": [
+                str(paths.ctx.venvs),
+                str(paths.ctx.shared_libs),
+                str(paths.ctx.venv_cache),
+                str(paths.ctx.standalone_python_cachedir),
+                str(paths.ctx.logs),
+            ],
+        },
+        "pipx_result_version": "0.1",
+        "status": "success",
+    }
+
+
+def test_reset_without_a_terminal_demands_force(
+    installed_pycowsay: None,
+    capsys: pytest.CaptureFixture[str],
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("pipx.main.sys.stdin.isatty", return_value=False)
+
+    assert run_pipx_cli(["reset"])
+
+    assert "Pass --force to reset" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("answer", "resets"),
+    [
+        pytest.param("y", True, id="y"),
+        pytest.param("Yes", True, id="yes"),
+        pytest.param("", False, id="empty"),
+        pytest.param("n", False, id="n"),
+    ],
+)
+def test_reset_asks_before_it_removes(
+    installed_pycowsay: None,
+    capsys: pytest.CaptureFixture[str],
+    mocker: MockerFixture,
+    answer: str,
+    resets: bool,
+) -> None:
+    mocker.patch("pipx.main.sys.stdin.isatty", return_value=True)
+    mocker.patch("pipx.main.input", return_value=answer)
+
+    assert bool(run_pipx_cli(["reset"])) is not resets
+
+    assert paths.ctx.venvs.is_dir() is not resets


### PR DESCRIPTION
An interrupted install or a shared upgrade that dies halfway can leave pipx in a state `pipx repair` cannot mend, the shared environment whose pip stops importing being the case [issue #1606](https://github.com/pypa/pipx/issues/1606) opens with. Recovering from that meant deleting the pipx directories by hand, and where those sit depends on the platform, so each user had to go and find them. 🧹

`pipx reset` uninstalls every package pipx manages and removes the shared libraries, the caches, the standalone interpreters, the logs and the trash, which leaves pipx as it stood the day you installed it. Uninstalling runs first and carries its weight: pipx links the apps and the man pages into the bin and man directories, which sit outside the pipx home, so removing the home on its own would leave those links behind pointing at nothing.

The command asks before it removes anything. `--force` answers for a script, `--dry-run` reports what would go and stops, and `--output json` hands the packages and the removed locations to a caller that wants to read them. ✨

One wrinkle shapes the code: pipx opens a log file for every command it runs, including this one, and Windows declines to unlink a file it still holds open. The logs directory therefore keeps the log of the reset itself and loses the rest.

`pipx cache purge` still clears the run cache on its own, for anyone who wants that and nothing more.

Closes #1606
