### PR TITLE
📝 docs: strip the prompt from copied console snippets

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -39,3 +39,26 @@
         margin-right: auto;
     }
 }
+
+/* Console prompts render as an accented "❯". The reStructuredText source keeps Pygments' literal "$ " prompt so the
+   command after it still gets shell highlighting and sphinx-copybutton can strip it on copy; only the shown glyph and
+   its colour change here. font-size:0 collapses the "$ " text so ::before can stand in; the glyph is sized in rem
+   rather than furo's --code-font-size, whose 81.25% would resolve against the zeroed parent to 0. */
+.highlight .gp {
+    font-size: 0;
+    user-select: none;
+}
+
+.highlight .gp::before {
+    content: "❯ ";
+    font-size: 0.8125rem;
+}
+
+/* Accent the prompt in the pipx brand colour (::before inherits it). furo's pygments sheet colours the prompt grey
+   through higher-specificity "body[data-theme=…]" selectors that also fire in OS-default light, so mirror them to win
+   the accent across explicit-light, explicit-dark, and no-preference states. */
+.highlight .gp,
+body[data-theme="dark"] .highlight .gp,
+body:not([data-theme="light"]) .highlight .gp {
+    color: var(--color-brand-content);
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -78,6 +78,12 @@ autosectionlabel_maxdepth = 2
 # a later one.
 codeautolink_concat_default = True
 
+# The console blocks keep a literal "$ " prompt so Pygments detects the prompt and highlights the command after it
+# (custom.css restyles that glyph). Strip the prompt on copy and drop the output lines, so the clipboard holds just the
+# command. The trailing space keeps the match from catching shell variables like $HOME.
+copybutton_prompt_text = "$ "
+copybutton_prompt_is_regexp = False
+
 # Read the Docs builds from a shallow clone, so sphinx-last-updated-by-git cannot see far enough back to stamp some
 # pages and warns "Git clone too shallow"; under -W that would fail the build. The stamp still resolves for pages within
 # the clone depth and degrades to the build date otherwise.


### PR DESCRIPTION
Copying a console example from the docs put the shell prompt on the clipboard along with the command, so pasting `$ pipx reinstall black` into a terminal failed. 📋 The prompt marks the line as a command and does not belong on the clipboard.

This tells `sphinx-copybutton` to strip the `$ ` prompt and drop the output lines, so the clipboard holds just the command. The source keeps the literal prompt, where Pygments needs it to detect the command and highlight what follows, and `custom.css` restyles the glyph to a `❯` in the pipx brand colour. The trailing space in the match keeps it from touching shell variables like `$HOME`, and the accent mirrors furo's own theme-scoped prompt selectors, which otherwise grey it out for readers on the OS default with no stored theme preference.

The rendered prompt now reads `❯` and copies clean across light, dark, and no-preference themes. Bare command lines still carry no token colour beyond the prompt, since `pipx reinstall black` gives Pygments no strings or operators to highlight.
