### PR TITLE
fix: handle UnicodeDecodeError in _copy_launcher_targets_venv

### DIFF
--- a/changelog.d/1965.bugfix.md
+++ b/changelog.d/1965.bugfix.md
@@ -1,0 +1,4 @@
+Stop `install` and `list` from crashing when the pipx bin directory contains an executable pipx did not create.
+Scanning for launcher ownership decoded arbitrary binary content as an interpreter path, which raised
+`UnicodeDecodeError` on Windows, or `ValueError` for a path holding a NUL byte. Such a file is now treated as not
+owned by the venv.

--- a/changelog.d/1965.bugfix.md
+++ b/changelog.d/1965.bugfix.md
@@ -1,4 +1,3 @@
-Stop `install` and `list` from crashing when the pipx bin directory contains an executable pipx did not create.
-Scanning for launcher ownership decoded arbitrary binary content as an interpreter path, which raised
-`UnicodeDecodeError` on Windows, or `ValueError` for a path holding a NUL byte. Such a file is now treated as not
-owned by the venv.
+Stop `install` and `list` from crashing when the pipx bin directory contains an executable pipx did not create. Scanning
+for launcher ownership decoded arbitrary binary content as an interpreter path, which raised `UnicodeDecodeError` on
+Windows, or `ValueError` for a path holding a NUL byte. Such a file is now treated as not owned by the venv.

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -425,7 +425,10 @@ def _copy_launcher_targets_venv(resource_path: Path, venv_resource_path: Path) -
         try:
             if interpreter and Path(os.fsdecode(interpreter)).parent.samefile(venv_resource_path):
                 return True
-        except (OSError, UnicodeDecodeError):
+        except (OSError, ValueError):
+            # The scan reads every file in the bin directory, so a stray "#!" in a foreign binary leads here with
+            # arbitrary bytes rather than a path: os.fsdecode rejects undecodable ones under the surrogatepass
+            # codec Windows uses, and stat rejects an embedded NUL. Neither makes the copy ours.
             continue
     return False
 

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -425,7 +425,7 @@ def _copy_launcher_targets_venv(resource_path: Path, venv_resource_path: Path) -
         try:
             if interpreter and Path(os.fsdecode(interpreter)).parent.samefile(venv_resource_path):
                 return True
-        except OSError:
+        except (OSError, UnicodeDecodeError):
             continue
     return False
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -9,8 +9,8 @@ import pytest
 
 from helpers import run_pipx_cli, skip_if_windows
 from pipx import paths
+from pipx.commands import common
 from pipx.commands.common import (
-    _copy_launcher_targets_venv,
     _remove_stale_venv_resources,  # noqa: PLC2701  # test exercises private helper, no public API
     expose_resources_globally,
     get_exposed_paths_for_package,
@@ -19,6 +19,8 @@ from pipx.venv import Venv
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from pytest_mock import MockerFixture
 
 
 @skip_if_windows
@@ -85,52 +87,46 @@ def test_remove_stale_venv_resources_keeps_files_pipx_does_not_own(capsys: pytes
     assert (owned.exists(), replaced.read_text()) == (False, "belongs to the user")
 
 
-def test_copy_launcher_targets_venv_unicode_decode_error(tmp_path: Path) -> None:
-    """_copy_launcher_targets_venv returns False for non-UTF8 file."""
+# A binary pipx did not create is parsed as if it were a launcher, so the bytes trailing a stray "#!" reach
+# os.fsdecode and stat as an interpreter path. Windows rejects the undecodable one, every platform the NUL.
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(b"MZ\x90\x00\x03#!\xff\xfe\x80\x81 more binary\n", id="undecodable-interpreter"),
+        pytest.param(b"MZ\x90\x00\x03#!/opt/no\x00pe/bin/python\n", id="nul-in-interpreter"),
+    ],
+)
+def test_get_exposed_paths_ignores_foreign_binary(tmp_path: Path, mocker: MockerFixture, payload: bytes) -> None:
+    # Only copy-based environments read a shebang to establish ownership, so without this the symlink branch
+    # short-circuits the scan and the parse under test never runs off Windows.
+    mocker.patch.object(common, "can_symlink", autospec=True, return_value=False)
     venv_resource_path = tmp_path / "venv_bin"
     venv_resource_path.mkdir()
     local_resource_dir = tmp_path / "bin"
     local_resource_dir.mkdir()
+    foreign = local_resource_dir / "foreign.exe"
+    foreign.write_bytes(payload)
 
-    # Create a non-UTF8 file in the local bin directory
-    non_utf8_file = local_resource_dir / "weird.exe"
-    non_utf8_file.write_bytes(b"\xff\xfe")  # Invalid UTF-8
+    exposed = get_exposed_paths_for_package(venv_resource_path, local_resource_dir)
 
-    # Should return False without raising UnicodeDecodeError
-    assert not _copy_launcher_targets_venv(non_utf8_file, venv_resource_path)
+    assert foreign not in exposed
 
 
-def test_copy_launcher_targets_venv_valid_launcher(tmp_path: Path) -> None:
-    """_copy_launcher_targets_venv returns True for a launcher pointing to venv."""
+@pytest.mark.parametrize(
+    "owned",
+    [pytest.param(True, id="shebang-into-venv"), pytest.param(False, id="shebang-elsewhere")],
+)
+def test_get_exposed_paths_matches_copied_launcher(tmp_path: Path, mocker: MockerFixture, owned: bool) -> None:
+    mocker.patch.object(common, "can_symlink", autospec=True, return_value=False)
     venv_resource_path = tmp_path / "venv_bin"
     venv_resource_path.mkdir()
     local_resource_dir = tmp_path / "bin"
     local_resource_dir.mkdir()
-
-    # Create a launcher with a shebang pointing to the venv's python
+    elsewhere = tmp_path / "other"
+    elsewhere.mkdir()
     launcher = local_resource_dir / "myapp"
-    shebang = f"#!{venv_resource_path / 'python'}\nprint('hello')"
-    launcher.write_text(shebang, encoding="utf-8")
-    launcher.chmod(0o755)
+    launcher.write_text(f"#!{(venv_resource_path if owned else elsewhere) / 'python'}\n")
 
-    # Should return True
-    assert _copy_launcher_targets_venv(launcher, venv_resource_path)
+    exposed = get_exposed_paths_for_package(venv_resource_path, local_resource_dir)
 
-
-def test_copy_launcher_targets_venv_launcher_pointing_outside(tmp_path: Path) -> None:
-    """_copy_launcher_targets_venv returns False for launcher pointing outside venv."""
-    venv_resource_path = tmp_path / "venv_bin"
-    venv_resource_path.mkdir()
-    local_resource_dir = tmp_path / "bin"
-    local_resource_dir.mkdir()
-    other_dir = tmp_path / "other"
-    other_dir.mkdir()
-
-    # Create a launcher with a shebang pointing to another directory
-    launcher = local_resource_dir / "myapp"
-    shebang = f"#!{other_dir / 'python'}\nprint('hello')"
-    launcher.write_text(shebang, encoding="utf-8")
-    launcher.chmod(0o755)
-
-    # Should return False
-    assert not _copy_launcher_targets_venv(launcher, venv_resource_path)
+    assert (launcher in exposed) is owned

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -11,6 +11,7 @@ from helpers import run_pipx_cli, skip_if_windows
 from pipx import paths
 from pipx.commands.common import (
     _remove_stale_venv_resources,  # noqa: PLC2701  # test exercises private helper, no public API
+    _copy_launcher_targets_venv,
     expose_resources_globally,
     get_exposed_paths_for_package,
 )
@@ -82,3 +83,54 @@ def test_remove_stale_venv_resources_keeps_files_pipx_does_not_own(capsys: pytes
     _remove_stale_venv_resources({owned, replaced}, venv, bin_dir, paths.ctx.man_dir)
 
     assert (owned.exists(), replaced.read_text()) == (False, "belongs to the user")
+
+
+def test_copy_launcher_targets_venv_unicode_decode_error(tmp_path: Path) -> None:
+    """_copy_launcher_targets_venv returns False for non-UTF8 file."""
+    venv_resource_path = tmp_path / "venv_bin"
+    venv_resource_path.mkdir()
+    local_resource_dir = tmp_path / "bin"
+    local_resource_dir.mkdir()
+
+    # Create a non-UTF8 file in the local bin directory
+    non_utf8_file = local_resource_dir / "weird.exe"
+    non_utf8_file.write_bytes(b'\xff\xfe')  # Invalid UTF-8
+
+    # Should return False without raising UnicodeDecodeError
+    assert not _copy_launcher_targets_venv(non_utf8_file, venv_resource_path)
+
+
+def test_copy_launcher_targets_venv_valid_launcher(tmp_path: Path) -> None:
+    """_copy_launcher_targets_venv returns True for a launcher pointing to venv."""
+    venv_resource_path = tmp_path / "venv_bin"
+    venv_resource_path.mkdir()
+    local_resource_dir = tmp_path / "bin"
+    local_resource_dir.mkdir()
+
+    # Create a launcher with a shebang pointing to the venv's python
+    launcher = local_resource_dir / "myapp"
+    shebang = f"#!{venv_resource_path / 'python'}\nprint('hello')"
+    launcher.write_text(shebang, encoding="utf-8")
+    launcher.chmod(0o755)
+
+    # Should return True
+    assert _copy_launcher_targets_venv(launcher, venv_resource_path)
+
+
+def test_copy_launcher_targets_venv_launcher_pointing_outside(tmp_path: Path) -> None:
+    """_copy_launcher_targets_venv returns False for launcher pointing outside venv."""
+    venv_resource_path = tmp_path / "venv_bin"
+    venv_resource_path.mkdir()
+    local_resource_dir = tmp_path / "bin"
+    local_resource_dir.mkdir()
+    other_dir = tmp_path / "other"
+    other_dir.mkdir()
+
+    # Create a launcher with a shebang pointing to another directory
+    launcher = local_resource_dir / "myapp"
+    shebang = f"#!{other_dir / 'python'}\nprint('hello')"
+    launcher.write_text(shebang, encoding="utf-8")
+    launcher.chmod(0o755)
+
+    # Should return False
+    assert not _copy_launcher_targets_venv(launcher, venv_resource_path)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -10,8 +10,8 @@ import pytest
 from helpers import run_pipx_cli, skip_if_windows
 from pipx import paths
 from pipx.commands.common import (
-    _remove_stale_venv_resources,  # noqa: PLC2701  # test exercises private helper, no public API
     _copy_launcher_targets_venv,
+    _remove_stale_venv_resources,  # noqa: PLC2701  # test exercises private helper, no public API
     expose_resources_globally,
     get_exposed_paths_for_package,
 )
@@ -94,7 +94,7 @@ def test_copy_launcher_targets_venv_unicode_decode_error(tmp_path: Path) -> None
 
     # Create a non-UTF8 file in the local bin directory
     non_utf8_file = local_resource_dir / "weird.exe"
-    non_utf8_file.write_bytes(b'\xff\xfe')  # Invalid UTF-8
+    non_utf8_file.write_bytes(b"\xff\xfe")  # Invalid UTF-8
 
     # Should return False without raising UnicodeDecodeError
     assert not _copy_launcher_targets_venv(non_utf8_file, venv_resource_path)


### PR DESCRIPTION
# fix: handle UnicodeDecodeError in _copy_launcher_targets_venv

## Summary

Fixes a crash (UnicodeDecodeError) that occurs when `pipx install` or `pipx list` encounters a non-UTF-8 executable file in the application's binary directory. The function `_copy_launcher_targets_venv` in `src/pipx/commands/common.py` was calling `os.fsdecode` on arbitrary bytes without handling decoding errors, causing an uncaught exception.

The fix wraps the `os.fsdecode` call in a try/except block that catches `UnicodeDecodeError` (and `OSError` for completeness) and returns `False`, indicating the resource does not belong to the venv, which allows the function to continue processing other files.

## Changes

- Modified `src/pipx/commands/common.py`: Wrapped the `os.fsdecode(interpreter)` call in a try/except block to catch `UnicodeDecodeError` and `OSError`, returning `False` on exception.
- Added unit tests in `tests/test_common.py`:
  - `test_copy_launcher_targets_venv_unicode_decode_error`: verifies that a non-UTF-8 file returns `False` without raising an exception.
  - `test_copy_launcher_targets_venv_valid_launcher`: ensures a valid launcher with a shebang pointing to the venv's python returns `True`.
  - `test_copy_launcher_targets_venv_launcher_pointing_outside`: ensures a launcher pointing outside the venv returns `False`.

## Testing

- Syntax check: `python3 -m py_compile src/pipx/commands/common.py` passed.
- Unit tests: Attempted to run the new and existing tests via `sandbox-run python -m pytest tests/test_common.py` but the sandbox environment encountered permission errors (`bwrap: setting up uid map: Permission denied`). Due to this environment issue, the tests were not executed in the sandbox. However, the changes are minimal and focused, and the new unit tests are designed to validate the fix.
- The existing tests in `tests/test_common.py` were not run due to the sandbox issue, but the change only adds exception handling and does not alter the existing success path.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
