### PR TITLE
🐛 fix(upgrade): honor the version specifier with --install

### DIFF
--- a/changelog.d/1987.bugfix.md
+++ b/changelog.d/1987.bugfix.md
@@ -1,0 +1,1 @@
+Honor the version specifier when `pipx upgrade --install` installs a missing package.

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 from dataclasses import dataclass, replace
 from enum import Enum
 from typing import TYPE_CHECKING, Final
@@ -49,7 +48,7 @@ def upgrade(  # ruff:ignore[too-many-arguments]  # mirrors the CLI's flat upgrad
     results: Final[list[PackageUpgradeResult]] = []
     install_messages: Final[list[OutputMessage]] = []
 
-    for venv_dir in venv_dirs.values():
+    for package_spec, venv_dir in venv_dirs.items():
         with VenvContainer(venv_dir.parent).venv_lock(venv_dir) as venv_lock:
             results.extend(
                 _upgrade_venv(
@@ -59,6 +58,7 @@ def upgrade(  # ruff:ignore[too-many-arguments]  # mirrors the CLI's flat upgrad
                     include_injected=include_injected,
                     force=force,
                     install=install,
+                    package_spec=package_spec,
                     venv_args=venv_args,
                     python=python,
                     python_flag_passed=python_flag_passed,
@@ -208,6 +208,7 @@ def _upgrade_venv(  # ruff:ignore[too-many-arguments]  # upgrade forwards the fu
     include_injected: bool,
     force: bool,
     install: bool = False,
+    package_spec: str | None = None,
     venv_args: list[str] | None = None,
     python: str | None = None,
     python_flag_passed: bool = False,
@@ -225,7 +226,9 @@ def _upgrade_venv(  # ruff:ignore[too-many-arguments]  # upgrade forwards the fu
                 venv_dir=None,
                 venv_args=venv_args or [],
                 package_names=None,
-                package_specs=[str(venv_dir).split(os.path.sep)[-1]],
+                # the venv directory only carries the package name; the original argument keeps
+                # any version specifier or extras the user asked to install
+                package_specs=[package_spec or venv_dir.name],
                 local_bin_dir=paths.ctx.bin_dir,
                 local_man_dir=paths.ctx.man_dir,
                 python=python,

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -273,6 +273,14 @@ def test_upgrade_install_missing(capsys: pytest.CaptureFixture[str]) -> None:
 
 
 @pytest.mark.usefixtures("pipx_temp_env")
+def test_upgrade_install_missing_honors_specifier(capsys: pytest.CaptureFixture[str]) -> None:
+    pkg_spec = PKG["pylint"]["spec"]
+    assert not run_pipx_cli(["upgrade", pkg_spec, "--install"])
+    captured = capsys.readouterr()
+    assert f"installed package pylint {pkg_spec.split('==')[-1]}" in captured.out
+
+
+@pytest.mark.usefixtures("pipx_temp_env")
 def test_upgrade_multiple(capsys: pytest.CaptureFixture[str]) -> None:
     name = "pylint"
     pkg_spec = PKG[name]["spec"]


### PR DESCRIPTION
`pipx upgrade --install 'pycowsay==0.0.0.1'` reports `done!` and installs 0.0.0.2, as reported in #1987. The command resolves each argument to a venv directory through `valid_pypi_name()`, and when the venv is missing it rebuilt the install spec from the directory name. The directory carries the package name alone, so the version specifier, extras, or any other PEP 508 marker vanished between parsing and install, while `pipx install` honors the identical argument.

The `venv_dirs` mapping that `commands.upgrade()` receives already keys each directory by the original argument, so the fix threads that key through `_upgrade_venv()` to the missing-venv install instead of reconstructing it from the path. 🧵

The behavior changes only when the venv does not exist and `--install` was passed; upgrades of existing venvs take the other branch and are untouched.
