### PR TITLE
✨ feat(output): report the scriptable commands as data

### DIFF
--- a/changelog.d/828.feature.6.md
+++ b/changelog.d/828.feature.6.md
@@ -1,0 +1,4 @@
+Give `pipx cache`, `pipx interpreter`, `pipx upgrade-shared`, `pipx lock` and `pipx sync` the structured output the
+other commands carry, so `--quiet` silences them and `--output json` hands a script the result. The `cache` and
+`interpreter` subcommands take `--quiet` and `--verbose` for the first time, since the shared options had passed them
+by. `pipx ensurepath` goes on printing its guidance, because its job is to tell a person what to add to a shell profile.

--- a/src/pipx/commands/__init__.py
+++ b/src/pipx/commands/__init__.py
@@ -1,4 +1,4 @@
-from pipx.commands.cache import print_cache_dir, purge_cache
+from pipx.commands.cache import CacheData, print_cache_dir, purge_cache
 from pipx.commands.ensure_path import ensure_pipx_paths
 from pipx.commands.environment import environment
 from pipx.commands.execute import execute
@@ -6,9 +6,14 @@ from pipx.commands.expose import ExposureData, expose, unexpose
 from pipx.commands.health import HealthData, RepairData, health, repair
 from pipx.commands.inject import InjectionData, inject
 from pipx.commands.install import InstallData, install, install_all
-from pipx.commands.interpreter import list_interpreters, prune_interpreters, upgrade_interpreters
+from pipx.commands.interpreter import (
+    InterpreterData,
+    list_interpreters,
+    prune_interpreters,
+    upgrade_interpreters,
+)
 from pipx.commands.list_packages import list_packages
-from pipx.commands.manifest import lock_manifest, sync_manifest
+from pipx.commands.manifest import ManifestData, lock_manifest, sync_manifest
 from pipx.commands.outdated import OutdatedData, list_outdated
 from pipx.commands.pin import PinData, pin, unpin
 from pipx.commands.reinstall import reinstall, reinstall_all
@@ -17,17 +22,21 @@ from pipx.commands.run import run
 from pipx.commands.run_pip import run_pip
 from pipx.commands.uninject import uninject
 from pipx.commands.uninstall import UninstallData, uninstall, uninstall_all
-from pipx.commands.upgrade import upgrade, upgrade_all, upgrade_shared
+from pipx.commands.upgrade import SharedData, upgrade, upgrade_all, upgrade_shared
 
 __all__ = [
+    "CacheData",
     "ExposureData",
     "HealthData",
     "InjectionData",
     "InstallData",
+    "InterpreterData",
+    "ManifestData",
     "OutdatedData",
     "PinData",
     "RepairData",
     "ResetData",
+    "SharedData",
     "UninstallData",
     "ensure_pipx_paths",
     "environment",

--- a/src/pipx/commands/cache.py
+++ b/src/pipx/commands/cache.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Final
 
-from pipx.constants import EXIT_CODE_OK, ExitCode
+from pipx.result import OperationData, OperationResult, OutputMessage
 from pipx.util import rmdir
 
 if TYPE_CHECKING:
@@ -11,23 +12,37 @@ if TYPE_CHECKING:
     from pipx.venv import VenvContainer
 
 
-def print_cache_dir(venv_container: VenvContainer) -> ExitCode:
-    print(venv_container)
-    return EXIT_CODE_OK
+@dataclass(frozen=True)
+class CacheData(OperationData):
+    directory: str
+    removed: tuple[str, ...]
 
 
-def purge_cache(venv_container: VenvContainer) -> ExitCode:
+def print_cache_dir(venv_container: VenvContainer) -> OperationResult[CacheData]:
+    directory: Final[str] = str(venv_container)
+    return OperationResult(
+        command="cache-dir",
+        data=CacheData(directory=directory, removed=()),
+        messages=(OutputMessage(directory),),
+    )
+
+
+def purge_cache(venv_container: VenvContainer) -> OperationResult[CacheData]:
     venv_dirs: Final[tuple[Path, ...]] = tuple(venv_container.iter_venv_dirs())
-    removed = 0
+    removed: Final[list[str]] = []
     for venv_dir in venv_container.iter_locked_venv_dirs(venv_dirs):
         rmdir(venv_dir)
-        removed += 1
-    noun: Final[str] = "environment" if removed == 1 else "environments"
-    print(f"Removed {removed} cached {noun}.")
-    return EXIT_CODE_OK
+        removed.append(venv_dir.name)
+    noun: Final[str] = "environment" if len(removed) == 1 else "environments"
+    return OperationResult(
+        command="cache-purge",
+        data=CacheData(directory=str(venv_container), removed=tuple(removed)),
+        messages=(OutputMessage(f"Removed {len(removed)} cached {noun}."),),
+    )
 
 
 __all__ = [
+    "CacheData",
     "print_cache_dir",
     "purge_cache",
 ]

--- a/src/pipx/commands/interpreter.py
+++ b/src/pipx/commands/interpreter.py
@@ -1,15 +1,22 @@
+from __future__ import annotations
+
 import logging
 import subprocess
-from pathlib import Path
-from typing import Final
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Final
 
 from packaging import version
 
 from pipx import commands, constants, paths, standalone_python
 from pipx.animate import animate
-from pipx.pipx_metadata_file import PipxMetadata
+from pipx.result import OperationData, OperationResult, OutputMessage
 from pipx.util import is_paths_relative, rmdir
 from pipx.venv import Venv, VenvContainer
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pipx.pipx_metadata_file import PipxMetadata
 
 _LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
@@ -39,11 +46,11 @@ def get_interpreter_users(interpreter: Path, venvs: list[Venv]) -> list[PipxMeta
 
 def list_interpreters(
     venv_container: VenvContainer,
-) -> constants.ExitCode:
+) -> OperationResult[InterpreterData]:
     interpreters = get_installed_standalone_interpreters()
     venvs = get_venvs_using_standalone_interpreter(venv_container)
-    output: list[str] = []
-    output.append(f"Standalone interpreters are in {paths.ctx.standalone_python_cachedir}")
+    output: list[str] = [f"Standalone interpreters are in {paths.ctx.standalone_python_cachedir}"]
+    listed: list[_Interpreter] = []
     for interpreter in interpreters:
         output.append(f"Python {interpreter.name}")
         used_in = get_interpreter_users(interpreter, venvs)
@@ -52,14 +59,23 @@ def list_interpreters(
             output.extend(f"     - {p.main_package.package} {p.main_package.package_version}" for p in used_in)
         else:
             output.append("    Unused")
+        listed.append(
+            _Interpreter(
+                version=interpreter.name,
+                used_by=tuple(str(metadata.main_package.package) for metadata in used_in),
+            )
+        )
 
-    print("\n".join(output))
-    return constants.EXIT_CODE_OK
+    return OperationResult(
+        command="interpreter-list",
+        data=InterpreterData(interpreters=tuple(listed), removed=(), upgraded=()),
+        messages=(OutputMessage("\n".join(output)),),
+    )
 
 
 def prune_interpreters(
     venv_container: VenvContainer,
-) -> constants.ExitCode:
+) -> OperationResult[InterpreterData]:
     interpreters = get_installed_standalone_interpreters()
     venvs = get_venvs_using_standalone_interpreter(venv_container)
     removed = []
@@ -69,12 +85,14 @@ def prune_interpreters(
         rmdir(interpreter, safe_rm=True)
         removed.append(interpreter.name)
     if removed:
-        print("Successfully removed:")
-        for interpreter_name in removed:
-            print(f" - Python {interpreter_name}")
+        report = "\n".join(["Successfully removed:", *(f" - Python {name}" for name in removed)])
     else:
-        print("Nothing to remove")
-    return constants.EXIT_CODE_OK
+        report = "Nothing to remove"
+    return OperationResult(
+        command="interpreter-prune",
+        data=InterpreterData(interpreters=(), removed=tuple(removed), upgraded=()),
+        messages=(OutputMessage(report),),
+    )
 
 
 def get_latest_micro_version(
@@ -86,7 +104,7 @@ def get_latest_micro_version(
     return current_version
 
 
-def upgrade_interpreters(venv_container: VenvContainer, verbose: bool) -> constants.ExitCode:
+def upgrade_interpreters(venv_container: VenvContainer, verbose: bool) -> OperationResult[InterpreterData]:
     with animate("Getting the index of the latest standalone python builds", not verbose):
         latest_pythons = standalone_python.list_pythons(use_cache=False)
 
@@ -129,9 +147,11 @@ def upgrade_interpreters(venv_container: VenvContainer, verbose: bool) -> consta
                     venv.pipx_metadata.source_interpreter, interpreter_dir
                 ):
                     with venv_container.venv_lock(venv.root) as venv_lock:
-                        print(
-                            f"Upgrade the interpreter of {venv.name} from "
-                            f"{interpreter_full_version} to {latest_micro_version}"
+                        _LOGGER.info(
+                            "Upgrade the interpreter of %s from %s to %s",
+                            venv.name,
+                            interpreter_full_version,
+                            latest_micro_version,
                         )
                         commands.reinstall(
                             venv_dir=venv.root,
@@ -144,17 +164,47 @@ def upgrade_interpreters(venv_container: VenvContainer, verbose: bool) -> consta
                         upgraded.append((venv.name, interpreter_full_version, latest_micro_version))
 
     if upgraded:
-        print("Successfully upgraded the interpreter(s):")
-        for venv_name, old_version, new_version in upgraded:
-            print(f" - {venv_name}: {old_version} -> {new_version}")
+        report = "\n".join(
+            [
+                "Successfully upgraded the interpreter(s):",
+                *(f" - {name}: {old} -> {new}" for name, old, new in upgraded),
+            ]
+        )
     else:
-        print("Nothing to upgrade")
+        report = "Nothing to upgrade"
+    return OperationResult(
+        command="interpreter-upgrade",
+        data=InterpreterData(
+            interpreters=(),
+            removed=(),
+            upgraded=tuple(_UpgradedInterpreter(name, old, str(new)) for name, old, new in upgraded),
+        ),
+        messages=(OutputMessage(report),),
+    )
 
-    # Any failure to upgrade will raise PipxError, otherwise success
-    return constants.EXIT_CODE_OK
+
+@dataclass(frozen=True)
+class _Interpreter:
+    version: str
+    used_by: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _UpgradedInterpreter:
+    environment: str
+    old_version: str
+    new_version: str
+
+
+@dataclass(frozen=True)
+class InterpreterData(OperationData):
+    interpreters: tuple[_Interpreter, ...]
+    removed: tuple[str, ...]
+    upgraded: tuple[_UpgradedInterpreter, ...]
 
 
 __all__ = [
+    "InterpreterData",
     "list_interpreters",
     "prune_interpreters",
     "upgrade_interpreters",

--- a/src/pipx/commands/manifest.py
+++ b/src/pipx/commands/manifest.py
@@ -19,7 +19,15 @@ from pipx.commands.install import install
 from pipx.commands.uninstall import uninstall
 from pipx.constants import EXIT_CODE_OK, ExitCode
 from pipx.pipx_metadata_file import PipxMetadata
-from pipx.result import OutputFormat, render_result
+from pipx.result import (
+    OperationData,
+    OperationResult,
+    OutputFormat,
+    OutputLevel,
+    OutputMessage,
+    OutputStream,
+    render_result,
+)
 from pipx.util import PipxError
 
 if TYPE_CHECKING:
@@ -44,9 +52,11 @@ def sync_manifest(
     prune: bool,
     backend: str | None,
     env_backend: str | None,
-) -> ExitCode:
+) -> OperationResult[ManifestData]:
     manifest = _load_manifest(manifest_file, require_locks=True)
-    failures: list[str] = []
+    failures: list[_FailedTool] = []
+    messages: list[OutputMessage] = []
+    synced: list[str] = []
     for tool in manifest.tools:
         venv_dir = venv_container.get_venv_dir(tool.environment)
         with venv_container.venv_lock(venv_dir) as venv_lock:
@@ -82,29 +92,38 @@ def sync_manifest(
                     venv_lock=venv_lock,
                 )
             except PipxError as error:
-                print(error, file=sys.stderr)
-                failures.append(tool.environment)
+                failures.append(_FailedTool(tool.environment, str(error)))
+                messages.append(OutputMessage(str(error), stream=OutputStream.STDERR, level=OutputLevel.ERROR))
                 if was_exposed:
                     expose(venv_dir, local_bin_dir, local_man_dir, verbose)
+            else:
+                synced.append(tool.environment)
 
-    if failures:
-        raise PipxError(f"The following manifest tools failed to sync: {', '.join(failures)}")
-    if prune:
+    if prune and not failures:
         _prune_environments(manifest, venv_container, local_bin_dir, local_man_dir, verbose)
-    return EXIT_CODE_OK
+    return OperationResult(
+        command="sync",
+        data=ManifestData(environments=tuple(synced), locks=(), failures=tuple(failures)),
+        messages=tuple(messages),
+        exit_code=ExitCode(1) if failures else EXIT_CODE_OK,
+    )
 
 
-def lock_manifest(manifest_file: Path) -> ExitCode:
+def lock_manifest(manifest_file: Path) -> OperationResult[ManifestData]:
     manifest = _load_manifest(manifest_file, require_locks=False)
     if not any(tool.lock_file is not None for tool in manifest.tools):
         raise PipxError("The manifest does not declare any lock files.")
     if not (nab := which("nab")):
         raise PipxError("The nab command is required. Install it with `pipx install nab`.")
     try:
-        _generate_locks(manifest, nab)
+        locked: Final[list[str]] = _generate_locks(manifest, nab)
     except OSError as error:
         raise PipxError(f"Cannot write manifest locks: {error}") from error
-    return EXIT_CODE_OK
+    return OperationResult(
+        command="lock",
+        data=ManifestData(environments=(), locks=tuple(locked), failures=()),
+        messages=tuple(OutputMessage(f"locked {lock_file}") for lock_file in locked),
+    )
 
 
 def _load_manifest(manifest_file: Path, *, require_locks: bool) -> _Manifest:
@@ -285,7 +304,7 @@ def _is_pylock_name(name: str) -> bool:
     )
 
 
-def _generate_locks(manifest: _Manifest, nab: str) -> None:
+def _generate_locks(manifest: _Manifest, nab: str) -> list[str]:
     with TemporaryDirectory(prefix=".pipx-lock-", dir=manifest.path.parent) as temporary_dir:
         generated: list[tuple[Path, Path]] = []
         for tool in manifest.tools:
@@ -314,10 +333,12 @@ def _generate_locks(manifest: _Manifest, nab: str) -> None:
                 raise PipxError(f"nab did not create {generated_lock.name} for {tool.environment}.")
             generated.append((generated_lock, tool.lock_file))
 
+        locked: Final[list[str]] = []
         for generated_lock, lock_file in generated:
             lock_file.parent.mkdir(parents=True, exist_ok=True)
             generated_lock.replace(lock_file)
-            print(f"locked {lock_file}")
+            locked.append(str(lock_file))
+    return locked
 
 
 def _prune_environments(
@@ -371,7 +392,21 @@ _TOOL_KEYS: Final[frozenset[str]] = frozenset(
 )
 
 
+@dataclass(frozen=True)
+class _FailedTool:
+    environment: str
+    error: str
+
+
+@dataclass(frozen=True)
+class ManifestData(OperationData):
+    environments: tuple[str, ...]
+    locks: tuple[str, ...]
+    failures: tuple[_FailedTool, ...]
+
+
 __all__ = [
+    "ManifestData",
     "lock_manifest",
     "sync_manifest",
 ]

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -11,7 +11,7 @@ from pipx.colors import bold, red
 from pipx.commands.common import expose_package_resources, locked_package_message, validate_expected_apps
 from pipx.commands.outdated import inspect_outdated
 from pipx.commands.transaction import preserve_venv
-from pipx.constants import EXIT_CODE_OK, ExitCode
+from pipx.constants import ExitCode
 from pipx.emojis import sleep
 from pipx.package_specifier import parse_specifier_for_upgrade
 from pipx.result import OperationData, OperationResult, OutputLevel, OutputMessage, OutputStream
@@ -176,10 +176,14 @@ def upgrade_all(
 def upgrade_shared(
     verbose: bool,
     pip_args: list[str],
-) -> ExitCode:
+) -> OperationResult[SharedData]:
     # pip-backed installs use this environment regardless of the installed environments' backends.
     shared_libs.upgrade(verbose=verbose, pip_args=pip_args, raises=True)
-    return EXIT_CODE_OK
+    return OperationResult(
+        command="upgrade-shared",
+        data=SharedData(location=str(shared_libs.root)),
+        messages=(OutputMessage(f"Upgraded the shared libraries in {shared_libs.root}."),),
+    )
 
 
 def _upgrade_venv(
@@ -496,7 +500,13 @@ class UpgradeData(OperationData):
     failures: tuple[FailedUpgrade, ...]
 
 
+@dataclass(frozen=True)
+class SharedData(OperationData):
+    location: str
+
+
 __all__ = [
+    "SharedData",
     "UpgradeData",
     "upgrade",
     "upgrade_all",

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -639,10 +639,11 @@ def _add_lock(subparsers: argparse._SubParsersAction, shared_parser: argparse.Ar
         parents=[shared_parser],
     )
     parser.add_argument("manifest", type=Path, help="Path to the tool manifest.")
+    _add_output_option(parser)
     parser.set_defaults(func=_cmd_lock)
 
 
-def _cmd_lock(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
+def _cmd_lock(args: argparse.Namespace, ctx: DispatchContext) -> OperationResult[commands.ManifestData]:
     return commands.lock_manifest(args.manifest)
 
 
@@ -656,10 +657,11 @@ def _add_sync(subparsers: argparse._SubParsersAction, shared_parser: argparse.Ar
     parser.add_argument("manifest", type=Path, help="Path to the tool manifest.")
     parser.add_argument("--prune", action="store_true", help="Uninstall environments absent from the manifest.")
     add_backend_arg(parser)
+    _add_output_option(parser)
     parser.set_defaults(func=_cmd_sync)
 
 
-def _cmd_sync(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
+def _cmd_sync(args: argparse.Namespace, ctx: DispatchContext) -> OperationResult[commands.ManifestData]:
     return commands.sync_manifest(
         args.manifest,
         ctx.venv_container,
@@ -985,10 +987,11 @@ def _add_upgrade_shared(subparsers: argparse._SubParsersAction, shared_parser: a
         "--pip-args",
         help="Arbitrary pip arguments to pass directly to pip install/upgrade commands",
     )
+    _add_output_option(p)
     p.set_defaults(func=_cmd_upgrade_shared)
 
 
-def _cmd_upgrade_shared(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
+def _cmd_upgrade_shared(args: argparse.Namespace, ctx: DispatchContext) -> OperationResult[commands.SharedData]:
     return commands.upgrade_shared(ctx.verbose, ctx.pip_args)
 
 
@@ -1266,29 +1269,45 @@ def _add_interpreter(
         description="Get help for commands with pipx interpreter COMMAND --help",
         dest="interpreter_command",
     )
-    list_p = s.add_parser("list", help="List available interpreters", description="List available interpreters")
-    prune_p = s.add_parser("prune", help="Prune unused interpreters", description="Prune unused interpreters")
+    list_p = s.add_parser(
+        "list",
+        help="List available interpreters",
+        description="List available interpreters",
+        parents=[shared_parser],
+    )
+    prune_p = s.add_parser(
+        "prune",
+        help="Prune unused interpreters",
+        description="Prune unused interpreters",
+        parents=[shared_parser],
+    )
     upgrade_p = s.add_parser(
         "upgrade",
         help="Upgrade installed interpreters to the latest available micro/patch version",
         description="Upgrade installed interpreters to the latest available micro/patch version",
+        parents=[shared_parser],
     )
+    _add_output_option(list_p)
     list_p.set_defaults(func=_cmd_interpreter_list)
+    _add_output_option(prune_p)
     prune_p.set_defaults(func=_cmd_interpreter_prune)
+    _add_output_option(upgrade_p)
     upgrade_p.set_defaults(func=_cmd_interpreter_upgrade)
     p.set_defaults(func=_make_print_help(p))
     return p
 
 
-def _cmd_interpreter_list(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
+def _cmd_interpreter_list(args: argparse.Namespace, ctx: DispatchContext) -> OperationResult[commands.InterpreterData]:
     return commands.list_interpreters(ctx.venv_container)
 
 
-def _cmd_interpreter_prune(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
+def _cmd_interpreter_prune(args: argparse.Namespace, ctx: DispatchContext) -> OperationResult[commands.InterpreterData]:
     return commands.prune_interpreters(ctx.venv_container)
 
 
-def _cmd_interpreter_upgrade(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
+def _cmd_interpreter_upgrade(
+    args: argparse.Namespace, ctx: DispatchContext
+) -> OperationResult[commands.InterpreterData]:
     return commands.upgrade_interpreters(ctx.venv_container, ctx.verbose)
 
 
@@ -1310,23 +1329,27 @@ def _add_cache(
         "dir",
         help="Show the cache directory",
         description="Show the cache directory",
+        parents=[shared_parser],
     )
     purge_parser: Final[argparse.ArgumentParser] = subcommands.add_parser(
         "purge",
         help="Remove cached run environments",
         description="Remove cached run environments",
+        parents=[shared_parser],
     )
+    _add_output_option(dir_parser)
     dir_parser.set_defaults(func=_cmd_cache_dir)
+    _add_output_option(purge_parser)
     purge_parser.set_defaults(func=_cmd_cache_purge)
     parser.set_defaults(func=_make_print_help(parser))
     return parser
 
 
-def _cmd_cache_dir(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
+def _cmd_cache_dir(args: argparse.Namespace, ctx: DispatchContext) -> OperationResult[commands.CacheData]:
     return commands.print_cache_dir(VenvContainer(paths.ctx.venv_cache))
 
 
-def _cmd_cache_purge(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:
+def _cmd_cache_purge(args: argparse.Namespace, ctx: DispatchContext) -> OperationResult[commands.CacheData]:
     return commands.purge_cache(VenvContainer(paths.ctx.venv_cache))
 
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
-from typing import Final
+import json
+from typing import TYPE_CHECKING, Final
 
 import pytest
 
 from helpers import run_pipx_cli
 from pipx import paths
+
+if TYPE_CHECKING:
+    from _pytest.capture import CaptureResult
 
 
 def test_cache_dir(pipx_temp_env: None, capsys: pytest.CaptureFixture[str]) -> None:
@@ -39,3 +43,38 @@ def test_cache_purge_removes_run_environments(
         capsys.readouterr().out,
         tuple(path for path in paths.ctx.venv_cache.iterdir() if path.is_dir()),
     ) == (expected, ())
+
+
+@pytest.mark.parametrize(
+    ("subcommand", "command"),
+    [
+        pytest.param("dir", "cache-dir", id="dir"),
+        pytest.param("purge", "cache-purge", id="purge"),
+    ],
+)
+def test_cache_json_reports_the_directory(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    subcommand: str,
+    command: str,
+) -> None:
+    assert not run_pipx_cli(["cache", subcommand, "--output", "json"])
+
+    assert json.loads(capsys.readouterr().out) == {
+        "command": command,
+        "data": {"directory": str(paths.ctx.venv_cache), "removed": []},
+        "pipx_result_version": "0.1",
+        "status": "success",
+    }
+
+
+@pytest.mark.parametrize("subcommand", [pytest.param("dir", id="dir"), pytest.param("purge", id="purge")])
+def test_cache_quiet_says_nothing(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    subcommand: str,
+) -> None:
+    assert not run_pipx_cli(["cache", subcommand, "--quiet"])
+
+    captured: Final[CaptureResult[str]] = capsys.readouterr()
+    assert (captured.out, captured.err) == ("", "")

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 import subprocess
@@ -11,6 +12,7 @@ from pytest_mock import MockerFixture
 import pipx.interpreter
 import pipx.paths
 import pipx.standalone_python
+from helpers import run_pipx_cli
 from pipx.constants import WINDOWS, FetchPythonOptions
 from pipx.interpreter import (
     InterpreterResolutionError,
@@ -346,3 +348,38 @@ def test_find_python_interpreter_py_launcher_success(monkeypatch):
     monkeypatch.setattr(shutil, "which", lambda name: None)
     monkeypatch.setattr(pipx.interpreter, "find_py_launcher_python", lambda v: f"/fake/python{v}")
     assert find_python_interpreter("3.13", fetch_python=FetchPythonOptions.NEVER) == "/fake/python3.13"
+
+
+@pytest.mark.parametrize(
+    ("subcommand", "command"),
+    [
+        pytest.param("list", "interpreter-list", id="list"),
+        pytest.param("prune", "interpreter-prune", id="prune"),
+    ],
+)
+def test_interpreter_json_reports_an_empty_cache(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    subcommand: str,
+    command: str,
+) -> None:
+    assert not run_pipx_cli(["interpreter", subcommand, "--output", "json"])
+
+    assert json.loads(capsys.readouterr().out) == {
+        "command": command,
+        "data": {"interpreters": [], "removed": [], "upgraded": []},
+        "pipx_result_version": "0.1",
+        "status": "success",
+    }
+
+
+@pytest.mark.parametrize("subcommand", [pytest.param("list", id="list"), pytest.param("prune", id="prune")])
+def test_interpreter_quiet_says_nothing(
+    pipx_temp_env: None,
+    capsys: pytest.CaptureFixture[str],
+    subcommand: str,
+) -> None:
+    assert not run_pipx_cli(["interpreter", subcommand, "--quiet"])
+
+    captured = capsys.readouterr()
+    assert (captured.out, captured.err) == ("", "")


### PR DESCRIPTION
[Issue #828](https://github.com/pypa/pipx/issues/828) asks pipx to keep quiet when told to, and to hand a script the result of whatever it ran. The commands that install and remove packages already answer both, and #1954 brought `reinstall` along. `cache`, `interpreter`, `upgrade-shared`, `lock` and `sync` still printed to the terminal and returned a bare exit code. 🔇

All five return an `OperationResult` now, so `--quiet` stays silent and `--output json` carries what they did.

```json
{"command": "cache-dir", "data": {"directory": "~/.local/share/pipx/.cache", "removed": []}, "status": "success"}
{"command": "interpreter-list", "data": {"interpreters": [], "removed": [], "upgraded": []}, "status": "success"}
```

Writing the sweep turned up a plain bug underneath it. Whoever wrote the `cache` and `interpreter` subparsers left the shared options out, so those subcommands rejected `--quiet` and `--verbose` outright.

```
$ pipx cache purge -q
error: unrecognized arguments: -q
```

Adding `--output` to them would have gone nowhere while that stood, so they take both flags for the first time. ✨

`ensurepath` goes on printing its guidance, and the changelog says as much. Its job is to tell a person what to add to a shell profile, and a JSON envelope helps no one there. `run`, `exec` and `runpip` hand control to another program, while `environment` already answers `--value`, so this leaves the four of them alone.

Closes #828
