### PR TITLE
Fix Release Notes project URL

### DIFF
--- a/changelog.d/1980.bugfix.md
+++ b/changelog.d/1980.bugfix.md
@@ -1,0 +1,1 @@
+Fix the Release Notes link published in package metadata.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ optional-dependencies.uv = [
   "uv>=0.9.17",
 ]
 urls."Issue Tracker" = "https://github.com/pypa/pipx/issues"
-urls."Release Notes" = "https://pipx.pypa.io/latest/changelog/"
+urls."Release Notes" = "https://pipx.pypa.io/latest/changelog.html"
 urls."Source Code" = "https://github.com/pypa/pipx"
 urls.Documentation = "https://pipx.pypa.io"
 urls.Homepage = "https://pipx.pypa.io"


### PR DESCRIPTION
Fixes #1980.

The Release Notes project URL currently points to the directory-style
`/latest/changelog/` path, but the generated Sphinx page is
`/latest/changelog.html`. This updates the package metadata and adds the
required news fragment.

Validation:

- `uv build --out-dir .devspace/artifacts/1980-dist`
- inspected the built wheel metadata for the corrected `Project-URL`
- changed-file pre-commit hooks
- `git diff --check`
