### PR TITLE
fix: allow read-only global list with inaccessible locks

### DIFF
--- a/changelog.d/1974.bugfix.md
+++ b/changelog.d/1974.bugfix.md
@@ -1,0 +1,1 @@
+Allow read-only global list commands when venv lock files are inaccessible.

--- a/src/pipx/commands/list_packages.py
+++ b/src/pipx/commands/list_packages.py
@@ -131,18 +131,21 @@ def list_packages(  # ruff:ignore[too-many-arguments]  # flat CLI-facing list op
         print(f"nothing has been installed with pipx {sleep}", file=sys.stderr)  # ruff:ignore[print]  # user-facing CLI output
 
     if json_format:
-        all_venv_problems = list_json(venv_container.iter_locked_venv_dirs(venv_dirs))
+        all_venv_problems = list_json(venv_container.iter_locked_venv_dirs(venv_dirs, allow_permission_error=True))
     elif short_format:
-        all_venv_problems = list_short(venv_container.iter_locked_venv_dirs(venv_dirs))
+        all_venv_problems = list_short(venv_container.iter_locked_venv_dirs(venv_dirs, allow_permission_error=True))
     elif pinned_only:
         all_venv_problems = list_pinned(
-            venv_container.iter_locked_venv_dirs(venv_dirs), include_injected=include_injected
+            venv_container.iter_locked_venv_dirs(venv_dirs, allow_permission_error=True),
+            include_injected=include_injected,
         )
     else:
         if not venv_dirs:
             return EXIT_CODE_OK
         all_venv_problems = list_text(
-            venv_container.iter_locked_venv_dirs(venv_dirs), str(venv_container), include_injected=include_injected
+            venv_container.iter_locked_venv_dirs(venv_dirs, allow_permission_error=True),
+            str(venv_container),
+            include_injected=include_injected,
         )
 
     if all_venv_problems.bad_venv_name:

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -143,11 +143,25 @@ class VenvContainer:
         """Return the expected venv path for given `package_name`."""
         return self._root.joinpath(canonicalize_name(package_name))
 
-    def iter_locked_venv_dirs(self, venv_dirs: Iterable[Path]) -> Generator[Path, None, None]:
+    def iter_locked_venv_dirs(
+        self, venv_dirs: Iterable[Path], *, allow_permission_error: bool = False
+    ) -> Generator[Path, None, None]:
         for venv_dir in venv_dirs:
-            with self.venv_lock(venv_dir):
+            lock = self.venv_lock(venv_dir)
+            try:
+                lock.acquire()
+            except PermissionError:
+                if not allow_permission_error:
+                    raise
                 if venv_dir.is_dir():
                     yield venv_dir
+                continue
+
+            try:
+                if venv_dir.is_dir():
+                    yield venv_dir
+            finally:
+                lock.release()
 
     def venv_lock(self, venv_dir: Path) -> BaseFileLock:
         self._root.mkdir(parents=True, exist_ok=True)

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import json
 import os
 import re
@@ -25,6 +26,7 @@ from helpers import (
 from package_info import PKG
 from pipx import constants, paths, shared_libs, venv
 from pipx.commands import common
+from pipx.commands.list_packages import list_packages
 from pipx.pipx_metadata_file import (
     PIPX_INFO_FILENAME,
     PackageInfo,
@@ -46,6 +48,32 @@ def test_cli(capsys: pytest.CaptureFixture[str]) -> None:
     assert not run_pipx_cli(["list"])
     captured = capsys.readouterr()
     assert "nothing has been installed with pipx" in captured.err
+
+
+def test_list_allows_read_only_venv_lock(tmp_path: Path, mocker: MockerFixture) -> None:
+    venv_dir = tmp_path / "venvs" / "example"
+    venv_dir.mkdir(parents=True)
+    venv_container = venv.VenvContainer(venv_dir.parent)
+    lock = mocker.Mock()
+    lock.acquire.side_effect = PermissionError("read-only lock file")
+    mocker.patch.object(venv_container, "venv_lock", return_value=lock)
+    list_packages_module = importlib.import_module("pipx.commands.list_packages")
+    mocker.patch.object(
+        list_packages_module,
+        "get_venv_summary",
+        return_value=("package example 1", common.VenvProblems()),
+    )
+
+    assert not list_packages(
+        venv_container,
+        [venv_dir],
+        include_injected=False,
+        json_format=False,
+        short_format=False,
+        pinned_only=False,
+    )
+
+    lock.release.assert_not_called()
 
 
 @skip_if_windows


### PR DESCRIPTION
## Summary

- Keep the existing per-venv lock for `pipx list` when it can be acquired.
- When a lock file is inaccessible, continue listing the readable venv instead of failing a read-only command.
- Add a regression test and changelog fragment for #1974.

## Why

Global venvs installed by root can leave lock files that non-root users cannot open. `pipx list --global` then fails before it reads any installed environment.

## Validation

- Targeted Ruff check and format check passed.
- Verified the read-only fallback with a mocked inaccessible lock, including successful list rendering.
- Verified the normal lock acquisition and release lifecycle.
- `git diff --check` passed.
- The full pytest suite did not complete locally before test initialization timed out; upstream CI will exercise the full suite and Linux permissions behavior.

## Checklist

- [ ] Ran `pre-commit run --all-files` (not run locally; targeted Ruff checks passed).
- [x] Wrote descriptive pull request text.
- [x] Added a regression test.
- [x] Added `changelog.d/1974.bugfix.md`.
- [x] Documentation update is not needed for this read-only failure path.
