### PR TITLE
Prune the logs when PIPX_MAX_LOGS is 0

### DIFF
--- a/changelog.d/+max-logs-zero.bugfix.md
+++ b/changelog.d/+max-logs-zero.bugfix.md
@@ -1,0 +1,1 @@
+`PIPX_MAX_LOGS=0` now prunes the log files instead of keeping all of them.

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -1826,9 +1826,11 @@ def _cmd_completions(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode
 
 def delete_oldest_logs(file_list: list[Path], keep_number: int) -> None:
     file_list = sorted(file_list)
-    if len(file_list) > keep_number:
-        for existing_file in file_list[:-keep_number]:
-            existing_file.unlink(missing_ok=True)
+    # Count from the front rather than slicing with -keep_number: file_list[:-0] is
+    # file_list[:0], so keeping none used to delete none. max() guards the other end,
+    # where keep_number exceeds the list and a negative bound would delete instead.
+    for existing_file in file_list[: max(0, len(file_list) - keep_number)]:
+        existing_file.unlink(missing_ok=True)
 
 
 def _setup_log_file(pipx_log_dir: Path | None = None) -> Path:

--- a/tests/test_max_logs.py
+++ b/tests/test_max_logs.py
@@ -32,6 +32,35 @@ def test_delete_oldest_logs_keeps_specified_number(tmp_path: Path) -> None:
     assert len(remaining) == 2
 
 
+def test_delete_oldest_logs_keeps_none(tmp_path: Path) -> None:
+    """Test that delete_oldest_logs with keep_number=0 deletes every file."""
+    log_files = []
+    for i in range(5):
+        log_file = tmp_path / f"cmd_2024-01-01_00.00.0{i}.log"
+        log_file.touch()
+        log_files.append(log_file)
+
+    delete_oldest_logs(log_files, keep_number=0)
+
+    remaining = list(tmp_path.glob("cmd_*.log"))
+    assert remaining == []
+
+
+def test_max_logs_zero_keeps_only_the_new_log(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that PIPX_MAX_LOGS=0 prunes the existing logs."""
+    monkeypatch.setenv("PIPX_MAX_LOGS", "0")
+
+    for i in range(15):
+        log_file = tmp_path / f"cmd_2024-01-01_00.00.{i:02d}.log"
+        log_file.touch()
+
+    _setup_log_file(pipx_log_dir=tmp_path)
+
+    # Every pre-existing log is pruned, leaving only the one just created.
+    remaining = list(tmp_path.glob("cmd_*.log"))
+    assert len(remaining) == 1
+
+
 def test_delete_oldest_logs_keeps_all_when_under_limit(tmp_path: Path) -> None:
     """Test that delete_oldest_logs keeps all files when under the limit."""
     log_files = []


### PR DESCRIPTION
## Summary

`PIPX_MAX_LOGS=0` kept every log instead of pruning them.

`delete_oldest_logs()` sliced with a negative bound:

```python
if len(file_list) > keep_number:
    for existing_file in file_list[:-keep_number]:
```

For `keep_number == 0` that is `file_list[:0]` — the empty list — so the guard passed and the loop body never ran. Asking to keep no logs kept all of them.

Counting from the front says what is meant. `max()` covers the other end: where `keep_number` exceeds the list, `len - keep_number` goes negative and a negative bound would start deleting again. The old `len(file_list) > keep_number` guard was carrying that case, so dropping it without the clamp would have traded one bug for a worse one.

Measured across both boundaries, 5 files in:

```
keep_number=0: 0 left   keep_number=1: 1 left   keep_number=3: 3 left
keep_number=5: 5 left   keep_number=9: 5 left
```

## Tests

`tests/test_max_logs.py` already pins `keep_number` at 2, at 10 against 3 files, and `PIPX_MAX_LOGS` at the default, at 5 and at 100 — so the file deliberately covers boundaries and 0 was the one missing. Added at both levels: on `delete_oldest_logs` directly, and through `_setup_log_file`, where the 15 pre-existing logs are pruned and only the newly created one remains.

`python -m pytest tests/test_max_logs.py` → **7 passed**.

Negative control, `main.py` reverted with the new tests kept:

```
FAILED tests/test_max_logs.py::test_delete_oldest_logs_keeps_none
FAILED tests/test_max_logs.py::test_max_logs_zero_keeps_only_the_new_log
2 failed, 5 passed
```

— exactly the two new cases fail and the five pre-existing ones pass.

`ruff check src/ tests/` and `ruff format --check src/ tests/` both clean. Towncrier fragment included, with the `+` orphan prefix since there is no issue number.

## Possible drawbacks

`PIPX_MAX_LOGS` is read as `int(os.getenv("PIPX_MAX_LOGS", "10"))`, so a negative value is possible and now deletes everything rather than being absorbed by the old guard. That seemed the least surprising reading of "keep fewer than zero", but if you would rather it were rejected at the parse site I am happy to do that instead.

I did not run the full suite here: integration tests that request `pipx_temp_env` fail on this machine in fixture setup with `OSError [WinError 1314]` from the `Path.symlink_to(git.EXE)` in `tests/conftest.py`, since it has no Developer Mode and is not elevated. That is unrelated to this change — the unit-level modules run fine, which is what the numbers above are.
