### PR TITLE
🔧 chore: batch dependency updates weekly on Tuesday

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+      day: tuesday
     groups:
       actions:
         patterns:


### PR DESCRIPTION
Every project I maintain now checks for dependency updates on the same day, so the batched pull requests arrive together instead of scattered across the week. 🔁

Bumps already land grouped here; this moves the run to weekly on Tuesday.
