### PR TITLE
DOC: Use pipx as the docs parser program name

### DIFF
--- a/changelog.d/2005.doc.md
+++ b/changelog.d/2005.doc.md
@@ -1,0 +1,2 @@
+The CLI reference in the documentation now shows ``pipx run`` instead of
+``sphinx-build run``.

--- a/changelog.d/2005.doc.md
+++ b/changelog.d/2005.doc.md
@@ -1,2 +1,1 @@
-The CLI reference in the documentation now shows ``pipx run`` instead of
-``sphinx-build run``.
+The CLI reference in the documentation now shows `pipx run` instead of `sphinx-build run`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,32 +138,32 @@ lint.select = [
   "ALL",
 ]
 lint.ignore = [
-  "COM812", # conflicts with formatter
-  "CPY",    # no copyright header
-  "D",      # ignore documentation for now
-  "D203",   # `one-blank-line-before-class` and `no-blank-line-before-class` are incompatible
-  "D212",   # `multi-line-summary-first-line` and `multi-line-summary-second-line` are incompatible
-  "DOC201", # no restructuredtext support yet
-  "DOC402", # no restructuredtext support yet
-  "DOC501", # broken with sphinx docs
-  "INP001", # no implicit namespaces here
-  "ISC001", # conflicts with formatter
-  "RUF067", # `__init__` module should only contain docstrings and re-exports
-  "S104",   # possible binding to all interfaces
-  "S404",   # using subprocess is alright
-  "S603",   # using subprocess is alright
+  "CPY",                                       # no copyright header
+  "D",                                         # ignore documentation for now
+  "docstring-missing-exception",               # broken with sphinx docs
+  "docstring-missing-returns",                 # no restructuredtext support yet
+  "docstring-missing-yields",                  # no restructuredtext support yet
+  "hardcoded-bind-all-interfaces",             # possible binding to all interfaces
+  "implicit-namespace-package",                # no implicit namespaces here
+  "incorrect-blank-line-before-class",         # `one-blank-line-before-class` and `no-blank-line-before-class` are incompatible
+  "missing-trailing-comma",                    # conflicts with formatter
+  "multi-line-summary-first-line",             # `multi-line-summary-first-line` and `multi-line-summary-second-line` are incompatible
+  "non-empty-init-module",                     # `__init__` module should only contain docstrings and re-exports
+  "single-line-implicit-string-concatenation", # conflicts with formatter
+  "subprocess-without-shell-equals-true",      # using subprocess is alright
+  "suspicious-subprocess-import",              # using subprocess is alright
 ]
 lint.per-file-ignores."src/pipx/venv.py" = [
-  "A005", # module shadows the standard library
+  "stdlib-module-shadowing", # module shadows the standard library
 ]
 lint.per-file-ignores."tests/**/*.py" = [
-  "D",       # don't care about documentation in tests
-  "FBT",     # don't care about booleans as positional arguments in tests
-  "INP001",  # no implicit namespace
-  "PLR0913", # too many arguments to function definition
-  "PLR2004", # magic value used in comparison
-  "S101",    # asserts allowed in tests
-  "S603",    # subprocess call: check for execution of untrusted input
+  "assert",                               # asserts allowed in tests
+  "D",                                    # don't care about documentation in tests
+  "FBT",                                  # don't care about booleans as positional arguments in tests
+  "implicit-namespace-package",           # no implicit namespace
+  "magic-value-comparison",               # magic value used in comparison
+  "subprocess-without-shell-equals-true", # subprocess call: check for execution of untrusted input
+  "too-many-arguments",                   # too many arguments to function definition
 ]
 lint.isort = { known-first-party = [
   "helpers",

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -1759,7 +1759,7 @@ def get_command_parser(
         )
 
     parser = argparse.ArgumentParser(
-        prog=prog or prog_name(),
+        prog=prog_name() if prog is None else prog,
         formatter_class=LineWrapRawTextHelpFormatter,
         description=PIPX_DESCRIPTION,
     )

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -1508,7 +1508,8 @@ def _add_run(subparsers: argparse._SubParsersAction, shared_parser: argparse.Arg
     add_backend_arg(p)
     p.set_defaults(subparser=p, func=_cmd_run)
 
-    # modify usage text to show required app argument
+    # modify usage text to show required app argument; this freezes the prog into the usage line, so a parser built
+    # for the docs has to be given its program name up front
     p.usage = re.sub(r"^usage: ", "", p.format_usage())
     # add a double-dash to usage text to show requirement before app
     p.usage = re.sub(r"\.\.\.", "app ...", p.usage)
@@ -1759,7 +1760,7 @@ def get_command_parser(
         )
 
     parser = argparse.ArgumentParser(
-        prog=prog_name() if prog is None else prog,
+        prog=prog or prog_name(),
         formatter_class=LineWrapRawTextHelpFormatter,
         description=PIPX_DESCRIPTION,
     )
@@ -1816,7 +1817,9 @@ def get_command_parser(
 
 def build_parser() -> argparse.ArgumentParser:
     # sphinx-argparse-cli renders the CLI reference from a parser-returning callable; expose the root parser alone
-    # so the docs build cannot drift from the argument definitions.
+    # so the docs build cannot drift from the argument definitions. Name the program here rather than inherit the docs
+    # builder's argv[0]: ``run`` bakes the prog into a frozen usage string, which the directive's ``:prog:`` option
+    # cannot rewrite afterwards.
     return get_command_parser(prog="pipx")[0]
 
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -1713,7 +1713,9 @@ def _make_print_help(
     return _print_help
 
 
-def get_command_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.ArgumentParser]]:
+def get_command_parser(
+    *, prog: str | None = None
+) -> tuple[argparse.ArgumentParser, dict[str, argparse.ArgumentParser]]:
     venv_container = VenvContainer(paths.ctx.venvs)
 
     completer_venvs = InstalledVenvsCompleter(venv_container)
@@ -1757,7 +1759,7 @@ def get_command_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Ar
         )
 
     parser = argparse.ArgumentParser(
-        prog=prog_name(),
+        prog=prog or prog_name(),
         formatter_class=LineWrapRawTextHelpFormatter,
         description=PIPX_DESCRIPTION,
     )
@@ -1815,7 +1817,7 @@ def get_command_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Ar
 def build_parser() -> argparse.ArgumentParser:
     # sphinx-argparse-cli renders the CLI reference from a parser-returning callable; expose the root parser alone
     # so the docs build cannot drift from the argument definitions.
-    return get_command_parser()[0]
+    return get_command_parser(prog="pipx")[0]
 
 
 def _cmd_completions(args: argparse.Namespace, ctx: DispatchContext) -> ExitCode:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -68,6 +68,17 @@ def test_prog_name(monkeypatch: pytest.MonkeyPatch, argv: str, executable: str, 
     assert main.prog_name() == expected
 
 
+def test_build_parser_uses_pipx_prog(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    # The docs build renders the CLI reference from build_parser(); sys.argv[0]
+    # is sphinx-build there, so the parser must not derive its name from it.
+    monkeypatch.setattr("pipx.main.sys.argv", ["sphinx-build"])
+    parser = main.build_parser()
+    assert parser.prog == "pipx"
+    with pytest.raises(SystemExit):
+        parser.parse_args(["run", "--help"])
+    assert "pipx run" in capsys.readouterr().out
+
+
 def test_limit_verbosity() -> None:
     assert not run_pipx_cli(["list", "-qqq"])
     assert not run_pipx_cli(["list", "-vvvv"])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,7 +7,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Final, cast
+from typing import TYPE_CHECKING, Final, cast
 from unittest import mock
 
 import pytest
@@ -15,6 +15,9 @@ from docutils.core import publish_string
 
 from helpers import run_pipx_cli
 from pipx import constants, main
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 _ROOT: Final = Path(__file__).parents[1]
 _MANPAGE_RST: Final = _ROOT / "docs" / "man" / "pipx.1.rst"
@@ -62,21 +65,18 @@ def test_version(capsys: pytest.CaptureFixture[str]) -> None:
         ("__main__.py", "/usr/bin/python", "/usr/bin/python -m pipx"),
     ],
 )
-def test_prog_name(monkeypatch: pytest.MonkeyPatch, argv: str, executable: str, expected: str) -> None:
-    monkeypatch.setattr("pipx.main.sys.argv", [argv])
-    monkeypatch.setattr("pipx.main.sys.executable", executable)
+def test_prog_name(mocker: MockerFixture, argv: str, executable: str, expected: str) -> None:
+    mocker.patch.object(sys, "argv", [argv])
+    mocker.patch.object(sys, "executable", executable)
     assert main.prog_name() == expected
 
 
-def test_build_parser_uses_pipx_prog(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
-    # The docs build renders the CLI reference from build_parser(); sys.argv[0]
-    # is sphinx-build there, so the parser must not derive its name from it.
-    monkeypatch.setattr("pipx.main.sys.argv", ["sphinx-build"])
+def test_build_parser_uses_pipx_in_subcommand_help(mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    mocker.patch.object(sys, "argv", ["sphinx-build"])
     parser = main.build_parser()
-    assert parser.prog == "pipx"
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit, match="0"):
         parser.parse_args(["run", "--help"])
-    assert "pipx run" in capsys.readouterr().out
+    assert capsys.readouterr().out.startswith("usage: pipx run ")
 
 
 def test_limit_verbosity() -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -74,8 +74,11 @@ def test_prog_name(mocker: MockerFixture, argv: str, executable: str, expected: 
 def test_build_parser_uses_pipx_in_subcommand_help(mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
     mocker.patch.object(sys, "argv", ["sphinx-build"])
     parser = main.build_parser()
-    with pytest.raises(SystemExit, match="0"):
+
+    with pytest.raises(SystemExit) as sys_exit:
         parser.parse_args(["run", "--help"])
+
+    assert sys_exit.value.code == 0
     assert capsys.readouterr().out.startswith("usage: pipx run ")
 
 


### PR DESCRIPTION
Closes #2005.

The docs build renders the CLI reference from `build_parser()`, which derives
the program name from `sys.argv[0]` via `prog_name()`. During the Sphinx build
that value is `sphinx-build`, so the generated `run` subparser is named
`sphinx-build run` instead of `pipx run`.

Let `get_command_parser()` accept an explicit `prog` and have `build_parser()`
pass `prog="pipx"`, so the docs parser is always named `pipx` regardless of
`sys.argv[0]`. Add a regression test asserting both the root and nested
subparser program names, plus a `changelog.d/2005.doc.md` fragment.
