### PR TITLE
🐛 fix(tests): isolate empty_project builds from the race

### DIFF
--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1255,8 +1255,8 @@ def test_force_install_changes(capsys: pytest.CaptureFixture[str]) -> None:
 
 
 @pytest.mark.usefixtures("pipx_temp_env")
-def test_force_install_changes_editable(root: Path, capsys: pytest.CaptureFixture[str]) -> None:
-    empty_project_path_as_string = (root / "testdata" / "empty_project").as_posix()
+def test_force_install_changes_editable(empty_project: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    empty_project_path_as_string = empty_project.as_posix()
     assert not run_pipx_cli(["install", "--editable", empty_project_path_as_string])
     captured = capsys.readouterr()
     assert "empty-project" in captured.out
@@ -1267,8 +1267,8 @@ def test_force_install_changes_editable(root: Path, capsys: pytest.CaptureFixtur
 
 
 @pytest.mark.usefixtures("pipx_temp_env")
-def test_install_multiple_packages_preserves_editable_for_local_package(root: Path) -> None:
-    local_package = (root / "testdata" / "empty_project").as_posix()
+def test_install_multiple_packages_preserves_editable_for_local_package(empty_project: Path) -> None:
+    local_package = empty_project.as_posix()
     assert (
         run_pipx_cli(["install", PKG["pycowsay"]["spec"], local_package, "--editable"]),
         PipxMetadata(paths.ctx.venvs / "empty-project").main_package.pip_args,

--- a/tests/test_outdated.py
+++ b/tests/test_outdated.py
@@ -297,9 +297,9 @@ def test_list_outdated_reports_no_index_packages(
 @pytest.mark.usefixtures("pipx_temp_env")
 def test_list_outdated_json_reports_editable_skip(
     capsys: pytest.CaptureFixture[str],
-    root: Path,
+    empty_project: Path,
 ) -> None:
-    assert not run_pipx_cli(["install", "--editable", str(root / "testdata" / "empty_project")])
+    assert not run_pipx_cli(["install", "--editable", str(empty_project)])
     capsys.readouterr()
 
     assert not run_pipx_cli(["list", "--outdated", "--json"])

--- a/tests/test_runpip.py
+++ b/tests/test_runpip.py
@@ -34,8 +34,8 @@ def test_runpip_global() -> None:
 
 
 @pytest.mark.usefixtures("pipx_temp_env")
-def test_runpip_install_refreshes_main_package_metadata(root: Path, tmp_path: Path) -> None:
-    package_dir = root / "testdata" / "empty_project"
+def test_runpip_install_refreshes_main_package_metadata(empty_project: Path, tmp_path: Path) -> None:
+    package_dir = empty_project
     wheel_dir = tmp_path / "wheelhouse"
     wheel_dir.mkdir()
     subprocess.run(

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -235,8 +235,8 @@ def test_upgrade_ignores_venv_args_without_install(
 
 
 @pytest.mark.usefixtures("pipx_temp_env")
-def test_upgrade_editable(capsys: pytest.CaptureFixture[str], root: Path) -> None:
-    empty_project_path_as_string = (root / "testdata" / "empty_project").as_posix()
+def test_upgrade_editable(capsys: pytest.CaptureFixture[str], empty_project: Path) -> None:
+    empty_project_path_as_string = empty_project.as_posix()
     assert not run_pipx_cli(["install", "--editable", empty_project_path_as_string, "--force"])
     assert not run_pipx_cli(["upgrade", "--editable", "empty_project"])
     captured = capsys.readouterr()
@@ -288,8 +288,8 @@ def test_upgrade_multiple(capsys: pytest.CaptureFixture[str]) -> None:
 
 
 @pytest.mark.usefixtures("pipx_temp_env")
-def test_upgrade_absolute_path(capsys: pytest.CaptureFixture[str], root: Path) -> None:
-    assert run_pipx_cli(["upgrade", "--verbose", str((root / "testdata" / "empty_project").resolve())])
+def test_upgrade_absolute_path(capsys: pytest.CaptureFixture[str], empty_project: Path) -> None:
+    assert run_pipx_cli(["upgrade", "--verbose", str(empty_project.resolve())])
     captured = capsys.readouterr()
     assert "Package cannot be a URL" not in captured.err
 
@@ -391,9 +391,9 @@ def test_upgrade_cooldown(
 
 
 @pytest.mark.usefixtures("pipx_temp_env")
-def test_upgrade_injected_uses_stored_pip_args(root: Path) -> None:
+def test_upgrade_injected_uses_stored_pip_args(empty_project: Path) -> None:
     assert not run_pipx_cli(["install", PKG["pycowsay"]["spec"], "--pip-args=--no-cache-dir"])
-    assert not run_pipx_cli(["inject", "pycowsay", str(root / "testdata" / "empty_project"), "--pip-args=--no-compile"])
+    assert not run_pipx_cli(["inject", "pycowsay", str(empty_project), "--pip-args=--no-compile"])
 
     assert not run_pipx_cli(["upgrade", "--include-injected", "pycowsay"])
 

--- a/tests/test_upgrade_all.py
+++ b/tests/test_upgrade_all.py
@@ -301,8 +301,8 @@ def test_upgrade_all_json_requested_skip(capsys: pytest.CaptureFixture[str]) -> 
 
 
 @pytest.mark.usefixtures("pipx_temp_env")
-def test_upgrade_all_json_editable_skip(capsys: pytest.CaptureFixture[str], root: Path) -> None:
-    assert not run_pipx_cli(["install", "--editable", str(root / "testdata" / "empty_project"), "--force"])
+def test_upgrade_all_json_editable_skip(capsys: pytest.CaptureFixture[str], empty_project: Path) -> None:
+    assert not run_pipx_cli(["install", "--editable", str(empty_project), "--force"])
     capsys.readouterr()
 
     assert not run_pipx_cli(["upgrade-all", "--output", "json"])


### PR DESCRIPTION
The Windows test job failed intermittently with `Failed to build 'testdata/empty_project' when getting requirements to build wheel`. 🐛 Eight tests across six files installed or built `testdata/empty_project` straight from the source tree, and pytest-xdist runs different test files on separate workers in parallel. Two workers building the setuptools project at the same time race on the `build/` and `.egg-info` output it writes in place, so one build fails.

The `empty_project` fixture already exists to prevent this: it copies the project into the test's `tmp_path`, ignoring `build` and `*.egg-info`, so each build is private. This routes the eight raw-path call sites through that fixture, matching the isolation already applied to the `local_extras` and `uninject` builds in earlier fixes.
