### PR TITLE
🐛 fix(tests): seed the pinned pip so upgrade-shared stays green

### DIFF
--- a/testdata/tests_packages/primary_packages.txt
+++ b/testdata/tests_packages/primary_packages.txt
@@ -22,6 +22,7 @@ nox[tox_to_nox]==2023.4.22
 pbr==5.6.0
 pip==23.3.2
 pip==24.0
+pip==26.1.2
 pip
 pycowsay==0.0.0.2
 pygdbmi==0.10.0.0

--- a/tests/test_upgrade_shared.py
+++ b/tests/test_upgrade_shared.py
@@ -65,8 +65,13 @@ def test_upgrade_shared_pin_pip(shared_libs: _SharedLibs) -> None:
         ret = subprocess.run([shared_libs.python_path, "-c", cmd], check=True, capture_output=True, text=True)
         return ret.stdout.strip()
 
+    # Pin to a version testdata/tests_packages/primary_packages.txt seeds explicitly: it clears the `pip >= 26.1`
+    # floor upgrade-shared appends yet stays behind the latest, so a bare `pip` entry alone would drop it once pip
+    # moves on. The assertion then proves --pip-args placed it rather than matching the default upgrade.
+    pinned = "26.1.2"
+
     assert shared_libs.has_been_updated_this_run is False
     assert shared_libs.is_valid is False
-    assert run_pipx_cli(["upgrade-shared", "-v", "--pip-args=pip==26.1.2"]) == 0
+    assert run_pipx_cli(["upgrade-shared", "-v", f"--pip-args=pip=={pinned}"]) == 0
     assert shared_libs.is_valid is True
-    assert pip_version() == "26.1.2"
+    assert pip_version() == pinned


### PR DESCRIPTION
The `🧪 test` matrix fails on 3.14 and 3.15 with `No matching distribution found for pip==26.1.2`, which is what blocks the actions bump in #1992 (the failure has nothing to do with that PR). `test_upgrade_shared_pin_pip` pins pip to `26.1.2` to prove `--pip-args` places an exact version, but the local test index only ever seeded that value through the bare `pip` entry in `testdata/tests_packages/primary_packages.txt`, which tracks whatever pip is latest. 📌 Once pip `26.2` shipped, `26.1.2` dropped out of any index built from scratch.

The committed per-Python lists still carry `26.1.2`, so 3.10 through 3.13 stay green off their cached lists, while 3.14 and 3.15 have no committed list, rebuild the index from `primary_packages.txt`, and break. Seeding `pip==26.1.2` there by name pins it in place for every rebuild. It clears the `pip >= 26.1` floor that `upgrade-shared` appends yet stays behind the latest, so the assertion keeps proving the pin rather than matching whatever the default upgrade would pull.

Local checks confirm it two ways: the test passes on the committed-list path, and regenerating the index from the updated seed now lists `pip==23.3.2, 24.0, 26.1.2, 26.2`, so the 3.14 and 3.15 rebuild path has the version again. Once this lands, #1992 needs a `@dependabot rebase` to pick it up.
