### PR TITLE
✨ feat(install): honour the Python a package requires

### DIFF
--- a/changelog.d/387.feature.md
+++ b/changelog.d/387.feature.md
@@ -1,0 +1,4 @@
+Honour the `requires-python` a package declares. When the default interpreter fails it, pipx looks for one on the system
+that satisfies it and builds the environment there, so `pipx install mytool` no longer needs the user to work out the
+right `--python`. Pass `--fetch-python=missing` to let pipx download a matching interpreter when the system carries
+none, and name `--python` yourself to keep the last word.

--- a/docs/how-to/standalone-python.md
+++ b/docs/how-to/standalone-python.md
@@ -5,6 +5,22 @@ pipx can install applications under a Python interpreter downloaded from
 this when the system Python is missing the version you asked for, or when the distro patched its Python in ways that
 break the application.
 
+### When a package rules out your default Python
+
+A package declares the interpreters it runs on through `requires-python`. When your default Python fails that
+declaration, pipx looks through the interpreters on your system, picks the newest one the package accepts, and builds
+the environment there. It reports the interpreter it settled on, and you need no `--python` for this.
+
+Nothing on the system may satisfy the package. pipx then names the constraint and stops, unless `--fetch-python=missing`
+lets it download an interpreter that fits:
+
+```
+pipx install --fetch-python=missing mytool
+```
+
+Naming `--python` yourself keeps the last word: pipx uses the interpreter you named, and it says so rather than
+overriding you when the package rejects it.
+
 ### Choosing when to download
 
 Set `--fetch-python` (or `PIPX_FETCH_PYTHON`) to one of three values:

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -22,11 +22,13 @@ from pipx.commands.transaction import preserve_venv
 from pipx.constants import (
     EXIT_CODE_OK,
     ExitCode,
+    FetchPythonOptions,
 )
 from pipx.emojis import sleep
 from pipx.interpreter import get_default_python
 from pipx.package_specifier import package_spec_satisfied
 from pipx.pipx_metadata_file import PackageInfo, PipxMetadata, load_spec_file
+from pipx.requires_python import IncompatiblePythonError, interpreter_for
 from pipx.result import (
     OperationData,
     OperationResult,
@@ -46,6 +48,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from filelock import BaseFileLock
+    from packaging.specifiers import SpecifierSet
 
 _PYLOCK_NAME_RE: Final[re.Pattern[str]] = re.compile(r"pylock(?:\.[^.]+)?\.toml")
 
@@ -78,6 +81,7 @@ def install(
     cooldown_days: int | None = None,
     venv_lock: BaseFileLock | None = None,
     preserve_existing: bool = False,
+    fetch_python: FetchPythonOptions = FetchPythonOptions.NEVER,
     replace_expected_apps: bool = False,
     replace_lock: bool = False,
     emit_output: bool = True,
@@ -100,7 +104,7 @@ def install(
     except PipxError as error:
         return _finish_install(_failed_install_result(package_specs[0], error), emit_output=emit_output)
 
-    package_names, resolution_failure = _resolve_package_names(
+    package_names, resolution_failure, python = _resolve_package_names(
         package_names,
         package_specs,
         python,
@@ -110,6 +114,9 @@ def install(
         backend=backend,
         env_backend=env_backend,
         cooldown_days=cooldown_days,
+        fetch_python=fetch_python,
+        python_flag_passed=python_flag_passed,
+        messages=messages,
     )
     if resolution_failure is not None:
         package_spec, resolution_error = resolution_failure
@@ -203,25 +210,32 @@ def install(
                             verbose=verbose,
                             backend=install_backend or recorded_backend,
                         )
-                    override_shared = canonicalize_name(package_name) == "pip"
-                    venv.create_venv(venv_args, pip_args, override_shared)
-                    venv.pipx_metadata.exposure_enabled = required_exposure
-                    venv.pipx_metadata.environment = venv.root.name
-                    for dependency in preinstall_packages or []:
-                        venv.upgrade_package_no_metadata(dependency, pip_args, cooldown_days=required_cooldown)
-                    venv.install_package(
-                        package_name=package_name,
-                        package_or_url=package_spec,
+                    build = _EnvironmentBuild(
+                        venv_args=venv_args,
                         pip_args=pip_args,
-                        install_only_pip_args=["--force-reinstall"] if force and exists else None,
+                        override_shared=canonicalize_name(package_name) == "pip",
+                        exposure_enabled=required_exposure,
+                        preinstall_packages=preinstall_packages,
+                        package_name=package_name,
+                        package_spec=package_spec,
+                        force_reinstall=force and exists,
                         include_dependencies=include_dependencies,
                         include_apps_from=include_apps_from,
-                        include_apps=True,
-                        is_main_package=True,
                         suffix=suffix,
                         expected_apps=required_apps,
                         lock_file=required_lock,
                         cooldown_days=required_cooldown,
+                    )
+                    venv = _install_on_supported_python(
+                        venv,
+                        build,
+                        venv_dir=venv_dir,
+                        fetch_python=fetch_python,
+                        python_flag_passed=python_flag_passed,
+                        verbose=verbose,
+                        backend=install_backend,
+                        env_backend=env_backend,
+                        messages=messages,
                     )
                     validate_expected_apps(venv, package_name, required_apps)
                     messages.extend(
@@ -290,9 +304,12 @@ def _resolve_package_names(
     backend: str | None,
     env_backend: str | None,
     cooldown_days: int | None,
-) -> tuple[list[str], tuple[str, PipxError] | None]:
+    fetch_python: FetchPythonOptions,
+    python_flag_passed: bool,
+    messages: list[OutputMessage],
+) -> tuple[list[str], tuple[str, PipxError] | None, str]:
     if package_names is not None and len(package_names) == len(package_specs):
-        return package_names, None
+        return package_names, None, python
 
     resolved: Final[list[str]] = []
     for package_spec in package_specs:
@@ -300,8 +317,8 @@ def _resolve_package_names(
             if (script_name := script_name_from_spec(package_spec, expected_apps)) is not None:
                 resolved.append(script_name)
                 continue
-            resolved.append(
-                package_name_from_spec(
+            try:
+                name = package_name_from_spec(
                     package_spec,
                     python,
                     pip_args=pip_args,
@@ -310,10 +327,27 @@ def _resolve_package_names(
                     env_backend=env_backend,
                     cooldown_days=cooldown_days,
                 )
-            )
+            except IncompatiblePythonError as error:
+                # reading the name off a local project already runs an install, so the constraint surfaces here first
+                python = _supported_python(
+                    error.constraint,
+                    fetch_python=fetch_python,
+                    python_flag_passed=python_flag_passed,
+                    messages=messages,
+                )
+                name = package_name_from_spec(
+                    package_spec,
+                    python,
+                    pip_args=pip_args,
+                    verbose=verbose,
+                    backend=backend,
+                    env_backend=env_backend,
+                    cooldown_days=cooldown_days,
+                )
+            resolved.append(name)
         except PipxError as error:
-            return resolved, (package_spec, error)
-    return resolved, None
+            return resolved, (package_spec, error), python
+    return resolved, None, python
 
 
 def _validate_install_options(
@@ -727,6 +761,120 @@ class InstallData(OperationData):
     packages: tuple[_InstalledPackage, ...]
     skipped: tuple[_SkippedInstall, ...]
     failures: tuple[_FailedInstall, ...]
+
+
+@dataclass(frozen=True)
+class _EnvironmentBuild:
+    """Everything needed to fill a venv, so pipx can do it twice when the first interpreter turns out unsupported."""
+
+    venv_args: list[str]
+    pip_args: list[str]
+    override_shared: bool
+    exposure_enabled: bool
+    preinstall_packages: list[str] | None
+    package_name: str
+    package_spec: str
+    force_reinstall: bool
+    include_dependencies: bool
+    include_apps_from: Sequence[str]
+    suffix: str
+    expected_apps: tuple[str, ...]
+    lock_file: Path | None
+    cooldown_days: int | None
+
+    def run(self, venv: Venv) -> None:
+        venv.create_venv(self.venv_args, self.pip_args, self.override_shared)
+        venv.pipx_metadata.exposure_enabled = self.exposure_enabled
+        venv.pipx_metadata.environment = venv.root.name
+        for dependency in self.preinstall_packages or []:
+            venv.upgrade_package_no_metadata(dependency, self.pip_args, cooldown_days=self.cooldown_days)
+        venv.install_package(
+            package_name=self.package_name,
+            package_or_url=self.package_spec,
+            pip_args=self.pip_args,
+            install_only_pip_args=["--force-reinstall"] if self.force_reinstall else None,
+            include_dependencies=self.include_dependencies,
+            include_apps_from=self.include_apps_from,
+            include_apps=True,
+            is_main_package=True,
+            suffix=self.suffix,
+            expected_apps=self.expected_apps,
+            lock_file=self.lock_file,
+            cooldown_days=self.cooldown_days,
+        )
+
+
+def _install_on_supported_python(
+    venv: Venv,
+    build: _EnvironmentBuild,
+    *,
+    venv_dir: Path,
+    fetch_python: FetchPythonOptions,
+    python_flag_passed: bool,
+    verbose: bool,
+    backend: str | None,
+    env_backend: str | None,
+    messages: list[OutputMessage],
+) -> Venv:
+    try:
+        build.run(venv)
+        # pip refuses an interpreter the package rules out, while uv installs onto it, so ask the metadata as well
+        constraint = venv.unsupported_python(build.package_name)
+    except IncompatiblePythonError as error:
+        constraint = error.constraint
+    if constraint is None:
+        return venv
+
+    venv = _rebuild_on_supported_python(
+        venv_dir=venv_dir,
+        constraint=constraint,
+        fetch_python=fetch_python,
+        python_flag_passed=python_flag_passed,
+        verbose=verbose,
+        backend=backend,
+        env_backend=env_backend,
+        messages=messages,
+    )
+    build.run(venv)
+    return venv
+
+
+def _supported_python(
+    constraint: SpecifierSet,
+    *,
+    fetch_python: FetchPythonOptions,
+    python_flag_passed: bool,
+    messages: list[OutputMessage],
+) -> str:
+    if python_flag_passed:
+        raise PipxError(
+            f"The Python you named does not satisfy {str(constraint)!r}, which this package requires. "
+            f"Name one that does, or leave --python out and let pipx choose."
+        )
+    interpreter: Final[str] = interpreter_for(constraint, fetch_python)
+    messages.append(OutputMessage(f"This package needs Python {constraint}, so pipx used {interpreter}."))
+    return interpreter
+
+
+def _rebuild_on_supported_python(
+    *,
+    venv_dir: Path,
+    constraint: SpecifierSet,
+    fetch_python: FetchPythonOptions,
+    python_flag_passed: bool,
+    verbose: bool,
+    backend: str | None,
+    env_backend: str | None,
+    messages: list[OutputMessage],
+) -> Venv:
+    interpreter: Final[str] = _supported_python(
+        constraint,
+        fetch_python=fetch_python,
+        python_flag_passed=python_flag_passed,
+        messages=messages,
+    )
+    rmdir(venv_dir)
+    return Venv(venv_dir, python=interpreter, verbose=verbose, backend=backend, env_backend=env_backend)
 
 
 __all__ = [

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -317,6 +317,7 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:
     _validate_backend_available(cli_backend, env_backend)
 
     ctx = DispatchContext(
+        fetch_python=args.fetch_python if "fetch_python" in args else FetchPythonOptions.NEVER,
         verbose=bool(args.verbose) if "verbose" in args else False,
         pip_args=get_pip_args(vars(args)),
         venv_args=get_venv_args(vars(args)),
@@ -366,6 +367,7 @@ class DispatchContext:
     backend: str | None = None
     env_backend: str | None = None
     cooldown_days: int | None = None
+    fetch_python: FetchPythonOptions = FetchPythonOptions.NEVER
 
     @property
     def effective_backend(self) -> str | None:
@@ -580,6 +582,7 @@ def _cmd_install(args: argparse.Namespace, ctx: DispatchContext) -> OperationRes
         lock_file=args.lock,
         suffix=args.suffix,
         python_flag_passed=ctx.python_flag_passed,
+        fetch_python=ctx.fetch_python,
         backend=ctx.backend,
         env_backend=ctx.env_backend,
         upgrade_strategy=args.upgrade_strategy,

--- a/src/pipx/requires_python.py
+++ b/src/pipx/requires_python.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING, Final
+
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+
+from pipx.constants import MINIMUM_PYTHON_VERSION, FetchPythonOptions
+from pipx.interpreter import InterpreterResolutionError, find_python_interpreter
+from pipx.util import PipxError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+_LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
+
+# pip prints this and installs nothing; uv installs the package regardless, so the metadata check covers that backend
+_PIP_REJECTION: Final[re.Pattern[str]] = re.compile(
+    r"""
+    requires\ a\ different\ Python:   # pip's wording for a Requires-Python mismatch
+    \s*\S+                            # the interpreter version pip rejected
+    \s*not\ in\ '(?P<constraint>[^']*)'
+    """,
+    re.VERBOSE,
+)
+# the newest release pipx looks for when a package rules out the default interpreter
+_NEWEST_PYTHON_MINOR: Final[int] = 14
+
+
+class IncompatiblePythonError(PipxError):
+    def __init__(self, constraint: SpecifierSet) -> None:
+        self.constraint: Final[SpecifierSet] = constraint
+        super().__init__(f"This package needs a Python matching {str(constraint)!r}.")
+
+
+def rejected_constraint(backend_output: str) -> SpecifierSet | None:
+    match: Final[re.Match[str] | None] = _PIP_REJECTION.search(backend_output)
+    if match is None:
+        return None
+    return _parse(match.group("constraint"))
+
+
+def unsatisfied_constraint(requires_python: str | None, python_version: str) -> SpecifierSet | None:
+    """The declared constraint when ``python_version`` fails it, otherwise nothing."""
+    if not requires_python or (constraint := _parse(requires_python)) is None:
+        return None
+    return None if constraint.contains(python_version, prereleases=True) else constraint
+
+
+def interpreter_for(constraint: SpecifierSet, fetch_python: FetchPythonOptions) -> str:
+    candidates: Final[list[str]] = [version for version in _candidate_versions() if constraint.contains(version)]
+    if not candidates:
+        raise PipxError(f"No Python that pipx supports satisfies {str(constraint)!r}.")
+
+    for candidate in candidates:
+        try:
+            interpreter = find_python_interpreter(candidate, FetchPythonOptions.NEVER)
+        except (InterpreterResolutionError, PipxError):
+            continue
+        _LOGGER.info("Python %s satisfies %s", candidate, constraint)
+        return interpreter
+
+    if fetch_python is FetchPythonOptions.NEVER:
+        raise PipxError(
+            f"This package needs a Python matching {str(constraint)!r} and none of the interpreters on this "
+            f"system does. Install one of {', '.join(candidates)}, name it with --python, or pass "
+            f"--fetch-python=missing to let pipx download it."
+        )
+    return find_python_interpreter(candidates[0], FetchPythonOptions.MISSING)
+
+
+def _candidate_versions() -> Iterator[str]:
+    lowest: Final[int] = int(MINIMUM_PYTHON_VERSION.split(".")[1])
+    for minor in range(_NEWEST_PYTHON_MINOR, lowest - 1, -1):
+        yield f"3.{minor}"
+
+
+def _parse(requires_python: str) -> SpecifierSet | None:
+    try:
+        return SpecifierSet(requires_python)
+    except InvalidSpecifier:
+        _LOGGER.info("Cannot read the Python constraint %r", requires_python)
+        return None
+
+
+__all__ = [
+    "interpreter_for",
+    "rejected_constraint",
+    "unsatisfied_constraint",
+]

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -11,6 +11,7 @@ from filelock import BaseFileLock, FileLock
 if TYPE_CHECKING:
     from subprocess import CompletedProcess
 
+from packaging.specifiers import SpecifierSet
 from packaging.utils import canonicalize_name
 from packaging.version import Version
 
@@ -35,6 +36,7 @@ from pipx.package_specifier import (
     valid_pypi_name,
 )
 from pipx.pipx_metadata_file import PackageInfo, PipxMetadata
+from pipx.requires_python import IncompatiblePythonError, rejected_constraint, unsatisfied_constraint
 from pipx.script import installable_script
 from pipx.shared_libs import (
     DISABLE_SHARED_LIBS_AUTO_UPGRADE,
@@ -55,6 +57,12 @@ from pipx.util import (
 from pipx.venv_inspect import VenvMetadata, inspect_venv
 
 _LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
+_REQUIRES_PYTHON_SCRIPT: Final[str] = (
+    "import sys;"
+    "from importlib.metadata import distribution;"
+    "print(distribution(sys.argv[1]).metadata['Requires-Python'] or '');"
+    "print('.'.join(str(part) for part in sys.version_info[:3]))"
+)
 _BACKEND_METADATA_VERSION: Final[Version] = Version("0.6")
 
 # Keyed on full path so global vs user-local venvs with the same name don't
@@ -266,6 +274,22 @@ class Venv:
         else:
             return self.pipx_metadata.main_package.package
 
+    def unsupported_python(self, package_name: str) -> SpecifierSet | None:
+        """The constraint an installed package declares when this venv's interpreter fails it.
+
+        uv installs a package onto an interpreter its Requires-Python rules out, so pipx reads the metadata rather
+        than trust the backend to refuse.
+        """
+        process = run_subprocess(
+            [self.python_path, "-c", _REQUIRES_PYTHON_SCRIPT, package_name],
+            capture_stderr=False,
+            log_stdout=False,
+        )
+        if process.returncode:
+            return None
+        requires_python, _, python_version = process.stdout.strip().partition("\n")
+        return unsatisfied_constraint(requires_python, python_version)
+
     def create_venv(self, venv_args: list[str], pip_args: list[str], override_shared: bool = False) -> None:
         """
         override_shared -- Override installing shared libraries to the pipx shared directory (default False)
@@ -377,6 +401,10 @@ class Venv:
                         progress=self.show_progress,
                     )
                 if process.returncode:
+                    # pip refuses the interpreter and installs nothing, so its complaint is the only place the
+                    # constraint appears; uv installs regardless, which the caller catches from the metadata instead
+                    if constraint := rejected_constraint(process.stderr or ""):
+                        raise IncompatiblePythonError(constraint)
                     raise PipxError(f"Error installing {full_package_description(package_name, package_or_url)}.")
             else:
                 self._install_locked_package(package_name, install_spec, lock_file, install_pip_args)
@@ -502,6 +530,8 @@ class Venv:
             )
         if process.returncode:
             error_output = (process.stderr or process.stdout or "").strip()
+            if constraint := rejected_constraint(error_output):
+                raise IncompatiblePythonError(constraint)
             if error_output:
                 raise PipxError(error_output, wrap_message=False)
             raise PipxError(

--- a/tests/test_requires_python.py
+++ b/tests/test_requires_python.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from typing import TYPE_CHECKING, Final
+
+import pytest
+from packaging.specifiers import SpecifierSet
+
+from helpers import run_pipx_cli
+from pipx import paths
+from pipx.constants import MINIMUM_PYTHON_VERSION, FetchPythonOptions
+from pipx.interpreter import InterpreterResolutionError
+from pipx.pipx_metadata_file import PipxMetadata
+from pipx.requires_python import interpreter_for, rejected_constraint, unsatisfied_constraint
+from pipx.util import PipxError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
+
+
+@pytest.mark.parametrize(
+    ("output", "expected"),
+    [
+        pytest.param(
+            "ERROR: Package 'oldpkg' requires a different Python: 3.14.6 not in '<3.12'",
+            "<3.12",
+            id="rejection",
+        ),
+        pytest.param(
+            "ERROR: Package 'x' requires a different Python: 3.14.6 not in '>=3.9,<3.12'",
+            "<3.12,>=3.9",
+            id="two-clauses",
+        ),
+        pytest.param("ERROR: No matching distribution found for oldpkg", None, id="other-error"),
+        pytest.param("", None, id="empty"),
+    ],
+)
+def test_rejected_constraint_reads_the_backend_complaint(output: str, expected: str | None) -> None:
+    constraint: Final[SpecifierSet | None] = rejected_constraint(output)
+
+    assert (None if constraint is None else str(constraint)) == expected
+
+
+@pytest.mark.parametrize(
+    ("requires_python", "python_version", "expected"),
+    [
+        pytest.param("<3.12", "3.14.6", "<3.12", id="violated"),
+        pytest.param("<3.12", "3.11.9", None, id="satisfied"),
+        pytest.param(None, "3.14.6", None, id="undeclared"),
+        pytest.param("", "3.14.6", None, id="empty"),
+        pytest.param("not-a-specifier", "3.14.6", None, id="unreadable"),
+    ],
+)
+def test_unsatisfied_constraint_reports_only_a_mismatch(
+    requires_python: str | None,
+    python_version: str,
+    expected: str | None,
+) -> None:
+    constraint: Final[SpecifierSet | None] = unsatisfied_constraint(requires_python, python_version)
+
+    assert (None if constraint is None else str(constraint)) == expected
+
+
+def test_interpreter_for_takes_the_newest_installed_match(mocker: MockerFixture) -> None:
+    find = mocker.patch("pipx.requires_python.find_python_interpreter", return_value="/usr/bin/python3.11")
+
+    assert interpreter_for(SpecifierSet("<3.12"), FetchPythonOptions.NEVER) == "/usr/bin/python3.11"
+    assert find.call_args.args[0] == "3.11"
+
+
+def test_interpreter_for_skips_a_version_the_system_lacks(mocker: MockerFixture) -> None:
+    def resolve(version: str, _fetch: FetchPythonOptions) -> str:
+        if version == "3.11":
+            raise InterpreterResolutionError(source="the system", version=version)
+        return f"/usr/bin/python{version}"
+
+    mocker.patch("pipx.requires_python.find_python_interpreter", side_effect=resolve)
+
+    assert interpreter_for(SpecifierSet("<3.12"), FetchPythonOptions.NEVER) == "/usr/bin/python3.10"
+
+
+def test_interpreter_for_fetches_when_the_caller_allows_it(mocker: MockerFixture) -> None:
+    find = mocker.patch(
+        "pipx.requires_python.find_python_interpreter",
+        side_effect=[InterpreterResolutionError(source="the system", version="3.11"), "/downloaded/python3.11"],
+    )
+
+    assert interpreter_for(SpecifierSet("==3.11.*"), FetchPythonOptions.MISSING) == "/downloaded/python3.11"
+    assert find.call_args.args[1] is FetchPythonOptions.MISSING
+
+
+def test_interpreter_for_reports_a_system_without_a_match(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "pipx.requires_python.find_python_interpreter",
+        side_effect=InterpreterResolutionError(source="the system", version="3.11"),
+    )
+
+    with pytest.raises(PipxError, match="--fetch-python=missing"):
+        interpreter_for(SpecifierSet("==3.11.*"), FetchPythonOptions.NEVER)
+
+
+def test_interpreter_for_reports_a_constraint_no_release_meets() -> None:
+    with pytest.raises(PipxError, match="No Python that pipx supports satisfies"):
+        interpreter_for(SpecifierSet("<3.5"), FetchPythonOptions.NEVER)
+
+
+@pytest.fixture
+def older_python(pipx_temp_env: None, monkeypatch: pytest.MonkeyPatch) -> str:
+    # pipx_temp_env strips the system directories out of PATH, and pipx looks the interpreters up there
+    monkeypatch.setenv("PATH", os.environ["PATH_ORIG"])
+    for minor in range(sys.version_info[1] - 1, int(MINIMUM_PYTHON_VERSION.split(".")[1]) - 1, -1):
+        if (found := shutil.which(f"python3.{minor}")) is not None:
+            return found
+    pytest.skip("no supported Python older than the one running the tests")
+
+
+@pytest.fixture
+def project_excluding_this_python(tmp_path: Path) -> Path:
+    project: Final[Path] = tmp_path / "needs-older"
+    (project / "needs_older").mkdir(parents=True)
+    (project / "needs_older" / "__init__.py").touch()
+    (project / "needs_older" / "main.py").write_text("def main() -> None:\n    print('needs-older')\n")
+    (project / "setup.py").write_text(
+        "from setuptools import setup\n\n"
+        "setup(\n"
+        "    name='needs-older',\n"
+        "    version='0.1',\n"
+        "    packages=['needs_older'],\n"
+        f"    python_requires='<{sys.version_info.major}.{sys.version_info.minor}',\n"
+        "    entry_points={'console_scripts': ['needs-older=needs_older.main:main']},\n"
+        ")\n"
+    )
+    return project
+
+
+@pytest.mark.parametrize("backend", [pytest.param("pip", id="pip"), pytest.param("uv", id="uv")])
+def test_install_moves_to_a_python_the_package_supports(
+    pipx_temp_env: None,
+    project_excluding_this_python: Path,
+    older_python: str,
+    capsys: pytest.CaptureFixture[str],
+    backend: str,
+) -> None:
+    if backend == "uv" and shutil.which("uv") is None:
+        pytest.skip("uv binary not on PATH")
+
+    assert not run_pipx_cli(["install", "--backend", backend, str(project_excluding_this_python)])
+
+    recorded: Final[str] = PipxMetadata(paths.ctx.venvs / "needs-older").python_version or ""
+    assert recorded != f"Python {sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"


### PR DESCRIPTION
A package declares the interpreters it runs on through `requires-python`, and pipx built every environment on its default one. A tool that rules that one out left the user to work out the right `--python` and to keep it right as the tool moved on, which is what [issue #387](https://github.com/pypa/pipx/issues/387) asks pipx to take over. `pipx install mytool` now lands on an interpreter the package accepts. 🐍

The constraint reaches pipx only once a resolve has run, and a local path or a URL has no index to ask, so pipx reads it from the failure instead. `pip` refuses the interpreter and names the constraint it wanted, which is the only place it appears, since the install stops there. `uv` takes the opposite line and installs the package onto an interpreter its own metadata rules out, so pipx reads `Requires-Python` off the installed distribution as well. That second check asks no backend to cooperate, so it also covers whatever follows `uv`. Reading the name off a local project already runs an install, so the constraint turns up there first and the interpreter it picks carries into the real one.

Both paths meet at the same repair. pipx walks the releases it supports from the newest down, takes the first one the constraint accepts and the system already carries, and builds the environment there, naming the interpreter it settled on. ✨

A system carrying no match stops with the constraint and the two ways forward, rather than downloading a Python the user did not ask for. `--fetch-python=missing` opts into the download. Naming `--python` keeps the last word: pipx reports that the interpreter fails the package instead of overriding the choice.

The `uv` divergence is the load-bearing part and worth a look during review. A wheel whose metadata reads `Requires-Python: <3.12` installs under `uv` on 3.14 and exits 0, so a retry hung off a refusal from the backend alone would not fire there.

Closes #387
