### PR TITLE
fix: don't crash on non-UTF8 shebang in foreign bin-dir executables

### DIFF
--- a/changelog.d/1965.bugfix.md
+++ b/changelog.d/1965.bugfix.md
@@ -1,0 +1,3 @@
+Stop crashing `install`/`list` with an unhandled `UnicodeDecodeError` when the bin directory contains a
+foreign binary that isn't a launcher pipx created (for example another CLI tool's `.exe` sharing
+`~/.local/bin` on Windows); such files are now treated as not owned by the venv.

--- a/changelog.d/1965.bugfix.md
+++ b/changelog.d/1965.bugfix.md
@@ -1,3 +1,3 @@
-Stop crashing `install`/`list` with an unhandled `UnicodeDecodeError` when the bin directory contains a
-foreign binary that isn't a launcher pipx created (for example another CLI tool's `.exe` sharing
-`~/.local/bin` on Windows); such files are now treated as not owned by the venv.
+Stop crashing `install`/`list` with an unhandled `UnicodeDecodeError` when the bin directory contains a foreign binary
+that isn't a launcher pipx created (for example another CLI tool's `.exe` sharing `~/.local/bin` on Windows); such files
+are now treated as not owned by the venv.

--- a/changelog.d/1965.bugfix.md
+++ b/changelog.d/1965.bugfix.md
@@ -1,3 +1,4 @@
-Stop crashing `install`/`list` with an unhandled `UnicodeDecodeError` when the bin directory contains a foreign binary
-that isn't a launcher pipx created (for example another CLI tool's `.exe` sharing `~/.local/bin` on Windows); such files
-are now treated as not owned by the venv.
+Stop `install` and `list` from crashing when the pipx bin directory contains an executable pipx did not create.
+Scanning for launcher ownership decoded arbitrary binary content as an interpreter path, which raised
+`UnicodeDecodeError` on Windows, or `ValueError` for a path holding a NUL byte. Such a file is now treated as not
+owned by the venv.

--- a/changelog.d/1965.bugfix.md
+++ b/changelog.d/1965.bugfix.md
@@ -1,4 +1,3 @@
-Stop `install` and `list` from crashing when the pipx bin directory contains an executable pipx did not create.
-Scanning for launcher ownership decoded arbitrary binary content as an interpreter path, which raised
-`UnicodeDecodeError` on Windows, or `ValueError` for a path holding a NUL byte. Such a file is now treated as not
-owned by the venv.
+Stop `install` and `list` from crashing when the pipx bin directory contains an executable pipx did not create. Scanning
+for launcher ownership decoded arbitrary binary content as an interpreter path, which raised `UnicodeDecodeError` on
+Windows, or `ValueError` for a path holding a NUL byte. Such a file is now treated as not owned by the venv.

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -425,7 +425,10 @@ def _copy_launcher_targets_venv(resource_path: Path, venv_resource_path: Path) -
         try:
             if interpreter and Path(os.fsdecode(interpreter)).parent.samefile(venv_resource_path):
                 return True
-        except (OSError, UnicodeDecodeError):
+        except (OSError, ValueError):
+            # The scan reads every file in the bin directory, so a stray "#!" in a foreign binary leads here with
+            # arbitrary bytes rather than a path: os.fsdecode rejects undecodable ones under the surrogatepass
+            # codec Windows uses, and stat rejects an embedded NUL. Neither makes the copy ours.
             continue
     return False
 

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -425,7 +425,7 @@ def _copy_launcher_targets_venv(resource_path: Path, venv_resource_path: Path) -
         try:
             if interpreter and Path(os.fsdecode(interpreter)).parent.samefile(venv_resource_path):
                 return True
-        except OSError:
+        except (OSError, UnicodeDecodeError):
             continue
     return False
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -50,7 +50,8 @@ def test_copy_launcher_targets_venv_ignores_invalid_utf8_shebang(
 
     def raise_unicode_decode_error(*_args: object, **_kwargs: object) -> str:
         reason = "invalid continuation byte"
-        raise UnicodeDecodeError("utf-8", b"\xeb", 0, 1, reason)
+        msg = "utf-8"
+        raise UnicodeDecodeError(msg, b"\xeb", 0, 1, reason)
 
     monkeypatch.setattr(os, "fsdecode", raise_unicode_decode_error)
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -9,8 +9,8 @@ import pytest
 
 from helpers import run_pipx_cli, skip_if_windows
 from pipx import paths
+from pipx.commands import common
 from pipx.commands.common import (
-    _copy_launcher_targets_venv,  # noqa: PLC2701  # test exercises private helper, no public API
     _remove_stale_venv_resources,  # noqa: PLC2701  # test exercises private helper, no public API
     expose_resources_globally,
     get_exposed_paths_for_package,
@@ -19,6 +19,8 @@ from pipx.venv import Venv
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from pytest_mock import MockerFixture
 
 
 @skip_if_windows
@@ -35,27 +37,29 @@ def test_get_exposed_paths_ignores_recursive_symlink(tmp_path: Path) -> None:
     assert loop not in exposed
 
 
-def test_copy_launcher_targets_venv_ignores_invalid_utf8_shebang(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    # Regression test for #1965: a foreign binary sharing the bin dir (e.g. an unrelated multi-hundred-MB
-    # .exe) can contain a stray b"#!" byte pair followed by bytes that aren't valid UTF-8. On Windows,
-    # os.fsdecode raises UnicodeDecodeError for such bytes instead of silently escaping them like POSIX's
-    # surrogateescape does, which used to crash `pipx install`/`pipx list` outright. Reproduce that failure
-    # mode deterministically here by forcing os.fsdecode to raise, regardless of the host platform.
+# A binary pipx did not create is parsed as if it were a launcher, so the bytes trailing a stray "#!" reach
+# os.fsdecode and stat as an interpreter path. Windows rejects the undecodable one, every platform the NUL.
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(b"MZ\x90\x00\x03#!\xff\xfe\x80\x81 more binary\n", id="undecodable-interpreter"),
+        pytest.param(b"MZ\x90\x00\x03#!/opt/no\x00pe/bin/python\n", id="nul-in-interpreter"),
+    ],
+)
+def test_get_exposed_paths_ignores_foreign_binary(tmp_path: Path, mocker: MockerFixture, payload: bytes) -> None:
+    # Only copy-based environments read a shebang to establish ownership, so without this the symlink branch
+    # short-circuits the scan and the parse under test never runs off Windows.
+    mocker.patch.object(common, "can_symlink", autospec=True, return_value=False)
     venv_resource_path = tmp_path / "venv_bin"
     venv_resource_path.mkdir()
-    resource_path = tmp_path / "unrelated.exe"
-    resource_path.write_bytes(b"\x00" * 32 + b"#!" + bytes([0xEB, 0x00, 0x01]) + b"\x00" * 32)
+    local_resource_dir = tmp_path / "bin"
+    local_resource_dir.mkdir()
+    foreign = local_resource_dir / "foreign.exe"
+    foreign.write_bytes(payload)
 
-    def raise_unicode_decode_error(*_args: object, **_kwargs: object) -> str:
-        reason = "invalid continuation byte"
-        msg = "utf-8"
-        raise UnicodeDecodeError(msg, b"\xeb", 0, 1, reason)
+    exposed = get_exposed_paths_for_package(venv_resource_path, local_resource_dir)
 
-    monkeypatch.setattr(os, "fsdecode", raise_unicode_decode_error)
-
-    assert _copy_launcher_targets_venv(resource_path, venv_resource_path) is False
+    assert foreign not in exposed
 
 
 @skip_if_windows

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -10,6 +10,7 @@ import pytest
 from helpers import run_pipx_cli, skip_if_windows
 from pipx import paths
 from pipx.commands.common import (
+    _copy_launcher_targets_venv,  # noqa: PLC2701  # test exercises private helper, no public API
     _remove_stale_venv_resources,  # noqa: PLC2701  # test exercises private helper, no public API
     expose_resources_globally,
     get_exposed_paths_for_package,
@@ -32,6 +33,28 @@ def test_get_exposed_paths_ignores_recursive_symlink(tmp_path: Path) -> None:
     exposed = get_exposed_paths_for_package(venv_resource_path, local_resource_dir)
 
     assert loop not in exposed
+
+
+def test_copy_launcher_targets_venv_ignores_invalid_utf8_shebang(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Regression test for #1965: a foreign binary sharing the bin dir (e.g. an unrelated multi-hundred-MB
+    # .exe) can contain a stray b"#!" byte pair followed by bytes that aren't valid UTF-8. On Windows,
+    # os.fsdecode raises UnicodeDecodeError for such bytes instead of silently escaping them like POSIX's
+    # surrogateescape does, which used to crash `pipx install`/`pipx list` outright. Reproduce that failure
+    # mode deterministically here by forcing os.fsdecode to raise, regardless of the host platform.
+    venv_resource_path = tmp_path / "venv_bin"
+    venv_resource_path.mkdir()
+    resource_path = tmp_path / "unrelated.exe"
+    resource_path.write_bytes(b"\x00" * 32 + b"#!" + bytes([0xEB, 0x00, 0x01]) + b"\x00" * 32)
+
+    def raise_unicode_decode_error(*_args: object, **_kwargs: object) -> str:
+        reason = "invalid continuation byte"
+        raise UnicodeDecodeError("utf-8", b"\xeb", 0, 1, reason)
+
+    monkeypatch.setattr(os, "fsdecode", raise_unicode_decode_error)
+
+    assert _copy_launcher_targets_venv(resource_path, venv_resource_path) is False
 
 
 @skip_if_windows


### PR DESCRIPTION
Fixes #1965

## Summary

`pipx install` and `pipx list` crash with an unhandled `UnicodeDecodeError`
when the pipx bin directory contains a file that isn't a launcher pipx
created — for example another CLI tool's large standalone `.exe` sharing
`~/.local/bin` on Windows.

## Root cause

While determining which bin-dir resources are owned by a venv,
`_copy_launcher_targets_venv` (`src/pipx/commands/common.py`) scans a
file's *entire* byte content for a `#!` marker and decodes whatever follows
as the launcher's interpreter path via `os.fsdecode()`. For a large
unrelated binary, a stray `#!` byte pair can occur anywhere in the file,
and the bytes that happen to follow it are effectively random — not valid
UTF-8.

On Windows, `os.fsdecode()` uses the `utf-8`/`surrogatepass` codec, which
(unlike POSIX's `surrogateescape`) does not rescue genuinely invalid byte
sequences, so it raises `UnicodeDecodeError`. That exception wasn't in the
existing `except OSError:` guard, so it propagated and aborted the whole
`install`/`list` command instead of just being treated as "not a pipx
launcher."

## Fix

Widen the `except OSError:` to also catch `UnicodeDecodeError`, so a
malformed/foreign file at that stage is simply treated as not owned by the
venv, matching the handling already in place for other malformed-launcher
conditions.

## Testing

- Added `test_copy_launcher_targets_venv_ignores_invalid_utf8_shebang` in
  `tests/test_common.py`, which reproduces the failure deterministically
  (independent of host OS) by forcing `os.fsdecode` to raise
  `UnicodeDecodeError`, and asserts the function now returns `False`
  instead of propagating.
- Verified against the pre-fix code that the test fails with the exact
  traceback reported in #1965, and passes with the fix applied.
- Full `tests/test_common.py` suite passes locally.
- Ran the "tests" GitHub Actions workflow on a fork branch: all jobs green
  across Python 3.10–3.14 on Ubuntu, macOS, and **Windows** (the platform
  the bug is specific to).

## Use of AI tools

This PR — diagnosis, the fix itself, the regression test, and this
description — was developed with the assistance of Claude (Anthropic's
Claude Code), working from the traceback and repro steps in #1965. The
change has been reviewed by me, although I do not have a specific
competence of this codebase.

## Checklist

- [x] ran the linter to address style issues (`pre-commit run --all-files`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `changelog.d/` folder (`changelog.d/1965.bugfix.md`)
- [ ] updated/extended the documentation *(not applicable — internal
      resource-ownership logic, no user-facing behavior/API change)*