### PR TITLE
📝 docs: update Linux install guidance

### DIFF
--- a/changelog.d/1976.doc.md
+++ b/changelog.d/1976.doc.md
@@ -1,0 +1,1 @@
+Direct Linux users to PEP 668-compatible installation methods.

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,9 +56,11 @@ pipx ensurepath
 
 ### On Linux
 
+Install pipx with your distribution's package manager. See the
+[Linux installation instructions](https://pipx.pypa.io/stable/how-to/install-pipx/) for commands and alternatives.
+
 ```
-python3 -m pip install --user pipx
-python3 -m pipx ensurepath
+pipx ensurepath
 ```
 
 ### On Windows


### PR DESCRIPTION
## Summary

- replace the generic Linux `pip install --user` recommendation with distro package-manager guidance
- keep the `pipx ensurepath` step in the quick installation flow
- add the required documentation changelog fragment

Fixes #1976

## Testing

- `uvx --from 'tox>=4.45' --with tox-uv tox run -e lint`
- `uvx --from 'tox>=4.45' --with tox-uv tox run -e docs`
- focused assertion that the Linux README section links to the detailed guide and no longer recommends `pip install --user`

### Checklist

- [x] ran the linter to address style issues (`pre-commit run --all-files`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `changelog.d/` folder
- [x] updated/extended the documentation
