### PR TITLE
Fall back to 'pipx' when argv[0] is not pipx

### DIFF
--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -75,7 +75,15 @@ def print_version() -> None:
 def prog_name() -> str:
     with contextlib.suppress(IndexError):
         prog = Path(sys.argv[0]).name
-        return f"{sys.executable} -m pipx" if prog == "__main__.py" else prog
+        if prog == "__main__.py":
+            return f"{sys.executable} -m pipx"
+        # Only trust argv[0] when it actually names pipx. The parser is also built
+        # by processes that are not pipx -- the docs build imports build_parser from
+        # sphinx-build -- and argparse bakes the parent prog into every subparser at
+        # construction time, so an unrelated argv[0] leaks into the whole CLI
+        # reference as "sphinx-build run", "sphinx-build install" and so on.
+        if prog.startswith("pipx"):
+            return prog
     return "pipx"
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -60,12 +60,33 @@ def test_version(capsys: pytest.CaptureFixture[str]) -> None:
     [
         ("/usr/bin/pipx", "", "pipx"),
         ("__main__.py", "/usr/bin/python", "/usr/bin/python -m pipx"),
+        # An alternate install name is still the user's own invocation, so keep it.
+        ("/usr/bin/pipx3", "", "pipx3"),
+        # Anything that is not pipx is some other process importing the parser --
+        # the docs build runs under sphinx-build -- and must not leak into help output.
+        ("/usr/local/bin/sphinx-build", "", "pipx"),
+        ("/usr/bin/pytest", "", "pipx"),
     ],
 )
 def test_prog_name(monkeypatch: pytest.MonkeyPatch, argv: str, executable: str, expected: str) -> None:
     monkeypatch.setattr("pipx.main.sys.argv", [argv])
     monkeypatch.setattr("pipx.main.sys.executable", executable)
     assert main.prog_name() == expected
+
+
+def test_subparser_prog_does_not_leak_host_program(monkeypatch: pytest.MonkeyPatch) -> None:
+    """argparse bakes the parent prog into each subparser when it is created."""
+    monkeypatch.setattr("pipx.main.sys.argv", ["/usr/local/bin/sphinx-build"])
+    parser, _ = main.get_command_parser()
+
+    subparsers_type = argparse._SubParsersAction  # ruff:ignore[private-member-access]  # argparse has no public subparser API
+    top_actions = parser._actions  # ruff:ignore[private-member-access]  # argparse has no public subparser API
+    subparsers_action = next(a for a in top_actions if isinstance(a, subparsers_type))
+    choices = cast("dict[str, argparse.ArgumentParser]", subparsers_action.choices)
+
+    assert parser.prog == "pipx"
+    for name, subparser in choices.items():
+        assert subparser.prog.startswith("pipx "), f"{name!r} usage line reads {subparser.prog!r}"
 
 
 def test_limit_verbosity() -> None:


### PR DESCRIPTION
Fixes #2005.

## The problem

`prog_name()` returns `Path(sys.argv[0]).name` unconditionally:

```python
def prog_name() -> str:
    with contextlib.suppress(IndexError):
        prog = Path(sys.argv[0]).name
        return f"{sys.executable} -m pipx" if prog == "__main__.py" else prog
    return "pipx"
```

The CLI reference is generated by `sphinx_argparse_cli` from `pipx.main.build_parser`, which runs inside the docs build — so `sys.argv[0]` is `sphinx-build`, and every usage line on the published page reads:

```
sphinx-build run [-h] [--quiet] [--verbose] [--skip-maintenance]
```

## Why `:prog: pipx` does not already fix it

`docs/reference/cli.rst` does set `:prog: pipx`, but that only relabels the root. `argparse` computes each subparser's `prog` from its parent at `add_parser()` time, so `sphinx-build run` is baked in before the directive ever runs.

Reproduced on `main`:

```python
>>> sys.argv[0] = "/usr/local/bin/sphinx-build"
>>> p = build_parser()
>>> p.prog
'sphinx-build'
>>> # every subcommand inherits it
'sphinx-build run', 'sphinx-build install', 'sphinx-build list'
```

## The change

Only trust `argv[0]` when it actually names pipx:

| `argv[0]` | before | after |
|---|---|---|
| `/usr/bin/pipx` | `pipx` | `pipx` |
| `/usr/bin/pipx3` | `pipx3` | `pipx3` |
| `__main__.py` | `python -m pipx` | `python -m pipx` |
| `sphinx-build` | **`sphinx-build`** | `pipx` |
| `pytest` | **`pytest`** | `pipx` |

An alternate install name like `pipx3` is still the user's own invocation, so it is preserved. Anything else is some other process importing the parser, and falls back to the literal `pipx`.

## Tests

Added cases to the existing `test_prog_name` parametrisation, plus a test asserting no subparser usage line leaks the host program. Both fail before the change — `AssertionError: assert 'sphinx-build' == 'pipx'` — and pass after.

`tests/test_main.py`: **46 passed**.