### PR TITLE
🐛 fix: don't crash scanning a foreign binary in the bin dir

### DIFF
--- a/changelog.d/1965.bugfix.md
+++ b/changelog.d/1965.bugfix.md
@@ -1,0 +1,3 @@
+Stop `install` and `list` from crashing when the pipx bin directory contains an executable pipx did not create. Scanning
+for launcher ownership decoded arbitrary binary content as an interpreter path, which raised `UnicodeDecodeError` on
+Windows, or `ValueError` for a path holding a NUL byte. Such a file is now treated as not owned by the venv.

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -425,7 +425,10 @@ def _copy_launcher_targets_venv(resource_path: Path, venv_resource_path: Path) -
         try:
             if interpreter and Path(os.fsdecode(interpreter)).parent.samefile(venv_resource_path):
                 return True
-        except OSError:
+        except (OSError, ValueError):
+            # The scan reads every file in the bin directory, so a stray "#!" in a foreign binary leads here with
+            # arbitrary bytes rather than a path: os.fsdecode rejects undecodable ones under the surrogatepass
+            # codec Windows uses, and stat rejects an embedded NUL. Neither makes the copy ours.
             continue
     return False
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -9,6 +9,7 @@ import pytest
 
 from helpers import run_pipx_cli, skip_if_windows
 from pipx import paths
+from pipx.commands import common
 from pipx.commands.common import (
     _remove_stale_venv_resources,  # noqa: PLC2701  # test exercises private helper, no public API
     expose_resources_globally,
@@ -18,6 +19,8 @@ from pipx.venv import Venv
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from pytest_mock import MockerFixture
 
 
 @skip_if_windows
@@ -82,3 +85,48 @@ def test_remove_stale_venv_resources_keeps_files_pipx_does_not_own(capsys: pytes
     _remove_stale_venv_resources({owned, replaced}, venv, bin_dir, paths.ctx.man_dir)
 
     assert (owned.exists(), replaced.read_text()) == (False, "belongs to the user")
+
+
+# A binary pipx did not create is parsed as if it were a launcher, so the bytes trailing a stray "#!" reach
+# os.fsdecode and stat as an interpreter path. Windows rejects the undecodable one, every platform the NUL.
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(b"MZ\x90\x00\x03#!\xff\xfe\x80\x81 more binary\n", id="undecodable-interpreter"),
+        pytest.param(b"MZ\x90\x00\x03#!/opt/no\x00pe/bin/python\n", id="nul-in-interpreter"),
+    ],
+)
+def test_get_exposed_paths_ignores_foreign_binary(tmp_path: Path, mocker: MockerFixture, payload: bytes) -> None:
+    # Only copy-based environments read a shebang to establish ownership, so without this the symlink branch
+    # short-circuits the scan and the parse under test never runs off Windows.
+    mocker.patch.object(common, "can_symlink", autospec=True, return_value=False)
+    venv_resource_path = tmp_path / "venv_bin"
+    venv_resource_path.mkdir()
+    local_resource_dir = tmp_path / "bin"
+    local_resource_dir.mkdir()
+    foreign = local_resource_dir / "foreign.exe"
+    foreign.write_bytes(payload)
+
+    exposed = get_exposed_paths_for_package(venv_resource_path, local_resource_dir)
+
+    assert foreign not in exposed
+
+
+@pytest.mark.parametrize(
+    "owned",
+    [pytest.param(True, id="shebang-into-venv"), pytest.param(False, id="shebang-elsewhere")],
+)
+def test_get_exposed_paths_matches_copied_launcher(tmp_path: Path, mocker: MockerFixture, owned: bool) -> None:
+    mocker.patch.object(common, "can_symlink", autospec=True, return_value=False)
+    venv_resource_path = tmp_path / "venv_bin"
+    venv_resource_path.mkdir()
+    local_resource_dir = tmp_path / "bin"
+    local_resource_dir.mkdir()
+    elsewhere = tmp_path / "other"
+    elsewhere.mkdir()
+    launcher = local_resource_dir / "myapp"
+    launcher.write_text(f"#!{(venv_resource_path if owned else elsewhere) / 'python'}\n")
+
+    exposed = get_exposed_paths_for_package(venv_resource_path, local_resource_dir)
+
+    assert (launcher in exposed) is owned


### PR DESCRIPTION
`pipx install` and `pipx list` abort with an unhandled exception when the bin directory holds an executable pipx did not create, as reported in #1965 with a standalone `claude.exe` sharing `~/.local/bin`. 💥 Ownership scanning reads each file in that directory looking for a launcher's `#!` line, so pipx parses an unrelated binary as if it were a launcher, and the bytes trailing a stray marker reach `os.fsdecode` and `stat` as though they were an interpreter path.

That throws two different ways, and the report covers the first. Windows decodes filesystem bytes with `surrogatepass`, so undecodable input raises `UnicodeDecodeError`. POSIX uses `surrogateescape` and raises nothing there, but a decoded path holding a NUL still reaches `stat`, which raises `ValueError: stat: embedded null character in path`. Binary content is full of NULs, so the same scan aborts off Windows too. `UnicodeDecodeError` is itself a `ValueError`, so widening the existing `except OSError` to `except (OSError, ValueError)` covers both, and pipx keeps treating the file as not owned by the venv.

One detail worth a reviewer's attention. `can_symlink` returns `True` on every non-Windows platform, so `_resource_belongs_to_venv` takes the symlink branch and the parse under test stays unreachable through the public API off Windows. A regression test that skips that point passes on Linux and macOS whether or not the guard is in place. These tests patch `can_symlink` the way `conftest.py` and `test_list.py` do for copy-based environments, so reverting `src/` fails the `nul-in-interpreter` case instead of passing outside CI's Windows jobs.

This supersedes #1966, #1967 and #1968, which each fix the same issue. The commit credits their authors as co-authors. I checked the Windows-only `undecodable-interpreter` path by reading the codecs rather than running it, since the crash it guards cannot reproduce off Windows.
