### PR TITLE
🧪 test: isolate the verbosity test from the real pipx home

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -82,9 +82,10 @@ def test_build_parser_uses_pipx_in_subcommand_help(mocker: MockerFixture, capsys
     assert capsys.readouterr().out.startswith("usage: pipx run ")
 
 
-def test_limit_verbosity() -> None:
-    assert not run_pipx_cli(["list", "-qqq"])
-    assert not run_pipx_cli(["list", "-vvvv"])
+@pytest.mark.parametrize("flag", [pytest.param("-qqq", id="quiet"), pytest.param("-vvvv", id="verbose")])
+@pytest.mark.usefixtures("pipx_temp_env")
+def test_limit_verbosity(flag: str) -> None:
+    assert not run_pipx_cli(["list", flag])
 
 
 def test_all_subcommands_have_func_registered() -> None:


### PR DESCRIPTION
A contributor runs the suite, `test_limit_verbosity` fails, and nothing they changed caused it. The test calls `pipx list` without the temporary-home fixture, so it reads whatever the developer has installed on their own machine. One local environment with a missing interpreter makes `list` exit non-zero and the test goes red on a state that has nothing to do with the code under review. 🧹

CI stays green here, because a fresh runner holds no pipx installs to trip over. That is what makes it worth fixing rather than living with: the failure lands on the people whose environments are the messiest, and it teaches them that a red suite is normal noise.

The test checks that `-qqq` and `-vvvv` are accepted, which needs no packages, so it now runs against the temporary home like the rest of the suite. The two flags become separate cases so a future failure names the one that broke instead of leaving the reader to guess.

I swept the rest of the suite for the same pattern. The other tests that run a command reach the temporary home through their own fixtures, which leaves this one as the last reading a developer's real installation.
