### PR TITLE
fix: don't crash on a foreign executable in the pipx bin directory

### DIFF
--- a/changelog.d/1965.bugfix.md
+++ b/changelog.d/1965.bugfix.md
@@ -1,1 +1,3 @@
-Stop `install` and `list` from crashing when the pipx bin directory contains an executable pipx did not create. Scanning for launcher ownership decoded arbitrary binary content as a path, which raised `UnicodeDecodeError` on Windows, or `ValueError` for a path containing a NUL byte. Such a file is now treated as not belonging to the venv.
+Stop `install` and `list` from crashing when the pipx bin directory contains an executable pipx did not create. Scanning
+for launcher ownership decoded arbitrary binary content as a path, which raised `UnicodeDecodeError` on Windows, or
+`ValueError` for a path containing a NUL byte. Such a file is now treated as not belonging to the venv.

--- a/changelog.d/1965.bugfix.md
+++ b/changelog.d/1965.bugfix.md
@@ -1,0 +1,1 @@
+Stop `install` and `list` from crashing when the pipx bin directory contains an executable pipx did not create. Scanning for launcher ownership decoded arbitrary binary content as a path, which raised `UnicodeDecodeError` on Windows, or `ValueError` for a path containing a NUL byte. Such a file is now treated as not belonging to the venv.

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -426,10 +426,9 @@ def _copy_launcher_targets_venv(resource_path: Path, venv_resource_path: Path) -
             if interpreter and Path(os.fsdecode(interpreter)).parent.samefile(venv_resource_path):
                 return True
         except (OSError, ValueError):
-            # Any file in the bin directory is scanned, including binaries pipx did not
-            # create, so these bytes are not necessarily a path. ValueError covers both
-            # `os.fsdecode` rejecting non-UTF-8 bytes (Windows uses surrogatepass) and
-            # `stat` rejecting an embedded NUL. Neither means the copy is ours.
+            # The scan reads every file in the bin directory, so a stray "#!" in a foreign binary leads here with
+            # arbitrary bytes rather than a path: os.fsdecode rejects undecodable ones under the surrogatepass
+            # codec Windows uses, and stat rejects an embedded NUL. Neither makes the copy ours.
             continue
     return False
 

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -425,7 +425,11 @@ def _copy_launcher_targets_venv(resource_path: Path, venv_resource_path: Path) -
         try:
             if interpreter and Path(os.fsdecode(interpreter)).parent.samefile(venv_resource_path):
                 return True
-        except OSError:
+        except (OSError, ValueError):
+            # Any file in the bin directory is scanned, including binaries pipx did not
+            # create, so these bytes are not necessarily a path. ValueError covers both
+            # `os.fsdecode` rejecting non-UTF-8 bytes (Windows uses surrogatepass) and
+            # `stat` rejecting an embedded NUL. Neither means the copy is ours.
             continue
     return False
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -34,6 +34,35 @@ def test_get_exposed_paths_ignores_recursive_symlink(tmp_path: Path) -> None:
     assert loop not in exposed
 
 
+@pytest.mark.parametrize(
+    ("name", "payload"),
+    [
+        # Non-UTF-8 bytes after the marker. os.fsdecode rejects these on Windows,
+        # whose filesystem encoding is utf-8/surrogatepass.
+        ("undecodable", b"MZ\x90\x00\x03#!\xff\xfe\x80\x81 more binary\n"),
+        # A NUL inside the would-be path. os.fsdecode accepts it, then stat rejects it.
+        ("embedded-nul", b"MZ\x90\x00\x03#!/opt/no\x00pe/bin/python\n"),
+    ],
+)
+def test_get_exposed_paths_ignores_foreign_binary(tmp_path: Path, name: str, payload: bytes) -> None:
+    """A binary pipx did not create must not abort the scan.
+
+    Every file in the bin directory is read looking for a launcher's "#!" line, so an
+    unrelated executable dropped there by another installer is parsed as if it were one.
+    Neither failure below means the file belongs to the venv.
+    """
+    venv_resource_path = tmp_path / "venv_bin"
+    venv_resource_path.mkdir()
+    local_resource_dir = tmp_path / "bin"
+    local_resource_dir.mkdir()
+    foreign = local_resource_dir / name
+    foreign.write_bytes(payload)
+
+    exposed = get_exposed_paths_for_package(venv_resource_path, local_resource_dir)
+
+    assert foreign not in exposed
+
+
 @skip_if_windows
 def test_expose_app_scripts_ignores_pythonpath(tmp_path: Path) -> None:
     venv_resource_path = tmp_path / "venv_bin"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -9,6 +9,7 @@ import pytest
 
 from helpers import run_pipx_cli, skip_if_windows
 from pipx import paths
+from pipx.commands import common
 from pipx.commands.common import (
     _remove_stale_venv_resources,  # noqa: PLC2701  # test exercises private helper, no public API
     expose_resources_globally,
@@ -18,6 +19,8 @@ from pipx.venv import Venv
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from pytest_mock import MockerFixture
 
 
 @skip_if_windows
@@ -34,28 +37,24 @@ def test_get_exposed_paths_ignores_recursive_symlink(tmp_path: Path) -> None:
     assert loop not in exposed
 
 
+# A binary pipx did not create is parsed as if it were a launcher, so the bytes trailing a stray "#!" reach
+# os.fsdecode and stat as an interpreter path. Windows rejects the undecodable one, every platform the NUL.
 @pytest.mark.parametrize(
-    ("name", "payload"),
+    "payload",
     [
-        # Non-UTF-8 bytes after the marker. os.fsdecode rejects these on Windows,
-        # whose filesystem encoding is utf-8/surrogatepass.
-        ("undecodable", b"MZ\x90\x00\x03#!\xff\xfe\x80\x81 more binary\n"),
-        # A NUL inside the would-be path. os.fsdecode accepts it, then stat rejects it.
-        ("embedded-nul", b"MZ\x90\x00\x03#!/opt/no\x00pe/bin/python\n"),
+        pytest.param(b"MZ\x90\x00\x03#!\xff\xfe\x80\x81 more binary\n", id="undecodable-interpreter"),
+        pytest.param(b"MZ\x90\x00\x03#!/opt/no\x00pe/bin/python\n", id="nul-in-interpreter"),
     ],
 )
-def test_get_exposed_paths_ignores_foreign_binary(tmp_path: Path, name: str, payload: bytes) -> None:
-    """A binary pipx did not create must not abort the scan.
-
-    Every file in the bin directory is read looking for a launcher's "#!" line, so an
-    unrelated executable dropped there by another installer is parsed as if it were one.
-    Neither failure below means the file belongs to the venv.
-    """
+def test_get_exposed_paths_ignores_foreign_binary(tmp_path: Path, mocker: MockerFixture, payload: bytes) -> None:
+    # Only copy-based environments read a shebang to establish ownership, so without this the symlink branch
+    # short-circuits the scan and the parse under test never runs off Windows.
+    mocker.patch.object(common, "can_symlink", autospec=True, return_value=False)
     venv_resource_path = tmp_path / "venv_bin"
     venv_resource_path.mkdir()
     local_resource_dir = tmp_path / "bin"
     local_resource_dir.mkdir()
-    foreign = local_resource_dir / name
+    foreign = local_resource_dir / "foreign.exe"
     foreign.write_bytes(payload)
 
     exposed = get_exposed_paths_for_package(venv_resource_path, local_resource_dir)


### PR DESCRIPTION
## Summary

Fixes #1965. `pipx install`/`pipx list` crashed with an unhandled `UnicodeDecodeError` when the bin directory contained an executable pipx did not create (in the report, a ~250 MB `claude.exe` dropped there by an unrelated installer).

`_copy_launcher_targets_venv` reads **every** file in the bin directory looking for a launcher's `#!` line, so an unrelated binary gets parsed as if it were one. The bytes after the marker were then passed to `os.fsdecode` and `Path.samefile`, guarded only by `OSError` — but neither failure mode is an `OSError`:

| failure | raised | caught by `except OSError`? |
| --- | --- | --- |
| `os.fsdecode` on non-UTF-8 bytes | `UnicodeDecodeError` | no |
| `stat` on a path containing a NUL | `ValueError` | no |

Both are `ValueError` subclasses, so catching `ValueError` alongside `OSError` fixes both, and the file keeps being treated as "not owned by this venv" — which is what it is.

## Two platforms, two failure modes

Worth flagging, because the second one isn't in the report:

- **Windows** uses `utf-8`/`surrogatepass`, so undecodable bytes raise `UnicodeDecodeError`. This is the reported crash.
- **POSIX** uses `surrogateescape`, so `fsdecode` never raises there — but a decoded path containing a NUL byte still reaches `stat`, which raises `ValueError: embedded null character in path`. Arbitrary binary content contains NULs constantly, so the same class of bug is reachable off Windows too.

Verified both on Windows 11 / CPython 3.12:

```
invalid utf-8: fsdecode raised UnicodeDecodeError (ValueError? True, OSError? False)
NUL in dir component -> ValueError | ValueError? True | OSError? False | stat: embedded null character in path
```

## Tests

`test_get_exposed_paths_ignores_foreign_binary` is parametrized over both payloads and goes through the public `get_exposed_paths_for_package`, so it exercises the real path from the traceback rather than the private helper.

Deliberately **not** marked `@skip_if_windows`: the `undecodable` case is the Windows-specific one, and the `embedded-nul` case is the guard that still bites on POSIX, so between them the pair is meaningful on every platform.

Confirmed they catch the real bug by reverting only `src/` and re-running:

```
E   UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte
E   ValueError: stat: embedded null character in path
2 failed
```

## Verification

- `pytest tests/test_common.py` → **2 passed, 3 skipped** (the 3 skips are the pre-existing `@skip_if_windows` tests)
- `ruff check src tests` → all checks passed; `ruff format --check` → 106 files already formatted
- Added `changelog.d/1965.bugfix.md`, matching the numbered towncrier convention

Note on how I ran the suite: I passed `--net-pypiserver` so the session-scoped local pypiserver fixture short-circuits. These tests do no network or package I/O, so it doesn't affect what they assert — it just avoids building the package cache locally.
