### PR TITLE
Ignore malformed copied launchers

### DIFF
--- a/changelog.d/1965.bugfix.md
+++ b/changelog.d/1965.bugfix.md
@@ -1,0 +1,1 @@
+Ignore malformed copied launchers when scanning exposed apps.

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -425,7 +425,7 @@ def _copy_launcher_targets_venv(resource_path: Path, venv_resource_path: Path) -
         try:
             if interpreter and Path(os.fsdecode(interpreter)).parent.samefile(venv_resource_path):
                 return True
-        except OSError:
+        except (OSError, UnicodeDecodeError):
             continue
     return False
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -7,8 +7,9 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from helpers import run_pipx_cli, skip_if_windows
+from helpers import WIN, run_pipx_cli, skip_if_windows
 from pipx import paths
+from pipx.commands import common
 from pipx.commands.common import (
     _remove_stale_venv_resources,  # noqa: PLC2701  # test exercises private helper, no public API
     expose_resources_globally,
@@ -32,6 +33,22 @@ def test_get_exposed_paths_ignores_recursive_symlink(tmp_path: Path) -> None:
     exposed = get_exposed_paths_for_package(venv_resource_path, local_resource_dir)
 
     assert loop not in exposed
+
+
+@pytest.mark.skipif(not WIN, reason="Windows decodes launcher bytes strictly")
+def test_get_exposed_paths_ignores_malformed_launcher(tmp_path: Path) -> None:
+    venv_resource_path = tmp_path / "venv_bin"
+    venv_resource_path.mkdir()
+    local_resource_dir = tmp_path / "bin"
+    local_resource_dir.mkdir()
+    foreign_executable = local_resource_dir / "foreign.exe"
+    foreign_executable.write_bytes(b"unrelated binary data#!\xeb\n")
+
+    common._can_symlink_cache[local_resource_dir] = False  # noqa: SLF001  # exercise copy-launcher path
+
+    exposed = get_exposed_paths_for_package(venv_resource_path, local_resource_dir)
+
+    assert exposed == set()
 
 
 @skip_if_windows


### PR DESCRIPTION
#Fixes #1965.

When pipx scans copied launchers, a foreign executable with malformed launcher bytes can raise `UnicodeDecodeError` while decoding the embedded interpreter path. This treats that file as not owned by the venv instead of aborting the scan.

Changes:
- Catch `UnicodeDecodeError` while checking copied launcher targets.
- Add a Windows regression test for a malformed foreign executable in the bin dir.
- Add a changelog fragment.

Checked locally:
- `python -m ruff check src\pipx\commands\common.py tests\test_common.py`
- `python -m ruff format --check src\pipx\commands\common.py tests\test_common.py`
- Direct reproduction script: fails on `origin/main` with `UnicodeDecodeError`, passes on this branch.
