### PR TITLE
🐛 fix(zipapp): bundle platform-gated dependencies in the artifact

### DIFF
--- a/changelog.d/1984.bugfix.md
+++ b/changelog.d/1984.bugfix.md
@@ -1,0 +1,1 @@
+Fix the zipapp crashing at startup on Windows and on Python 3.10.

--- a/tox.toml
+++ b/tox.toml
@@ -95,7 +95,11 @@ description = "build zipapp via shiv"
 skip_install = true
 dependency_groups = ["zipapp"]
 allowlist_externals = ["{tox_root}{/}pipx.pyz"]
+# The zipapp is one artifact for every platform and interpreter, but pip evaluates the
+# environment markers in `dependencies` against the machine that builds it. Requesting the
+# marker-gated dependencies explicitly keeps them in the artifact, so it also runs on the
+# platforms the release builder is not.
 commands = [
-  ["shiv", "-c", "pipx", "-o", "{tox_root}{/}pipx.pyz", "."],
+  ["shiv", "-c", "pipx", "-o", "{tox_root}{/}pipx.pyz", ".", "colorama>=0.4.4", "tomli"],
   ["{tox_root}{/}pipx.pyz", "--version"],
 ]


### PR DESCRIPTION
Closes #1984.

`tox run -e zipapp` builds one `pipx.pyz` that is published for every platform and every supported Python, but shiv delegates to pip and pip evaluates the environment markers in `dependencies` against the interpreter that builds the artifact. The release workflow builds on `ubuntu-latest`, so `colorama; sys_platform=='win32'` and `tomli; python_version<'3.11'` are both resolved away and never reach the zipapp.

Requesting the two explicitly makes shiv install them regardless of the builder's platform and version. Both wheels are pure-Python and small, so the artifact stays a single cross-platform file.

I verified the mechanism rather than assuming it, by building the zipapp on Windows with Python 3.13 — where `tomli`'s marker is false and `colorama`'s is true, so `tomli` is the one the build drops:

```
before   packages in artifact: argcomplete, click, colorama, filelock, packaging, pipx, platformdirs, userpath
after    ... same, plus tomli 2.4.1
```

The same mechanism covers `colorama` on the Linux release builder, where it is the marker that evaluates false.

I did not touch the smoke test in `[env.zipapp]`, but it is worth saying why it never caught this: `pipx.pyz --version` runs on Linux with output redirected, which makes the `colorama` import unreachable and `sys.stdout.isatty()` false at the same time. If you would like a guard that asserts the marker-gated distributions are present in the built artifact, I am happy to add it here or in a follow-up — I left it out to keep this diff to the defect.

- [x] I have added a news fragment under `changelog.d/`
- [x] I have verified the change (built the artifact both ways and inspected its contents)
