### PR TITLE
👷 ci: default to Python 3.14 and fix the release gate deadlock

### DIFF
--- a/.github/workflows/create_tests_package_lists.yml
+++ b/.github/workflows/create_tests_package_lists.yml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.13", "3.12", "3.11", "3.10"]
+        python-version: ["3.14", "3.13", "3.12", "3.11", "3.10"]
         include:
           - os: macos-latest
-            python-version: "3.13"
+            python-version: "3.14"
           - os: windows-latest
-            python-version: "3.13"
+            python-version: "3.14"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -13,7 +13,7 @@ on:
           - patch
         default: auto
 env:
-  default-python: "3.13"
+  default-python: "3.14"
 jobs:
   pre-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,9 @@ on:
   schedule:
     - cron: "0 8 * * *"
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # a literal prefix, not ${{ github.workflow }}: when release.yml calls this as a reusable workflow, github.workflow
+  # resolves to the caller ("Release"), which would collide with release.yml's own group and cancel the release run
+  group: tests-${{ github.ref }}
   cancel-in-progress: true
 permissions:
   contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: 📦 Install tox
-        run: uv tool install --python-preference only-managed --python 3.13 "tox>=4.45" --with tox-uv
+        run: uv tool install --python-preference only-managed --python 3.14 "tox>=4.45" --with tox-uv
       - name: Persistent .pipx_tests/package_cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -69,7 +69,7 @@ jobs:
       - name: 🚀 Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: 📦 Install tox
-        run: uv tool install --python-preference only-managed --python 3.13 "tox>=4.45" --with tox-uv
+        run: uv tool install --python-preference only-managed --python 3.14 "tox>=4.45" --with tox-uv
       - name: 🔍 Run ty
         run: tox run -e type
   man:
@@ -83,7 +83,7 @@ jobs:
       - name: 🚀 Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: 📦 Install tox
-        run: uv tool install --python-preference only-managed --python 3.13 "tox>=4.45" --with tox-uv
+        run: uv tool install --python-preference only-managed --python 3.14 "tox>=4.45" --with tox-uv
       - name: 📖 Build man page
         run: tox run -e man
       - name: Show man page

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,7 +2,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.13"
+    python: "3.14"
   commands:
     - pip install "tox>=4.45" tox-uv
     - tox run -e docs


### PR DESCRIPTION
Tagging `1.16.0` failed the [Release run](https://github.com/pypa/pipx/actions/runs/29440236979) in two seconds with every publish job skipped. 🐛 `release.yml` gates publishing on the test suite by calling `tests.yml` as a reusable workflow, and inside a reusable workflow `github.workflow` resolves to the caller. So this workflow's concurrency group `${{ github.workflow }}-${{ github.ref }}` evaluated to `Release-<ref>`, the same group `release.yml` uses for itself, and `cancel-in-progress` made the gate cancel its own parent run the moment it started. Giving `tests.yml` a literal `tests-` group prefix removes the collision.

The rest moves the CI jobs that do not target a particular interpreter to Python 3.14: the runner interpreter for the tox-install steps, the Read the Docs build, the pre-release build, and the latest-version entries in the package-list matrix, which also gains a 3.14 row. The zipapp job stays on 3.10 by design, since it builds the distributable on the floor version to catch anything that would not run there.

The already-tagged `1.16.0` still points at the old workflow, so re-running that release will keep failing; the fix takes effect for the next tag (or a moved `1.16.0`).
