### PR TITLE
🐛 fix(deps): require packaging>=26

### DIFF
--- a/changelog.d/2015.bugfix.md
+++ b/changelog.d/2015.bugfix.md
@@ -1,0 +1,3 @@
+Require `packaging>=26`. Earlier releases serialize a direct reference as `name@ url` rather than PEP 508's
+`name @ url`, so the specifier pipx recorded in `pipx_metadata.json` and passed to the backend depended on which
+`packaging` happened to be installed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "argcomplete>=1.9.4",
   "colorama>=0.4.4; sys_platform=='win32'",
   "filelock>=3.16",
-  "packaging>=20",
+  "packaging>=26",
   "platformdirs>=4.6",
   "tomli; python_version<'3.11'",
   "userpath>=1.6,!=1.9",


### PR DESCRIPTION
Install the same URL-based package on two machines and pipx can record it two different ways. `pipx install "black @ https://example.com/black.zip"` writes `black@ https://…` under one version of `packaging` and `black @ https://…` under another, then hands the matching string to pip or uv the next time it upgrades that package. The user typed the same command both times; the shape of what we store comes from a transitive dependency they never chose. 🔧

We also advertise a support window we never checked. We tell redistributors `packaging>=20` is fine, so a distro building pipx against its own older `packaging` would take that as a supported combination. As [#2015](https://github.com/pypa/pipx/issues/2015) reports, our own suite disagreed: 12 cases failed on releases 20 through 25.0 and passed from 26.0 on, where `packaging` started emitting PEP 508's space before the `@`.

Raising the floor to `packaging>=26` is the honest fix. The alternative, normalizing the separator inside pipx, buys support for a range that no CI job resolves against, so the claim would stay unverified and we would keep the workaround around to protect it. `packaging` is pure Python with no dependencies of its own and 26.0 landed in January 2026, so resolvers pick it up without friction, and pipx already sets comparable floors on `filelock`, `platformdirs` and `userpath`.

The cost sits with redistributors pinned to an older `packaging` in a frozen release; they hold their current pipx until they can move, which is the usual shape of a dependency bump. Existing environments keep working either way: an older recorded spelling still parses, and pipx rewrites it the next time it touches one.

Closes #2015
