### PR TITLE
Honor [pipx.run] for typed --spec app names on the uv backend

### DIFF
--- a/changelog.d/2004.bugfix.md
+++ b/changelog.d/2004.bugfix.md
@@ -1,3 +1,2 @@
-Honor a package's `[pipx.run]` entry point when `pipx run --spec` names an app
-that is not the PEP 503-normalized distribution name, instead of passing that
-name to `uv tool run`.
+Honor a package's `[pipx.run]` entry point when `pipx run --spec` names an app that is not the PEP 503-normalized
+distribution name, instead of passing that name to `uv tool run`.

--- a/changelog.d/2004.bugfix.md
+++ b/changelog.d/2004.bugfix.md
@@ -1,0 +1,3 @@
+Honor a package's `[pipx.run]` entry point when `pipx run --spec` names an app
+that is not the PEP 503-normalized distribution name, instead of passing that
+name to `uv tool run`.

--- a/changelog.d/2004.bugfix.md
+++ b/changelog.d/2004.bugfix.md
@@ -1,2 +1,2 @@
-Honor a package's `[pipx.run]` entry point when `pipx run --spec` names an app that is not the PEP 503-normalized
-distribution name, instead of passing that name to `uv tool run`.
+`pipx run --spec` uses a managed venv when the spec has no requirement name or the app differs from its PEP
+503-normalized distribution name. pipx discovers the package's `[pipx.run]` entry point.

--- a/changelog.d/2004.bugfix.md
+++ b/changelog.d/2004.bugfix.md
@@ -1,2 +1,3 @@
-`pipx run --spec` uses a managed venv when the spec has no requirement name or the app differs from its PEP
-503-normalized distribution name. pipx discovers the package's `[pipx.run]` entry point.
+`pipx run --spec <spec> <app>` on the uv backend builds a pipx-managed venv when `<app>` differs from the spec's
+normalized distribution name, or when the spec carries no name at all, so pipx honors the package's `[pipx.run]` entry
+point. An `<app>` that matches the name still runs through `uv tool run`, which sees console scripts only.

--- a/docs/how-to/use-uv-backend.rst
+++ b/docs/how-to/use-uv-backend.rst
@@ -73,9 +73,10 @@ all accept ``--backend``. Switch an installed venv with ``pipx reinstall NAME --
 ************
 
 - ``pipx install pip --backend uv`` errors: a uv venv has no pip. Use ``--backend pip``.
-- ``pipx run --spec <spec> <app> --backend uv`` uses a pipx-managed venv when the spec has no requirement name or
-  ``<app>`` differs from its normalized distribution name. pipx reads ``[pipx.run]`` metadata from the venv;
-  ``uv tool run`` reads only console scripts.
+- ``pipx run --backend uv`` honors ``[pipx.run]`` entry points only where it builds a venv, which with ``--spec``
+  means an ``<app>`` that differs from the spec's normalized distribution name, or a spec carrying no name at all.
+  An ``<app>`` matching that name goes to ``uv tool run``, which reads console scripts only, so reach for
+  ``--backend pip`` to override a console script of the same name.
 - Some ``--pip-args`` values have no ``uv tool run`` equivalent (``--editable``, ``--no-build-isolation``); pipx errors
   instead of dropping them. See :doc:`use-private-index` for which flags uv translates.
 - ``pipx run --backend uv`` against URL or named-pipe scripts falls back to a pipx-managed venv, because ``uv run
@@ -84,6 +85,8 @@ all accept ``--backend``. Switch an installed venv with ``pipx reinstall NAME --
   path, or a name it normalizes (``pipx run pip_search`` installs ``pip-search``). ``uv tool run`` takes that name up
   front and would guess it from the package, so pipx installs the package first and runs the script it declares. Pass
   ``pipx run --spec <spec> <normalized-name>`` to keep uv's cache when the package declares a matching console script.
+  A spec with no distribution name (a path, a URL, a direct reference) is installed twice, once to learn its name and
+  once into the run venv.
 
 *************
  Cache layout

--- a/docs/how-to/use-uv-backend.rst
+++ b/docs/how-to/use-uv-backend.rst
@@ -73,8 +73,9 @@ all accept ``--backend``. Switch an installed venv with ``pipx reinstall NAME --
 ************
 
 - ``pipx install pip --backend uv`` errors: a uv venv has no pip. Use ``--backend pip``.
-- ``pipx run --backend uv`` does not honor ``[pipx.run]`` entry points when it hands the run to ``uv tool run``, which
-  sees only standard console scripts. Use ``--backend pip`` when your package declares them.
+- ``pipx run --spec <spec> <app> --backend uv`` uses a pipx-managed venv when the spec has no requirement name or
+  ``<app>`` differs from its normalized distribution name. pipx reads ``[pipx.run]`` metadata from the venv;
+  ``uv tool run`` reads only console scripts.
 - Some ``--pip-args`` values have no ``uv tool run`` equivalent (``--editable``, ``--no-build-isolation``); pipx errors
   instead of dropping them. See :doc:`use-private-index` for which flags uv translates.
 - ``pipx run --backend uv`` against URL or named-pipe scripts falls back to a pipx-managed venv, because ``uv run
@@ -82,7 +83,7 @@ all accept ``--backend``. Switch an installed venv with ``pipx reinstall NAME --
 - ``pipx run`` falls back to a pipx-managed venv when it has to infer the script name: from a VCS URL, a local project
   path, or a name it normalizes (``pipx run pip_search`` installs ``pip-search``). ``uv tool run`` takes that name up
   front and would guess it from the package, so pipx installs the package first and runs the script it declares. Pass
-  ``pipx run --spec <spec> <script>`` to keep uv's cache.
+  ``pipx run --spec <spec> <normalized-name>`` to keep uv's cache when the package declares a matching console script.
 
 *************
  Cache layout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,32 +138,32 @@ lint.select = [
   "ALL",
 ]
 lint.ignore = [
-  "COM812", # conflicts with formatter
-  "CPY",    # no copyright header
-  "D",      # ignore documentation for now
-  "D203",   # `one-blank-line-before-class` and `no-blank-line-before-class` are incompatible
-  "D212",   # `multi-line-summary-first-line` and `multi-line-summary-second-line` are incompatible
-  "DOC201", # no restructuredtext support yet
-  "DOC402", # no restructuredtext support yet
-  "DOC501", # broken with sphinx docs
-  "INP001", # no implicit namespaces here
-  "ISC001", # conflicts with formatter
-  "RUF067", # `__init__` module should only contain docstrings and re-exports
-  "S104",   # possible binding to all interfaces
-  "S404",   # using subprocess is alright
-  "S603",   # using subprocess is alright
+  "CPY",                                       # no copyright header
+  "D",                                         # ignore documentation for now
+  "docstring-missing-exception",               # broken with sphinx docs
+  "docstring-missing-returns",                 # no restructuredtext support yet
+  "docstring-missing-yields",                  # no restructuredtext support yet
+  "hardcoded-bind-all-interfaces",             # possible binding to all interfaces
+  "implicit-namespace-package",                # no implicit namespaces here
+  "incorrect-blank-line-before-class",         # `one-blank-line-before-class` and `no-blank-line-before-class` are incompatible
+  "missing-trailing-comma",                    # conflicts with formatter
+  "multi-line-summary-first-line",             # `multi-line-summary-first-line` and `multi-line-summary-second-line` are incompatible
+  "non-empty-init-module",                     # `__init__` module should only contain docstrings and re-exports
+  "single-line-implicit-string-concatenation", # conflicts with formatter
+  "subprocess-without-shell-equals-true",      # using subprocess is alright
+  "suspicious-subprocess-import",              # using subprocess is alright
 ]
 lint.per-file-ignores."src/pipx/venv.py" = [
-  "A005", # module shadows the standard library
+  "stdlib-module-shadowing", # module shadows the standard library
 ]
 lint.per-file-ignores."tests/**/*.py" = [
-  "D",       # don't care about documentation in tests
-  "FBT",     # don't care about booleans as positional arguments in tests
-  "INP001",  # no implicit namespace
-  "PLR0913", # too many arguments to function definition
-  "PLR2004", # magic value used in comparison
-  "S101",    # asserts allowed in tests
-  "S603",    # subprocess call: check for execution of untrusted input
+  "assert",                               # asserts allowed in tests
+  "D",                                    # don't care about documentation in tests
+  "FBT",                                  # don't care about booleans as positional arguments in tests
+  "implicit-namespace-package",           # no implicit namespace
+  "magic-value-comparison",               # magic value used in comparison
+  "subprocess-without-shell-equals-true", # subprocess call: check for execution of untrusted input
+  "too-many-arguments",                   # too many arguments to function definition
 ]
 lint.isort = { known-first-party = [
   "helpers",

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -372,15 +372,13 @@ def run(  # ruff:ignore[too-many-arguments, too-many-positional-arguments]  # mi
     # ``resolved_backend`` only decides ROUTING (uv tool run vs Venv); cli/env
     # stay separate when we hand off so the Venv's source-attribution stays right.
     resolved_backend, _ = resolve_backend_name(cli_value=backend, env_value=env_backend)
-    # `uv tool run` takes the script name up front and would guess an inferred one from the package name.
-    # It also has no knowledge of pipx's [pipx.run] group, so a typed ``--spec`` app name that is not
-    # the PEP 503-normalized distribution name must use the venv path (https://github.com/pypa/pipx/issues/2004).
-    use_uvx = (
+    # uv cannot discover inferred app names or pipx.run entry points before installing the package.
+    use_uvx: Final[bool] = (
         resolved_backend == UV
         and not pypackages
         and not python_args
         and not infer_app_name
-        and not _typed_app_skips_uvx(app, spec)
+        and _can_use_uvx_for_spec(app, spec)
     )
 
     content = None if spec is not None else maybe_script_content(app, is_path=is_path)
@@ -451,22 +449,13 @@ def _requirement_name(app: str) -> str:
         return app
 
 
-def _typed_app_skips_uvx(app: str, spec: str | None) -> bool:
-    """Return True when a typed ``--spec`` app name cannot be an ``uv tool run`` console-script lookup.
-
-    ``uv tool run`` looks up a console script by the exact app name and does not consult ``[pipx.run]``.
-    When the typed name is not the PEP 503-normalized distribution name — the usual ``[pipx.run]``
-    case, e.g. ``pipx run --spec 'coherent.test>=0.7.0' coherent.test`` — the venv path is the one
-    that honors that group. Non-requirement specs (local paths, VCS URLs) also go through the venv
-    path so the installed metadata can be read.
-    """
+def _can_use_uvx_for_spec(app: str, spec: str | None) -> bool:
     if spec is None:
-        return False
-    try:
-        spec_name = canonicalize_name(Requirement(spec).name)
-    except InvalidRequirement:
         return True
-    return app != spec_name
+    try:
+        return app == canonicalize_name(Requirement(spec).name)
+    except InvalidRequirement:
+        return False
 
 
 def _prepare_venv(  # ruff:ignore[too-many-arguments]  # mirrors the flat run/install option set for one temporary venv

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -480,11 +480,14 @@ def _prepare_venv(  # ruff:ignore[too-many-arguments]  # mirrors the flat run/in
     if venv.pipx_metadata.main_package.package is not None:
         package_name = venv.pipx_metadata.main_package.package
     else:
+        # a spec without a distribution name costs a throwaway venv here, so resolve it on the requested backend
         package_name = package_name_from_spec(
             package_or_url,
             python,
             pip_args=pip_args,
             verbose=verbose,
+            backend=backend,
+            env_backend=env_backend,
             cooldown_days=cooldown_days,
         )
 

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -372,8 +372,16 @@ def run(  # ruff:ignore[too-many-arguments, too-many-positional-arguments]  # mi
     # ``resolved_backend`` only decides ROUTING (uv tool run vs Venv); cli/env
     # stay separate when we hand off so the Venv's source-attribution stays right.
     resolved_backend, _ = resolve_backend_name(cli_value=backend, env_value=env_backend)
-    # `uv tool run` takes the script name up front and would guess an inferred one from the package name
-    use_uvx = resolved_backend == UV and not pypackages and not python_args and not infer_app_name
+    # `uv tool run` takes the script name up front and would guess an inferred one from the package name.
+    # It also has no knowledge of pipx's [pipx.run] group, so a typed ``--spec`` app name that is not
+    # the PEP 503-normalized distribution name must use the venv path (https://github.com/pypa/pipx/issues/2004).
+    use_uvx = (
+        resolved_backend == UV
+        and not pypackages
+        and not python_args
+        and not infer_app_name
+        and not _typed_app_skips_uvx(app, spec)
+    )
 
     content = None if spec is not None else maybe_script_content(app, is_path=is_path)
     if content is not None:
@@ -441,6 +449,24 @@ def _requirement_name(app: str) -> str:
         return Requirement(app).name
     except InvalidRequirement:
         return app
+
+
+def _typed_app_skips_uvx(app: str, spec: str | None) -> bool:
+    """Return True when a typed ``--spec`` app name cannot be an ``uv tool run`` console-script lookup.
+
+    ``uv tool run`` looks up a console script by the exact app name and does not consult ``[pipx.run]``.
+    When the typed name is not the PEP 503-normalized distribution name — the usual ``[pipx.run]``
+    case, e.g. ``pipx run --spec 'coherent.test>=0.7.0' coherent.test`` — the venv path is the one
+    that honors that group. Non-requirement specs (local paths, VCS URLs) also go through the venv
+    path so the installed metadata can be read.
+    """
+    if spec is None:
+        return False
+    try:
+        spec_name = canonicalize_name(Requirement(spec).name)
+    except InvalidRequirement:
+        return True
+    return app != spec_name
 
 
 def _prepare_venv(  # ruff:ignore[too-many-arguments]  # mirrors the flat run/install option set for one temporary venv

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -121,7 +121,8 @@ def test_run_spec_honors_dotted_pipx_run_entry_point(
 ) -> None:
     pyproject = empty_project / "pyproject.toml"
     pyproject.write_text(
-        pyproject.read_text(encoding="utf-8")
+        pyproject
+        .read_text(encoding="utf-8")
         .replace('scripts.empty-project = "empty_project.main:cli"', "")
         .replace(
             'entry-points."pipx.run".empty-project = "empty_project.main:cli"',

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -97,11 +97,13 @@ def test_run_normalized_name_skips_uv_tool_run(caplog: pytest.LogCaptureFixture)
 )
 @pytest.mark.usefixtures("pipx_temp_env")
 def test_run_matching_name_uses_uv_tool_run(mocker: MockerFixture, spec_args: list[str]) -> None:
-    execvpe: Final = mocker.patch("os.execvpe", autospec=True, side_effect=SystemExit(0))
+    # patch the handover rather than os.execvpe, which exec_app calls on POSIX only
+    exec_app: Final = mocker.patch("pipx.commands.run_uv.exec_app", autospec=True, side_effect=SystemExit(0))
 
     run_pipx_cli_exit(["run", "--backend", "uv", *spec_args, "pycowsay", "cowsay", "hi"], assert_exit=0)
 
-    assert execvpe.call_args.args[1][1:3] == ["tool", "run"]
+    exec_app.assert_called_once()
+    assert exec_app.call_args.args[0][1:3] == ["tool", "run"]
 
 
 @pytest.mark.parametrize(
@@ -112,13 +114,12 @@ def test_run_matching_name_uses_uv_tool_run(mocker: MockerFixture, spec_args: li
     ],
 )
 @pytest.mark.usefixtures("pipx_temp_env")
+@mock.patch("os.execvpe", new=execvpe_mock)
 def test_run_spec_honors_dotted_pipx_run_entry_point(
     empty_project: Path,
     caplog: pytest.LogCaptureFixture,
-    mocker: MockerFixture,
     spec_template: str,
 ) -> None:
-    mocker.patch("os.execvpe", autospec=True, side_effect=execvpe_mock)
     pyproject: Final[Path] = empty_project / "pyproject.toml"
     pyproject.write_text(
         pyproject

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -89,6 +89,55 @@ def test_run_normalized_name_skips_uv_tool_run(caplog: pytest.LogCaptureFixture)
 
 
 @pytest.mark.usefixtures("pipx_temp_env")
+def test_run_spec_typed_pipx_run_name_skips_uv_tool_run(mocker: MockerFixture) -> None:
+    # ``uv tool run --from coherent.test>=0.7.0 coherent.test`` has no [pipx.run] support; venv path does
+    uvx = mocker.patch("pipx.commands.run.run_via_uv_tool_run")
+    venv = mocker.patch("pipx.commands.run.run_package", side_effect=SystemExit(0))
+
+    run_pipx_cli_exit(["run", "--backend", "uv", "--spec", "coherent.test>=0.7.0", "coherent.test"], assert_exit=0)
+
+    uvx.assert_not_called()
+    venv.assert_called_once()
+    assert venv.call_args.args[0] == "coherent.test"
+    assert venv.call_args.args[1] == "coherent.test>=0.7.0"
+
+
+@pytest.mark.usefixtures("pipx_temp_env")
+def test_run_spec_matching_name_uses_uv_tool_run(mocker: MockerFixture) -> None:
+    uvx = mocker.patch("pipx.commands.run.run_via_uv_tool_run", side_effect=SystemExit(0))
+    venv = mocker.patch("pipx.commands.run.run_package")
+
+    run_pipx_cli_exit(["run", "--backend", "uv", "--spec", "pycowsay", "pycowsay", "cowsay", "hi"], assert_exit=0)
+
+    uvx.assert_called_once()
+    venv.assert_not_called()
+
+
+@pytest.mark.usefixtures("pipx_temp_env")
+@mock.patch("os.execvpe", new=execvpe_mock)
+def test_run_spec_honors_dotted_pipx_run_entry_point(
+    empty_project: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    pyproject = empty_project / "pyproject.toml"
+    pyproject.write_text(
+        pyproject.read_text(encoding="utf-8")
+        .replace('scripts.empty-project = "empty_project.main:cli"', "")
+        .replace(
+            'entry-points."pipx.run".empty-project = "empty_project.main:cli"',
+            'entry-points."pipx.run"."empty.project" = "empty_project.main:main"',
+        ),
+        encoding="utf-8",
+    )
+    caplog.set_level(logging.INFO)
+
+    run_pipx_cli_exit(["run", "--backend", "uv", "--spec", str(empty_project), "empty.project"], assert_exit=0)
+
+    assert "Using discovered entry point for 'pipx run'" in caplog.text
+    assert f"exec_app: {paths.ctx.venv_cache}" in caplog.text
+
+
+@pytest.mark.usefixtures("pipx_temp_env")
 def test_run_preserves_explicit_app_name(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -88,38 +88,38 @@ def test_run_normalized_name_skips_uv_tool_run(caplog: pytest.LogCaptureFixture)
     assert f"exec_app: {paths.ctx.venv_cache}" in caplog.text
 
 
+@pytest.mark.parametrize(
+    "spec_args",
+    [
+        pytest.param([], id="package-name"),
+        pytest.param(["--spec", "pycowsay"], id="explicit-spec"),
+    ],
+)
 @pytest.mark.usefixtures("pipx_temp_env")
-def test_run_spec_typed_pipx_run_name_skips_uv_tool_run(mocker: MockerFixture) -> None:
-    # ``uv tool run --from coherent.test>=0.7.0 coherent.test`` has no [pipx.run] support; venv path does
-    uvx = mocker.patch("pipx.commands.run.run_via_uv_tool_run")
-    venv = mocker.patch("pipx.commands.run.run_package", side_effect=SystemExit(0))
+def test_run_matching_name_uses_uv_tool_run(mocker: MockerFixture, spec_args: list[str]) -> None:
+    execvpe: Final = mocker.patch("os.execvpe", autospec=True, side_effect=SystemExit(0))
 
-    run_pipx_cli_exit(["run", "--backend", "uv", "--spec", "coherent.test>=0.7.0", "coherent.test"], assert_exit=0)
+    run_pipx_cli_exit(["run", "--backend", "uv", *spec_args, "pycowsay", "cowsay", "hi"], assert_exit=0)
 
-    uvx.assert_not_called()
-    venv.assert_called_once()
-    assert venv.call_args.args[0] == "coherent.test"
-    assert venv.call_args.args[1] == "coherent.test>=0.7.0"
+    assert execvpe.call_args.args[1][1:3] == ["tool", "run"]
 
 
+@pytest.mark.parametrize(
+    "spec_template",
+    [
+        pytest.param("{path}", id="local-path"),
+        pytest.param("empty-project @ {uri}", id="direct-reference"),
+    ],
+)
 @pytest.mark.usefixtures("pipx_temp_env")
-def test_run_spec_matching_name_uses_uv_tool_run(mocker: MockerFixture) -> None:
-    uvx = mocker.patch("pipx.commands.run.run_via_uv_tool_run", side_effect=SystemExit(0))
-    venv = mocker.patch("pipx.commands.run.run_package")
-
-    run_pipx_cli_exit(["run", "--backend", "uv", "--spec", "pycowsay", "pycowsay", "cowsay", "hi"], assert_exit=0)
-
-    uvx.assert_called_once()
-    venv.assert_not_called()
-
-
-@pytest.mark.usefixtures("pipx_temp_env")
-@mock.patch("os.execvpe", new=execvpe_mock)
 def test_run_spec_honors_dotted_pipx_run_entry_point(
     empty_project: Path,
     caplog: pytest.LogCaptureFixture,
+    mocker: MockerFixture,
+    spec_template: str,
 ) -> None:
-    pyproject = empty_project / "pyproject.toml"
+    mocker.patch("os.execvpe", autospec=True, side_effect=execvpe_mock)
+    pyproject: Final[Path] = empty_project / "pyproject.toml"
     pyproject.write_text(
         pyproject
         .read_text(encoding="utf-8")
@@ -132,7 +132,17 @@ def test_run_spec_honors_dotted_pipx_run_entry_point(
     )
     caplog.set_level(logging.INFO)
 
-    run_pipx_cli_exit(["run", "--backend", "uv", "--spec", str(empty_project), "empty.project"], assert_exit=0)
+    run_pipx_cli_exit(
+        [
+            "run",
+            "--backend",
+            "uv",
+            "--spec",
+            spec_template.format(path=empty_project, uri=empty_project.as_uri()),
+            "empty.project",
+        ],
+        assert_exit=0,
+    )
 
     assert "Using discovered entry point for 'pipx run'" in caplog.text
     assert f"exec_app: {paths.ctx.venv_cache}" in caplog.text


### PR DESCRIPTION
## Summary

- `uv tool run` has no knowledge of pipx's `[pipx.run]` entry-point group. After #1996, `pipx run coherent.test` already falls off the uvx fast-path because the name normalizes, but `pipx run --spec <spec> <app>` still handed the typed app name to `uv tool run`.
- When that typed name is not the PEP 503-normalized distribution name (the usual `[pipx.run]` case, e.g. `pipx run --spec 'coherent.test>=0.7.0' coherent.test`), route through the venv path so `_find_entry_point(..., "pipx.run")` can honor it. Matching names such as `pipx run --spec pycowsay pycowsay` still use `uv tool run`.
- Local-path / VCS `--spec` values also take the venv path, since they are not requirement names `uv tool run` can look up as console scripts.

Fixes #2004.

## Test plan

- [x] `test_run_spec_typed_pipx_run_name_skips_uv_tool_run` — `--spec coherent.test>=0.7.0 coherent.test` does not call `run_via_uv_tool_run`
- [x] `test_run_spec_matching_name_uses_uv_tool_run` — `--spec pycowsay pycowsay` still uses the uvx fast-path
- [x] `test_run_spec_honors_dotted_pipx_run_entry_point` — local project with only `[pipx.run] empty.project` runs via the venv path under `--backend uv`
- [x] Existing inferred-name / `--spec` tests still pass