### PR TITLE
docs: correct the Windows default for PIPX_HOME

### DIFF
--- a/changelog.d/2002.doc.md
+++ b/changelog.d/2002.doc.md
@@ -1,0 +1,2 @@
+Correct the documented Windows default for `PIPX_HOME`, which resolves to `%LOCALAPPDATA%\pipx\pipx` rather than
+`%LOCALAPPDATA%\pipx`.

--- a/docs/how-to/configure-paths.rst
+++ b/docs/how-to/configure-paths.rst
@@ -49,7 +49,7 @@ pipx splits its files across three locations, each with an environment-variable 
       - ``~/.local/share/man``
 
 The default ``PIPX_HOME`` is typically ``~/.local/share/pipx`` on Linux, ``~/Library/Application Support/pipx`` on
-macOS, and ``%USERPROFILE%\AppData\Local\pipx`` on Windows. Set any variable to override its location.
+macOS, and ``%USERPROFILE%\AppData\Local\pipx\pipx`` on Windows. Set any variable to override its location.
 
 .. _platformdirs-migration:
 

--- a/docs/reference/environment-variables.rst
+++ b/docs/reference/environment-variables.rst
@@ -17,7 +17,7 @@ environment`` to print the resolved value of each one on your system.
       - Meaning and default
     - - ``PIPX_HOME``
       - Root directory for pipx virtual environments. Default: ``platformdirs.user_data_path("pipx")`` — Linux
-        ``~/.local/share/pipx``, macOS ``~/Library/Application Support/pipx``, Windows ``%LOCALAPPDATA%\pipx``.
+        ``~/.local/share/pipx``, macOS ``~/Library/Application Support/pipx``, Windows ``%LOCALAPPDATA%\pipx\pipx``.
     - - ``PIPX_BIN_DIR``
       - Directory for application entry-point symlinks. Default: ``~/.local/bin``.
     - - ``PIPX_MAN_DIR``


### PR DESCRIPTION
The Windows `PIPX_HOME` documentation is missing the second `pipx` path component. This updates the two affected references and adds the required changelog entry.

Verified the documented path against pipx's current environment output and ran pre-commit successfully.

- [x] ran the linter to address style issues (`pre-commit run --all-files`) — run against the changed files; all hooks pass
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix — not applicable, docs only
- [x] added news fragment in `changelog.d/` folder (choose a type: `feature`, `bugfix`, `doc`, `removal`, or `misc`)
- [x] updated/extended the documentation
