### PR TITLE
✨ feat(reinstall): report through the shared renderer

### DIFF
--- a/changelog.d/828.feature.5.md
+++ b/changelog.d/828.feature.5.md
@@ -1,0 +1,3 @@
+Give `pipx reinstall` and `pipx reinstall-all` the structured output the other commands carry. They printed straight to
+the terminal, so `--quiet` left `uninstalled NAME!` behind and no `--output json` existed to read the result from a
+script. Both now report through the shared renderer.

--- a/src/pipx/commands/__init__.py
+++ b/src/pipx/commands/__init__.py
@@ -11,7 +11,7 @@ from pipx.commands.list_packages import list_packages
 from pipx.commands.manifest import lock_manifest, sync_manifest
 from pipx.commands.outdated import OutdatedData, list_outdated
 from pipx.commands.pin import PinData, pin, unpin
-from pipx.commands.reinstall import reinstall, reinstall_all
+from pipx.commands.reinstall import ReinstallData, reinstall, reinstall_all
 from pipx.commands.reset import ResetData, reset
 from pipx.commands.run import run
 from pipx.commands.run_pip import run_pip
@@ -26,6 +26,7 @@ __all__ = [
     "InstallData",
     "OutdatedData",
     "PinData",
+    "ReinstallData",
     "RepairData",
     "ResetData",
     "UninstallData",

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -1,9 +1,11 @@
-import sys
-from collections.abc import Sequence
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
 from pathlib import Path
 from tempfile import mkdtemp
+from typing import TYPE_CHECKING, Final
 
-from filelock import BaseFileLock
 from packaging.utils import canonicalize_name
 
 from pipx.commands.common import add_suffix
@@ -18,8 +20,16 @@ from pipx.constants import (
     ExitCode,
 )
 from pipx.emojis import error, sleep, stars
+from pipx.result import OperationData, OperationResult, OutputLevel, OutputMessage, OutputStream
 from pipx.util import PipxError, rmdir, safe_unlink
 from pipx.venv import Venv, VenvContainer
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from filelock import BaseFileLock
+
+_LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
 
 def _create_reinstall_backup(venv_dir: Path) -> Path:
@@ -78,22 +88,29 @@ def reinstall(
     backend: str | None = None,
     env_backend: str | None = None,
     venv_lock: BaseFileLock | None = None,
-) -> ExitCode:
-    """Returns pipx exit code."""
+) -> OperationResult[ReinstallData]:
     if not venv_dir.exists():
-        print(f"Nothing to reinstall for {venv_dir.name} {sleep}")
-        return EXIT_CODE_REINSTALL_VENV_NONEXISTENT
+        return _outcome(
+            venv_dir.name,
+            OutputMessage(f"Nothing to reinstall for {venv_dir.name} {sleep}"),
+            exit_code=EXIT_CODE_REINSTALL_VENV_NONEXISTENT,
+        )
 
     try:
         Path(python).relative_to(venv_dir)
     except ValueError:
         pass
     else:
-        print(
-            f"{error} Error, the python executable would be deleted!",
-            "Change it using the --python option or PIPX_DEFAULT_PYTHON environment variable.",
+        return _outcome(
+            venv_dir.name,
+            OutputMessage(
+                f"{error} Error, the python executable would be deleted! Change it using the --python option "
+                f"or PIPX_DEFAULT_PYTHON environment variable.",
+                stream=OutputStream.STDERR,
+                level=OutputLevel.ERROR,
+            ),
+            exit_code=EXIT_CODE_REINSTALL_INVALID_PYTHON,
         )
-        return EXIT_CODE_REINSTALL_INVALID_PYTHON
 
     venv = Venv(venv_dir, verbose=verbose, backend=backend, env_backend=env_backend)
     venv.check_upgrade_shared_libs(
@@ -111,7 +128,7 @@ def reinstall(
     old_resource_paths = _get_reinstall_resource_paths(venv, local_bin_dir, local_man_dir)
     original_venv_dir = venv_dir
     reinstall_backup_dir = _create_reinstall_backup(venv_dir)
-    print(f"uninstalled {venv.name}! {stars}")
+    messages: list[OutputMessage] = [OutputMessage(f"uninstalled {venv.name}! {stars}")]
 
     # in case legacy original dir name
     venv_dir = venv_dir.with_name(canonicalize_name(venv_dir.name))
@@ -171,13 +188,16 @@ def reinstall(
         _remove_stale_reinstall_resources(old_resource_paths - new_resource_paths)
     except (Exception, KeyboardInterrupt):
         _restore_reinstall_backup(venv_dir, original_venv_dir, reinstall_backup_dir)
-        print(f"{error} Reinstall failed; restored {venv.name}.", file=sys.stderr)
+        _LOGGER.error("%s Reinstall failed; restored %s.", error, venv.name)
         raise
     else:
         rmdir(reinstall_backup_dir)
 
-    # Any failure to install will raise PipxError, otherwise success
-    return EXIT_CODE_OK
+    return OperationResult(
+        command="reinstall",
+        data=ReinstallData(environments=(_ReinstalledEnvironment(venv.name),), failures=()),
+        messages=tuple(messages),
+    )
 
 
 def reinstall_all(
@@ -191,10 +211,10 @@ def reinstall_all(
     python_flag_passed: bool = False,
     backend: str | None = None,
     env_backend: str | None = None,
-) -> ExitCode:
-    """Returns pipx exit code."""
-    failed: list[str] = []
-    reinstalled: list[str] = []
+) -> OperationResult[ReinstallData]:
+    failures: list[_FailedReinstall] = []
+    reinstalled: list[_ReinstalledEnvironment] = []
+    messages: list[OutputMessage] = []
 
     # iterate on all packages and reinstall them
     # for the first one, we also trigger
@@ -205,7 +225,7 @@ def reinstall_all(
             continue
         try:
             with venv_container.venv_lock(venv_dir) as venv_lock:
-                reinstall(
+                outcome = reinstall(
                     venv_dir=venv_dir,
                     local_bin_dir=local_bin_dir,
                     local_man_dir=local_man_dir,
@@ -217,21 +237,52 @@ def reinstall_all(
                     env_backend=env_backend,
                     venv_lock=venv_lock,
                 )
-        except PipxError as e:
-            print(e, file=sys.stderr)
-            failed.append(venv_dir.name)
+        except PipxError as error_raised:
+            failure = _FailedReinstall(venv_dir.name, str(error_raised))
+            failures.append(failure)
+            messages.append(OutputMessage(str(error_raised), stream=OutputStream.STDERR, level=OutputLevel.ERROR))
         else:
             first_reinstall = False
-            reinstalled.append(venv_dir.name)
-    if len(reinstalled) == 0:
-        print(f"No packages reinstalled after running 'pipx reinstall-all' {sleep}")
-    if len(failed) > 0:
-        raise PipxError(f"The following package(s) failed to reinstall: {', '.join(failed)}")
-    # Any failure to install will raise PipxError, otherwise success
-    return EXIT_CODE_OK
+            reinstalled.append(_ReinstalledEnvironment(venv_dir.name))
+            messages.extend(outcome.messages)
+    if not reinstalled:
+        messages.append(OutputMessage(f"No packages reinstalled after running 'pipx reinstall-all' {sleep}"))
+    return OperationResult(
+        command="reinstall-all",
+        data=ReinstallData(environments=tuple(reinstalled), failures=tuple(failures)),
+        messages=tuple(messages),
+        exit_code=ExitCode(1) if failures else EXIT_CODE_OK,
+    )
+
+
+@dataclass(frozen=True)
+class _ReinstalledEnvironment:
+    environment: str
+
+
+@dataclass(frozen=True)
+class _FailedReinstall:
+    environment: str
+    error: str
+
+
+@dataclass(frozen=True)
+class ReinstallData(OperationData):
+    environments: tuple[_ReinstalledEnvironment, ...]
+    failures: tuple[_FailedReinstall, ...]
+
+
+def _outcome(environment: str, message: OutputMessage, *, exit_code: ExitCode) -> OperationResult[ReinstallData]:
+    return OperationResult(
+        command="reinstall",
+        data=ReinstallData(environments=(), failures=(_FailedReinstall(environment, message.text),)),
+        messages=(message,),
+        exit_code=exit_code,
+    )
 
 
 __all__ = [
+    "ReinstallData",
     "reinstall",
     "reinstall_all",
 ]

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -1079,10 +1079,11 @@ def _add_reinstall(subparsers, venv_completer: VenvCompleter, shared_parser: arg
     p.add_argument("package").completer = venv_completer
     add_python_options(p)
     add_backend_arg(p)
+    _add_output_option(p)
     p.set_defaults(func=_cmd_reinstall)
 
 
-def _cmd_reinstall(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
+def _cmd_reinstall(args: argparse.Namespace, ctx: DispatchContext) -> OperationResult[commands.ReinstallData]:
     venv_dir = _venv_dir(args, ctx)
     with ctx.venv_container.venv_lock(venv_dir) as venv_lock:
         return commands.reinstall(
@@ -1119,10 +1120,11 @@ def _add_reinstall_all(subparsers: argparse._SubParsersAction, shared_parser: ar
     add_python_options(p)
     p.add_argument("--skip", nargs="+", default=[], help="skip these packages")
     add_backend_arg(p)
+    _add_output_option(p)
     p.set_defaults(func=_cmd_reinstall_all)
 
 
-def _cmd_reinstall_all(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
+def _cmd_reinstall_all(args: argparse.Namespace, ctx: DispatchContext) -> OperationResult[commands.ReinstallData]:
     return commands.reinstall_all(
         ctx.venv_container,
         paths.ctx.bin_dir,

--- a/tests/test_reinstall.py
+++ b/tests/test_reinstall.py
@@ -1,16 +1,24 @@
+import json
 import subprocess
 import sys
 from collections.abc import Callable
 from dataclasses import replace
 from pathlib import Path
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 import pytest
+from _pytest.capture import CaptureResult
 from pytest_mock import MockerFixture
 
 from helpers import PIPX_METADATA_LEGACY_VERSIONS, app_name, mock_legacy_venv, run_pipx_cli, skip_if_windows
 from pipx import paths, util, venv_inspect
 from pipx.pipx_metadata_file import PackageInfo, PipxMetadata
+
+if TYPE_CHECKING:
+    from _pytest.capture import CaptureResult
+
+if True:
+    pass
 
 
 def test_reinstall(pipx_temp_env, capsys):
@@ -213,3 +221,49 @@ def test_reinstall_pinned_package(pipx_temp_env, capsys):
     assert not run_pipx_cli(["reinstall", "black"])
     captured = capsys.readouterr()
     assert "installed package black" in captured.out
+
+
+def test_reinstall_all_quiet_says_nothing(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    capsys.readouterr()
+
+    assert not run_pipx_cli(["reinstall-all", "--python", sys.executable, "--quiet"])
+
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
+    assert (captured.out, captured.err) == ("", "")
+
+
+def test_reinstall_all_json_reports_the_environments(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert not run_pipx_cli(["install", "pycowsay"])
+    capsys.readouterr()
+
+    assert not run_pipx_cli(["reinstall-all", "--python", sys.executable, "--output", "json"])
+
+    assert json.loads(capsys.readouterr().out) == {
+        "command": "reinstall-all",
+        "data": {"environments": [{"environment": "pycowsay"}], "failures": []},
+        "pipx_result_version": "0.1",
+        "status": "success",
+    }
+
+
+def test_reinstall_json_reports_a_missing_environment(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert run_pipx_cli(["reinstall", "--python", sys.executable, "--output", "json", "missing"])
+
+    payload: Final[dict[str, object]] = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "error"
+
+
+def test_reinstall_all_json_reports_no_environments(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert not run_pipx_cli(["reinstall-all", "--python", sys.executable, "--output", "json"])
+
+    assert json.loads(capsys.readouterr().out)["data"] == {"environments": [], "failures": []}


### PR DESCRIPTION
[Issue #828](https://github.com/pypa/pipx/issues/828) asks pipx to hold its tongue under `--quiet` and to hand a script a machine-readable result from any command. `pipx upgrade-all -q` already says nothing, and the structured commands already answer `--output json`, yet `reinstall` and `reinstall-all` sat outside all of it: they printed to the terminal and returned a bare exit code. 🔇

```
$ pipx reinstall-all -q
uninstalled pycowsay! ✨ 🌟 ✨
```

`--quiet` had no say over those lines, and no `--output json` existed to read the outcome from a cron job. `install` already honoured `--quiet`, so the output that leaked was the part `reinstall` wrote for itself.

Both commands now return an `OperationResult`, which hands the decision to the renderer the rest of pipx shares. `--quiet` prints nothing at all, and `--output json` carries the environments it rebuilt alongside the ones that failed:

```json
{
  "command": "reinstall-all",
  "data": {"environments": [{"environment": "pycowsay"}], "failures": []},
  "pipx_result_version": "0.1",
  "status": "success"
}
```

`pipx repair` calls `reinstall` underneath and discarded its exit code, so it keeps reporting its own summary and loses the lines `reinstall` used to print beneath it. ✨

This advances #828 rather than closing it. `cache`, `interpreter`, `ensurepath`, `upgrade-shared`, `lock` and `sync` still lack `--output`, and `run`, `exec` and `runpip` hand control to another program, so a structured result reads oddly there.

Advances #828
