### PR TITLE
🐛 fix(run): discover entry points for inferred names

### DIFF
--- a/changelog.d/1189.bugfix.md
+++ b/changelog.d/1189.bugfix.md
@@ -1,0 +1,1 @@
+Stop appending a second `.exe` on Windows to the app name `pipx run` infers.

--- a/changelog.d/1994.bugfix.md
+++ b/changelog.d/1994.bugfix.md
@@ -1,0 +1,3 @@
+Run the console script a package declares when `pipx run` infers the app name from a VCS URL, a local path, or a name it
+normalized, instead of passing a guess to `uv tool run`. Reusing that venv no longer reinstalls the package on every
+run.

--- a/docs/how-to/use-uv-backend.rst
+++ b/docs/how-to/use-uv-backend.rst
@@ -73,12 +73,16 @@ all accept ``--backend``. Switch an installed venv with ``pipx reinstall NAME --
 ************
 
 - ``pipx install pip --backend uv`` errors: a uv venv has no pip. Use ``--backend pip``.
-- ``pipx run --backend uv`` does not honor ``[pipx.run]`` entry points; ``uv tool run`` sees only standard console
-  scripts. Use ``--backend pip`` when your package declares them.
+- ``pipx run --backend uv`` does not honor ``[pipx.run]`` entry points when it hands the run to ``uv tool run``, which
+  sees only standard console scripts. Use ``--backend pip`` when your package declares them.
 - Some ``--pip-args`` values have no ``uv tool run`` equivalent (``--editable``, ``--no-build-isolation``); pipx errors
   instead of dropping them. See :doc:`use-private-index` for which flags uv translates.
 - ``pipx run --backend uv`` against URL or named-pipe scripts falls back to a pipx-managed venv, because ``uv run
   --script`` reads PEP 723 metadata off disk and runtime-fetched content has no on-disk path. pipx logs a warning.
+- ``pipx run`` falls back to a pipx-managed venv when it has to infer the script name: from a VCS URL, a local project
+  path, or a name it normalizes (``pipx run pip_search`` installs ``pip-search``). ``uv tool run`` takes that name up
+  front and would guess it from the package, so pipx installs the package first and runs the script it declares. Pass
+  ``pipx run --spec <spec> <script>`` to keep uv's cache.
 
 *************
  Cache layout

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -254,11 +254,7 @@ def run_package(  # ruff:ignore[too-many-arguments]  # mirrors the flat `pipx ru
             )
         )
 
-    if WINDOWS:
-        app_filename = f"{app}.exe"
-        _LOGGER.info("Assuming app is %r (Windows only)", app_filename)
-    else:
-        app_filename = app
+    app, app_filename = _app_names(app)
 
     pypackage_bin_path = get_pypackage_bin_path(app)
     if pypackage_bin_path.exists():
@@ -288,9 +284,9 @@ def run_package(  # ruff:ignore[too-many-arguments]  # mirrors the flat `pipx ru
 
     with _locked_venv_cache(venv_dir):
         venv = Venv(venv_dir, backend=backend, env_backend=env_backend)
-        if infer_app_name and venv.pipx_metadata.main_package.package is not None:
-            app = venv.pipx_metadata.main_package.package
-            app_filename = f"{app}.exe" if WINDOWS else app
+        if infer_app_name and (cached := venv.pipx_metadata.main_package).package is not None:
+            # repeat ``_prepare_venv``'s sole-script fallback, else the cache check below misses and rebuilds the venv
+            app, app_filename = _app_names(cached.apps[0] if len(cached.apps) == 1 else cached.package)
         bin_path = venv.bin_path / app_filename
         _prepare_venv_cache(venv, bin_path, use_cache=use_cache, refresh=refresh)
 
@@ -331,6 +327,16 @@ def run_package(  # ruff:ignore[too-many-arguments]  # mirrors the flat `pipx ru
         venv.run_app(app, app_filename, app_args, python_args=python_args)
 
 
+def _app_names(app: str) -> tuple[str, str]:
+    """Return an app's entry-point name and the filename it has inside the venv."""
+    if not WINDOWS:
+        return app, app
+    # apps recorded in the venv metadata carry the .exe stub suffix, so drop it before re-appending
+    name = app[: -len(".exe")] if app.lower().endswith(".exe") else app
+    _LOGGER.info("Assuming app is %r (Windows only)", app_filename := f"{name}.exe")
+    return name, app_filename
+
+
 def run(  # ruff:ignore[too-many-arguments, too-many-positional-arguments]  # mirrors the flat `pipx run` CLI options across the script/uvx/venv paths
     app: str,
     spec: str | None,
@@ -357,12 +363,17 @@ def run(  # ruff:ignore[too-many-arguments, too-many-positional-arguments]  # mi
     package
     """
 
-    package_name: Final[str] = _package_name_from_app(app, inferred=spec is None)
+    requirement_name: Final[str] = _requirement_name(app)
+    package_name: Final[str] = canonicalize_name(requirement_name) if spec is None else requirement_name
+    # a VCS URL names no script at all, and a normalized name is no longer the one on disk (`pip_search` installs a
+    # `pip_search` script but canonicalizes to `pip-search`), so pipx picks the app from the installed entry points
+    infer_app_name: Final[bool] = spec is None and (_is_vcs_url(app) or package_name != requirement_name)
 
     # ``resolved_backend`` only decides ROUTING (uv tool run vs Venv); cli/env
     # stay separate when we hand off so the Venv's source-attribution stays right.
     resolved_backend, _ = resolve_backend_name(cli_value=backend, env_value=env_backend)
-    use_uvx = resolved_backend == UV and not pypackages and not python_args
+    # `uv tool run` takes the script name up front and would guess an inferred one from the package name
+    use_uvx = resolved_backend == UV and not pypackages and not python_args and not infer_app_name
 
     content = None if spec is not None else maybe_script_content(app, is_path=is_path)
     if content is not None:
@@ -415,7 +426,7 @@ def run(  # ruff:ignore[too-many-arguments, too-many-positional-arguments]  # mi
             verbose=verbose,
             use_cache=use_cache,
             refresh=refresh,
-            infer_app_name=spec is None and _is_vcs_url(app),
+            infer_app_name=infer_app_name,
             backend=backend,
             env_backend=env_backend,
             resolved_backend=resolved_backend,
@@ -425,12 +436,11 @@ def run(  # ruff:ignore[too-many-arguments, too-many-positional-arguments]  # mi
         )
 
 
-def _package_name_from_app(app: str, *, inferred: bool) -> str:
+def _requirement_name(app: str) -> str:
     try:
-        package_name = Requirement(app).name
+        return Requirement(app).name
     except InvalidRequirement:
         return app
-    return canonicalize_name(package_name) if inferred else package_name
 
 
 def _prepare_venv(  # ruff:ignore[too-many-arguments]  # mirrors the flat run/install option set for one temporary venv
@@ -464,8 +474,7 @@ def _prepare_venv(  # ruff:ignore[too-many-arguments]  # mirrors the flat run/in
         )
 
     if infer_app_name:
-        app = package_name
-        app_filename = f"{app}.exe" if WINDOWS else app
+        app, app_filename = _app_names(package_name)
 
     override_shared = package_name == "pip"
 
@@ -486,13 +495,8 @@ def _prepare_venv(  # ruff:ignore[too-many-arguments]  # mirrors the flat run/in
 
         # If there's a single app inside the package, run that by default
         if app == package_name and len(apps) == 1:
-            app = apps[0]
+            app, app_filename = _app_names(apps[0])
             print(f"NOTE: running app {app!r} from {package_name!r}")  # ruff:ignore[print]  # user-facing CLI output
-            if WINDOWS:
-                app_filename = f"{app}.exe"
-                _LOGGER.info("Assuming app is %r (Windows only)", app_filename)
-            else:
-                app_filename = app
         else:
             all_apps = (f"{a} - usage: 'pipx run --spec {package_or_url} {a} [arguments?]'" for a in apps)
             raise PipxError(

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -80,6 +80,15 @@ def test_run_normalizes_inferred_package_name(
 
 
 @pytest.mark.usefixtures("pipx_temp_env")
+@mock.patch("os.execvpe", new=execvpe_mock)
+def test_run_normalized_name_skips_uv_tool_run(caplog: pytest.LogCaptureFixture) -> None:
+    # `uv tool run PyCowSay` would look for a `PyCowSay` script; only the venv path knows what the package installed
+    run_pipx_cli_exit(["run", "--backend", "uv", "PyCowSay", "cowsay", "hi"], assert_exit=0)
+
+    assert f"exec_app: {paths.ctx.venv_cache}" in caplog.text
+
+
+@pytest.mark.usefixtures("pipx_temp_env")
 def test_run_preserves_explicit_app_name(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -978,38 +987,76 @@ def test_run_local_path_entry_point(
     assert "Using discovered entry point for 'pipx run'" in caplog.text
 
 
+@pytest.fixture
+def vcs_project(root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Callable[[str, str], str]:
+    """Apply one pyproject substitution to the empty project, commit it and return its git URL."""
+
+    def create(old: str, new: str) -> str:
+        project = tmp_path / "vcs-project"
+        shutil.copytree(root / "testdata" / "empty_project", project)
+        pyproject = project / "pyproject.toml"
+        pyproject.write_text(pyproject.read_text().replace(old, new))
+        # uv clones through `git submodule`, a shell script needing the platform utilities the sandboxed PATH drops
+        monkeypatch.setenv("PATH", os.environ["PATH_ORIG"])
+        subprocess.run(["git", "init", "--quiet"], cwd=project, check=True)  # ruff:ignore[start-process-with-partial-path]  # git resolved from PATH in tests
+        subprocess.run(["git", "add", "."], cwd=project, check=True)  # ruff:ignore[start-process-with-partial-path]  # git resolved from PATH in tests
+        subprocess.run(
+            [  # ruff:ignore[start-process-with-partial-path]  # git resolved from PATH in tests
+                "git",
+                "-c",
+                "user.name=pipx tests",
+                "-c",
+                "user.email=pipx@example.invalid",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "--quiet",
+                "-m",
+                "test fixture",
+            ],
+            cwd=project,
+            check=True,
+        )
+        return f"git+{project.as_uri()}"
+
+    return create
+
+
+@pytest.mark.parametrize("backend", ["pip", "uv"])
 @pytest.mark.usefixtures("pipx_temp_env")
 @mock.patch("os.execvpe", new=execvpe_mock)
-def test_run_vcs_url_infers_app_name(root: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
-    project = tmp_path / "empty-project-vcs"
-    shutil.copytree(root / "testdata" / "empty_project", project)
-    pyproject = project / "pyproject.toml"
-    pyproject.write_text(pyproject.read_text().replace("empty_project.main:cli", "empty_project.main:main"))
-    subprocess.run(["git", "init", "--quiet"], cwd=project, check=True)  # ruff:ignore[start-process-with-partial-path]  # git resolved from PATH in tests
-    subprocess.run(["git", "add", "."], cwd=project, check=True)  # ruff:ignore[start-process-with-partial-path]  # git resolved from PATH in tests
-    subprocess.run(
-        [  # ruff:ignore[start-process-with-partial-path]  # git resolved from PATH in tests
-            "git",
-            "-c",
-            "user.name=pipx tests",
-            "-c",
-            "user.email=pipx@example.invalid",
-            "-c",
-            "commit.gpgsign=false",
-            "commit",
-            "--quiet",
-            "-m",
-            "test fixture",
-        ],
-        cwd=project,
-        check=True,
-    )
-
-    command = ["run", "--backend", "pip", f"git+{project.as_uri()}"]
+def test_run_vcs_url_infers_app_name(
+    vcs_project: Callable[[str, str], str],
+    caplog: pytest.LogCaptureFixture,
+    backend: str,
+) -> None:
+    command = ["run", "--backend", backend, vcs_project("empty_project.main:cli", "empty_project.main:main")]
     run_pipx_cli_exit(command, assert_exit=0)
     run_pipx_cli_exit(command, assert_exit=0)
 
     assert caplog.text.count("Determined package name: empty-project") == 1
+    assert "Reusing cached venv" in caplog.text
+
+
+@pytest.mark.parametrize("backend", ["pip", "uv"])
+@pytest.mark.usefixtures("pipx_temp_env")
+@mock.patch("os.execvpe", new=execvpe_mock)
+def test_run_vcs_url_runs_sole_script_of_other_name(
+    vcs_project: Callable[[str, str], str],
+    caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture[str],
+    backend: str,
+) -> None:
+    # drop the pipx.run entry point as well: it matches on package name and would hide the console script lookup
+    declared = (
+        'scripts.empty-project = "empty_project.main:cli"\n'
+        'entry-points."pipx.run".empty-project = "empty_project.main:cli"'
+    )
+    command = ["run", "--backend", backend, vcs_project(declared, 'scripts.renamed = "empty_project.main:main"')]
+    run_pipx_cli_exit(command, assert_exit=0)
+    assert "NOTE: running app 'renamed' from 'empty-project'" in capsys.readouterr().out
+
+    run_pipx_cli_exit(command, assert_exit=0)
     assert "Reusing cached venv" in caplog.text
 
 


### PR DESCRIPTION
`pipx run git+file:///tmp/src1` fails on the default uv backend with `An executable named 'rat-demo' is not provided by package 'rat-demo'`, while `pipx run --backend pip` on the same URL runs it, as [#1994](https://github.com/pypa/pipx/issues/1994) reports. The same guess breaks `pipx run pip_search` from [#1189](https://github.com/pypa/pipx/issues/1189), where pipx normalizes the typed name to `pip-search` and the installed script keeps its underscore. Both failures start in pipx. It passes `uv tool run` a script name the package never declared, and uv reports the name it could not find. 🔍

pipx now passes `uv tool run` a script name only when the user typed one. The three specs it has to infer from (a VCS URL, a local project path, or a name it normalizes) go through the venv path, where pipx installs the package first and reads the entry points it declares. A lone script runs under its own name, `[pipx.run]` entry points work again, and a package shipping several scripts gets pipx's own error listing them. uv still creates and populates that venv, so the run gives up uv's tool cache. Two more bugs sat behind that fallback and go away with it: pipx rebuilt the cached venv on every run, because the cache check looked for a script named after the package, and on Windows the inferred name grew a second `.exe`, the original complaint in #1189. ✨

`pipx run black` and `pipx run ruff==0.5.0` still exec `uv tool run` unchanged. The runs that move to the venv path pay a first-run install in exchange for working at all, and `pipx run --spec <spec> <script>` keeps them on uv's cache. Focus review on the routing predicate in `run()`; it decides which spec shapes lose the uvx fast path.
