### PR TITLE
📝 docs: fix trailing-slash links left by the Sphinx move

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,7 +5,7 @@ As a reminder, all contributors are expected to follow the [PSF Code of Conduct]
 
 ## Development Documentation
 
-Our [development documentation](https://pipx.pypa.io/latest/contributing/) contains details on how to get started with
-contributing to `pipx`, and details of our development processes.
+Our [development documentation](https://pipx.pypa.io/latest/contributing.html) contains details on how to get started
+with contributing to `pipx`, and details of our development processes.
 
 [coc]: https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://pipx.pypa.io/latest/contributing/))
+### Thanks for contributing, make sure you address all the checklists (for details on how see [development documentation](https://pipx.pypa.io/latest/contributing.html))
 
 - [ ] ran the linter to address style issues (`pre-commit run --all-files`)
 - [ ] wrote descriptive pull request text

--- a/changelog.d/1980.doc.md
+++ b/changelog.d/1980.doc.md
@@ -1,0 +1,1 @@
+Fix the documentation links that 404 after the Sphinx move, including the PyPI Release Notes link.

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@
 **Source Code**: <https://github.com/pypa/pipx>
 
 _For comparison to other tools including pipsi, see
-[Comparison to Other Tools](https://pipx.pypa.io/stable/explanation/comparisons/)._
+[Comparison to Other Tools](https://pipx.pypa.io/stable/explanation/comparisons.html)._
 
 ## Overview: What is `pipx`?
 
@@ -57,7 +57,7 @@ pipx ensurepath
 ### On Linux
 
 Install pipx with your distribution's package manager. See the
-[Linux installation instructions](https://pipx.pypa.io/stable/how-to/install-pipx/) for commands and alternatives.
+[Linux installation instructions](https://pipx.pypa.io/stable/how-to/install-pipx.html) for commands and alternatives.
 
 ```
 pipx ensurepath
@@ -71,7 +71,7 @@ pipx ensurepath
 ```
 
 For more detailed installation instructions, see the
-[full documentation](https://pipx.pypa.io/stable/how-to/install-pipx/).
+[full documentation](https://pipx.pypa.io/stable/how-to/install-pipx.html).
 
 ## Quick Start
 
@@ -92,6 +92,6 @@ See the [full documentation](https://pipx.pypa.io/stable/) for more details.
 
 ## Contributing
 
-Issues and Pull Requests are definitely welcome! Check out [Contributing](https://pipx.pypa.io/stable/contributing/) to
-get started. Everyone who interacts with the pipx project via codebase, issue tracker, chat rooms, or otherwise is
+Issues and Pull Requests are definitely welcome! Check out [Contributing](https://pipx.pypa.io/stable/contributing.html)
+to get started. Everyone who interacts with the pipx project via codebase, issue tracker, chat rooms, or otherwise is
 expected to follow the [PSF Code of Conduct](https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ optional-dependencies.uv = [
   "uv>=0.9.17",
 ]
 urls."Issue Tracker" = "https://github.com/pypa/pipx/issues"
-urls."Release Notes" = "https://pipx.pypa.io/latest/changelog/"
+urls."Release Notes" = "https://pipx.pypa.io/latest/changelog.html"
 urls."Source Code" = "https://github.com/pypa/pipx"
 urls.Documentation = "https://pipx.pypa.io"
 urls.Homepage = "https://pipx.pypa.io"

--- a/tests/test_docs_urls.py
+++ b/tests/test_docs_urls.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# MkDocs published every page as a directory, so links to one ended in a slash. Sphinx publishes <page>.html and Read
+# the Docs serves the built tree as is, so the old shape returns 404. The terminator set covers a bare URL, a markdown
+# link and a quoted value, because the Release Notes link lives in a TOML string.
+MKDOCS_PAGE_URL = re.compile(r"""https://pipx\.pypa\.io/(?:latest|stable)/[^\s<>)\]"']*/(?=[\s<>)\]"']|$)""")
+
+ROOT = Path(__file__).parents[1]
+# pyproject.toml is in the list because its urls table feeds the PyPI sidebar, which is where the
+# stale Release Notes link was reported from.
+SEARCHED_GLOBS = ("*.md", "*.rst", "pyproject.toml", ".github/*.md", "docs/**/*.md", "docs/**/*.rst")
+
+
+def test_documentation_links_do_not_use_mkdocs_page_urls() -> None:
+    stale = [
+        f"{path.relative_to(ROOT).as_posix()}: {url}"
+        for glob in SEARCHED_GLOBS
+        for path in sorted(ROOT.glob(glob))
+        for url in MKDOCS_PAGE_URL.findall(path.read_text(encoding="utf-8"))
+    ]
+
+    assert stale == []


### PR DESCRIPTION
Closes #1980.

The `Release Notes` link in `pyproject.toml` is the one @kevinbowen777 reported, and it turned out not to be alone — the same MkDocs directory-URL shape survives in six more places. MkDocs served every page as a directory, so a link to one ended in a slash; #1957 moved the site to Sphinx, which emits `<page>.html`, and Read the Docs serves the built tree as is.

All seven, found by scanning rather than by eye:

```
pyproject.toml                    /latest/changelog/
.github/CONTRIBUTING.md           /latest/contributing/
.github/PULL_REQUEST_TEMPLATE.md  /latest/contributing/
docs/README.md                    /stable/explanation/comparisons/
docs/README.md                    /stable/how-to/install-pipx/          (x2)
docs/README.md                    /stable/contributing/
```

`pyproject.toml` and `docs/README.md` both feed the PyPI project page — the sidebar link and the long description respectively — so five of the seven are visible to anyone who lands there.

Checked against the live site rather than assumed: `/latest/changelog.html` and `/stable/how-to/install-pipx.html` answer 200, `/latest/changelog/` answers 404.

### The test

`tests/test_docs_urls.py` scans tracked documentation and `pyproject.toml` for the old shape so it cannot come back. Two notes on how it is built, since both were mistakes I made first:

- It reads the tree with `pathlib` instead of shelling out to `git ls-files`. A `subprocess` call needs git on `PATH`, which is not guaranteed for whoever runs the suite.
- Its terminator set includes quotes. My first version only matched a bare URL or a markdown link, so it silently passed over the one link the issue is actually about — the URL in `pyproject.toml` is inside a TOML string and ends at a `"`.

It needs neither network nor the package cache, so it runs anywhere the suite runs.

- [x] I have added a news fragment under `changelog.d/`
- [x] I have added a test
