### PR TITLE
🧪 test: fail the suite on warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,14 +191,14 @@ rules.unused-ignore-comment = "error"
 ini_options.minversion = "8"
 ini_options.testpaths = [ "tests" ]
 ini_options.addopts = [ "-ra", "--strict-config", "--strict-markers" ]
+ini_options.markers = [
+  "all_packages: test install with maximum number of packages",
+]
 ini_options.filterwarnings = [
   "error",
   # importlib.metadata warns before returning None for a dist-info carrying no Name; venv_inspect handles that case
   # and Python 3.15 turns it into the KeyError the code already catches
   "ignore:Implicit None on return values is deprecated:DeprecationWarning",
-]
-ini_options.markers = [
-  "all_packages: test install with maximum number of packages",
 ]
 ini_options.log_level = "INFO"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,12 @@ rules.unused-ignore-comment = "error"
 ini_options.minversion = "8"
 ini_options.testpaths = [ "tests" ]
 ini_options.addopts = [ "-ra", "--strict-config", "--strict-markers" ]
+ini_options.filterwarnings = [
+  "error",
+  # importlib.metadata warns before returning None for a dist-info carrying no Name; venv_inspect handles that case
+  # and Python 3.15 turns it into the KeyError the code already catches
+  "ignore:Implicit None on return values is deprecated:DeprecationWarning",
+]
 ini_options.markers = [
   "all_packages: test install with maximum number of packages",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -387,16 +387,20 @@ def pipx_local_pypiserver(
     ]
     cmd += ["--log-file", str(server_log)]
     pypiserver_process = subprocess.Popen(cmd, cwd=root)
-    url = f"http://127.0.0.1:{port}/simple/"
-    while True:
-        try:
-            with urlopen(url) as response:
-                if response.code == HTTPStatus.OK:
-                    break
-        except (URLError, HTTPError):
-            continue
-    yield url
-    pypiserver_process.terminate()
+    try:
+        url = f"http://127.0.0.1:{port}/simple/"
+        while True:
+            try:
+                with urlopen(url) as response:
+                    if response.code == HTTPStatus.OK:
+                        break
+            except (URLError, HTTPError):
+                continue
+        yield url
+    finally:
+        pypiserver_process.terminate()
+        # reap the child before the Popen is collected, else its finalizer raises ResourceWarning
+        pypiserver_process.wait()
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_standalone_interpreter.py
+++ b/tests/test_standalone_interpreter.py
@@ -24,7 +24,7 @@ from package_info import PKG
 from pipx import constants, paths, pipx_metadata_file, standalone_python
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterator
     from unittest.mock import MagicMock
 
     from pytest_mock import MockerFixture
@@ -223,19 +223,31 @@ def test_standalone_python_upgrade_restores_backup_when_swap_fails(
     assert (install_dir / "keepme").read_text(encoding="utf-8") == "v1"
 
 
-def _http_error(code: int) -> urllib.error.HTTPError:
-    return urllib.error.HTTPError("https://example.invalid", code, "boom", email.message.Message(), None)
+@pytest.fixture
+def http_error() -> Iterator[Callable[[int], urllib.error.HTTPError]]:
+    errors: list[urllib.error.HTTPError] = []
+
+    def make(code: int) -> urllib.error.HTTPError:
+        error = urllib.error.HTTPError("https://example.invalid", code, "boom", email.message.Message(), None)
+        errors.append(error)
+        return error
+
+    yield make
+    # urllib hands a synthetic HTTPError an unclosed body, which warns once the object is collected
+    for error in errors:
+        error.close()
 
 
 @pytest.mark.usefixtures("pipx_temp_env")
 def test_standalone_python_download_retries_transient_http_error(
     published_darwin_release: tuple[Path, Callable[[bytes], None]],
     mocker: MockerFixture,
+    http_error: Callable[[int], urllib.error.HTTPError],
 ) -> None:
     _, publish = published_darwin_release
     archive_bytes = _python_archive_bytes()
     publish(archive_bytes)
-    mocker.patch.object(standalone_python, "urlopen", side_effect=[_http_error(503), io.BytesIO(archive_bytes)])
+    mocker.patch.object(standalone_python, "urlopen", side_effect=[http_error(503), io.BytesIO(archive_bytes)])
     sleep = mocker.patch.object(standalone_python.time, "sleep")
 
     python_path = standalone_python.download_python_build_standalone("3.99")
@@ -247,10 +259,11 @@ def test_standalone_python_download_retries_transient_http_error(
 def test_standalone_python_download_does_not_retry_missing_build(
     published_darwin_release: tuple[Path, Callable[[bytes], None]],
     mocker: MockerFixture,
+    http_error: Callable[[int], urllib.error.HTTPError],
 ) -> None:
     _, publish = published_darwin_release
     publish(_python_archive_bytes())
-    mocker.patch.object(standalone_python, "urlopen", side_effect=_http_error(404))
+    mocker.patch.object(standalone_python, "urlopen", side_effect=http_error(404))
     sleep = mocker.patch.object(standalone_python.time, "sleep")
 
     with pytest.raises(standalone_python.PipxError, match="Unable to download"):
@@ -263,10 +276,11 @@ def test_standalone_python_download_does_not_retry_missing_build(
 def test_standalone_python_download_gives_up_after_repeated_failures(
     published_darwin_release: tuple[Path, Callable[[bytes], None]],
     mocker: MockerFixture,
+    http_error: Callable[[int], urllib.error.HTTPError],
 ) -> None:
     _, publish = published_darwin_release
     publish(_python_archive_bytes())
-    mocker.patch.object(standalone_python, "urlopen", side_effect=_http_error(500))
+    mocker.patch.object(standalone_python, "urlopen", side_effect=http_error(500))
     sleep = mocker.patch.object(standalone_python.time, "sleep")
 
     with pytest.raises(standalone_python.PipxError, match="Unable to download"):
@@ -326,12 +340,14 @@ def test_standalone_python_download_restarts_when_range_ignored(
     assert (Path(python_path).is_file(), sleep.call_count) == (True, 1)
 
 
-def test_get_latest_python_releases_retries_transient_http_error(mocker: MockerFixture) -> None:
+def test_get_latest_python_releases_retries_transient_http_error(
+    mocker: MockerFixture, http_error: Callable[[int], urllib.error.HTTPError]
+) -> None:
     release = {"browser_download_url": "https://example.invalid/x.tar.gz", "digest": "sha256:" + "0" * 64}
     mocker.patch.object(
         standalone_python,
         "urlopen",
-        side_effect=[_http_error(503), io.StringIO(json.dumps({"assets": [release]}))],
+        side_effect=[http_error(503), io.StringIO(json.dumps({"assets": [release]}))],
     )
     sleep = mocker.patch.object(standalone_python.time, "sleep")
 
@@ -340,8 +356,10 @@ def test_get_latest_python_releases_retries_transient_http_error(mocker: MockerF
     assert (releases, sleep.call_count) == ([(release["browser_download_url"], release["digest"])], 1)
 
 
-def test_get_latest_python_releases_gives_up_after_repeated_failures(mocker: MockerFixture) -> None:
-    mocker.patch.object(standalone_python, "urlopen", side_effect=_http_error(500))
+def test_get_latest_python_releases_gives_up_after_repeated_failures(
+    mocker: MockerFixture, http_error: Callable[[int], urllib.error.HTTPError]
+) -> None:
+    mocker.patch.object(standalone_python, "urlopen", side_effect=http_error(500))
     sleep = mocker.patch.object(standalone_python.time, "sleep")
 
     with pytest.raises(standalone_python.PipxError, match="Unable to fetch"):
@@ -350,8 +368,10 @@ def test_get_latest_python_releases_gives_up_after_repeated_failures(mocker: Moc
     assert sleep.call_count == 2
 
 
-def test_get_latest_python_releases_does_not_retry_missing_release(mocker: MockerFixture) -> None:
-    mocker.patch.object(standalone_python, "urlopen", side_effect=_http_error(404))
+def test_get_latest_python_releases_does_not_retry_missing_release(
+    mocker: MockerFixture, http_error: Callable[[int], urllib.error.HTTPError]
+) -> None:
+    mocker.patch.object(standalone_python, "urlopen", side_effect=http_error(404))
     sleep = mocker.patch.object(standalone_python.time, "sleep")
 
     with pytest.raises(standalone_python.PipxError, match="Unable to fetch"):


### PR DESCRIPTION
A deprecation warning is a deadline with a grace period, and ours scroll past in CI where nobody reads them. We find out that the grace period expired when a new Python or a new dependency turns the warning into an exception and a green suite goes red on a release we did not plan for. Failing the suite on a warning moves that discovery to the day the warning first appears, while there is still a release or two of room to act on it. ⏱️

Two of the warnings already showing were leaks in our own test setup rather than deprecations. The session fixture signalled the pypiserver without reaping it, so the server could outlive the handle Python collected, and the standalone-Python tests raise synthetic `HTTPError` objects that `urllib` hands an unclosed body. Neither reached users, and a noisy warning stream keeps both out of sight.

One warning stays suppressed by pattern. `importlib.metadata` warns before returning nothing for a `dist-info` that carries no `Name`, which pipx meets in an environment holding a malformed distribution. pipx already treats that case as "no name" and already catches the error Python 3.15 raises in its place, so there is no deadline to act on and nothing to change beyond recording why we ignore it.

The suppression list is the thing to watch in review. Each future entry needs the same kind of justification, or the gate stops meaning anything.
