### PR TITLE
📄 docs: publish llms.txt from the docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,7 @@ version = ".".join(release.split(".")[:2])
 doctest_global_setup = "import pipx"
 
 extensions = [
+    "sphinx_llm.txt",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosectionlabel",  # reference any section by its title, scoped per document to keep labels unique
     "sphinx.ext.doctest",  # run the testcode/testoutput examples so the docs cannot drift from the code
@@ -156,3 +157,6 @@ def setup(app: Sphinx) -> dict[str, Any]:
     """Register the per-page meta description hook."""
     app.connect("html-page-context", _add_page_description)
     return {"parallel_read_safe": True, "parallel_write_safe": True}
+
+
+markdown_http_base = os.environ.get("READTHEDOCS_CANONICAL_URL", "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ docs = [
   "sphinx-design>=0.6",                # the card grid on the landing page
   "sphinx-issues>=5",                  # the :issue:/:pr: roles used in the changelog and notes
   "sphinx-last-updated-by-git>=0.3.8",
+  "sphinx-llm>=0.4.1",
   "sphinx-notfound-page>=1",           # a versioned 404 page
   "sphinx-reredirects>=0.1.5",         # keep old MkDocs URLs alive after the move to Sphinx
   "sphinx-sitemap>=2.6",               # emit sitemap.xml for crawlers


### PR DESCRIPTION
The [sphinx-llm](https://github.com/NVIDIA/sphinx-llm) extension emits `llms.txt` ([llmstxt.org](https://llmstxt.org/)), `llms-full.txt`, and a markdown twin of each page during the HTML build; Read the Docs serves `llms.txt` from the docs domain root ([announcement](https://about.readthedocs.com/blog/2026/02/llms-txt-support/)). Plain markdown lets agents read the docs without rendering themed, JavaScript-dependent HTML. `markdown_http_base` keeps the sitemap links absolute so they resolve from the domain root.
