### PR TITLE
🐛 fix(standalone): retry transient download failures

### DIFF
--- a/changelog.d/1960.bugfix.md
+++ b/changelog.d/1960.bugfix.md
@@ -1,0 +1,1 @@
+Retry fetching a standalone Python build when GitHub's release CDN returns a transient error, so a momentary `5xx` or rate-limit response no longer fails the install.

--- a/changelog.d/1960.bugfix.md
+++ b/changelog.d/1960.bugfix.md
@@ -1,1 +1,2 @@
-Retry fetching a standalone Python build when GitHub's release CDN returns a transient error, so a momentary `5xx` or rate-limit response no longer fails the install.
+Retry fetching a standalone Python build when GitHub's release CDN returns a transient error, so a momentary `5xx` or
+rate-limit response no longer fails the install.

--- a/src/pipx/standalone_python.py
+++ b/src/pipx/standalone_python.py
@@ -10,15 +10,19 @@ import re
 import shutil
 import tarfile
 import tempfile
+import time
 import urllib.error
 from functools import partial
 from pathlib import Path, PurePosixPath
-from typing import Any, Final, TypedDict, cast
+from typing import TYPE_CHECKING, Any, Final, TypedDict, cast
 from urllib.request import urlopen
 
 from pipx import constants, paths
 from pipx.animate import animate
 from pipx.util import PipxError
+
+if TYPE_CHECKING:
+    import http.client
 
 _LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
@@ -54,6 +58,11 @@ PYTHON_VERSION_REGEX: Final[re.Pattern[str]] = re.compile(r"cpython-(\d+\.\d+\.\
 _URL_OPEN_TIMEOUT: Final[float] = 30
 _INDEX_MAX_AGE: Final[datetime.timedelta] = datetime.timedelta(days=30)
 _RELEASE_ENTRY_LEN: Final[int] = 2
+_DOWNLOAD_ATTEMPTS: Final[int] = 3
+_DOWNLOAD_BACKOFF_SECONDS: Final[float] = 2.0
+# GitHub's release CDN answers with transient 5xx (and 429 under rate limiting) often enough that a single failure
+# should not abort a download; these statuses are safe to retry, unlike a 404 for a genuinely missing build.
+_RETRYABLE_HTTP_STATUS: Final[frozenset[int]] = frozenset({429, 500, 502, 503, 504})
 
 
 class _PythonIndex(TypedDict):
@@ -131,13 +140,29 @@ def _download(full_version: str, download_link: str, archive: Path) -> None:
             # ballooning memory usage, we read the file in chunks
             # download_link comes from the pinned GitHub release index
             with (
-                urlopen(download_link, timeout=_URL_OPEN_TIMEOUT) as response,  # noqa: S310  # release index URL
+                _urlopen_retrying(download_link) as response,
                 Path(archive).open("wb") as file_handle,
             ):
                 file_handle.writelines(iter(partial(response.read, 32768), b""))
         except urllib.error.URLError as e:
             msg = f"Unable to download python {full_version} build."
             raise PipxError(msg) from e
+
+
+def _urlopen_retrying(url: str) -> http.client.HTTPResponse:
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            return urlopen(url, timeout=_URL_OPEN_TIMEOUT)  # noqa: S310  # pinned GitHub release URL
+        except urllib.error.URLError as error:
+            retryable = not isinstance(error, urllib.error.HTTPError) or error.code in _RETRYABLE_HTTP_STATUS
+            if not retryable or attempt >= _DOWNLOAD_ATTEMPTS:
+                raise
+            _LOGGER.debug(
+                "download attempt %d/%d for %s failed (%s); retrying", attempt, _DOWNLOAD_ATTEMPTS, url, error
+            )
+            time.sleep(_DOWNLOAD_BACKOFF_SECONDS * attempt)
 
 
 def _unpack(full_version: str, archive: Path, download_dir: Path, expected_checksum: str) -> None:

--- a/tests/test_standalone_interpreter.py
+++ b/tests/test_standalone_interpreter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import email.message
 import hashlib
 import io
 import json
@@ -8,6 +9,7 @@ import shutil
 import subprocess
 import sys
 import tarfile
+import urllib.error
 import warnings
 from dataclasses import replace
 from pathlib import Path
@@ -218,6 +220,58 @@ def test_standalone_python_upgrade_restores_backup_when_swap_fails(
         standalone_python.download_python_build_standalone("3.99", override=True)
 
     assert (install_dir / "keepme").read_text(encoding="utf-8") == "v1"
+
+
+def _http_error(code: int) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError("https://example.invalid", code, "boom", email.message.Message(), None)
+
+
+@pytest.mark.usefixtures("pipx_temp_env")
+def test_standalone_python_download_retries_transient_http_error(
+    published_darwin_release: tuple[Path, Callable[[bytes], None]],
+    mocker: MockerFixture,
+) -> None:
+    _, publish = published_darwin_release
+    archive_bytes = _python_archive_bytes()
+    publish(archive_bytes)
+    mocker.patch.object(standalone_python, "urlopen", side_effect=[_http_error(503), io.BytesIO(archive_bytes)])
+    sleep = mocker.patch.object(standalone_python.time, "sleep")
+
+    python_path = standalone_python.download_python_build_standalone("3.99")
+
+    assert (Path(python_path).is_file(), sleep.call_count) == (True, 1)
+
+
+@pytest.mark.usefixtures("pipx_temp_env")
+def test_standalone_python_download_does_not_retry_missing_build(
+    published_darwin_release: tuple[Path, Callable[[bytes], None]],
+    mocker: MockerFixture,
+) -> None:
+    _, publish = published_darwin_release
+    publish(_python_archive_bytes())
+    mocker.patch.object(standalone_python, "urlopen", side_effect=_http_error(404))
+    sleep = mocker.patch.object(standalone_python.time, "sleep")
+
+    with pytest.raises(standalone_python.PipxError, match="Unable to download"):
+        standalone_python.download_python_build_standalone("3.99")
+
+    assert sleep.call_count == 0
+
+
+@pytest.mark.usefixtures("pipx_temp_env")
+def test_standalone_python_download_gives_up_after_repeated_failures(
+    published_darwin_release: tuple[Path, Callable[[bytes], None]],
+    mocker: MockerFixture,
+) -> None:
+    _, publish = published_darwin_release
+    publish(_python_archive_bytes())
+    mocker.patch.object(standalone_python, "urlopen", side_effect=_http_error(500))
+    sleep = mocker.patch.object(standalone_python.time, "sleep")
+
+    with pytest.raises(standalone_python.PipxError, match="Unable to download"):
+        standalone_python.download_python_build_standalone("3.99")
+
+    assert sleep.call_count == 2
 
 
 def test_get_latest_python_releases_sets_request_timeout(mocker: MockerFixture) -> None:


### PR DESCRIPTION
When pipx cannot find a suitable interpreter and `--fetch-python` is set, it downloads a ~32MB standalone build from GitHub's release CDN. That CDN intermittently answers `5xx` (and `429` under rate limiting), and a single such response aborted the whole install with `Unable to download python <version> build`. 🐛 The same flake failed CI: a test that fetches a real build hit an HTTP 500 on a macOS runner.

The download now retries a few times with linear backoff on the retryable HTTP statuses (`429`, `500`, `502`, `503`, `504`) and on network/timeout errors, so a momentary hiccup no longer fails the operation. A `404` for a genuinely missing build still fails fast, since retrying it would only waste time.
