### PR TITLE
👷 test: keep the suite off the real internet

### DIFF
--- a/changelog.d/2025.misc.md
+++ b/changelog.d/2025.misc.md
@@ -1,0 +1,1 @@
+Keep the test suite off the real internet so rate limits cannot turn into unraisable ResourceWarnings.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import importlib
 import io
+import ipaddress
 import logging
 import os
 import shutil
@@ -40,6 +41,7 @@ if TYPE_CHECKING:
 # ``import_module`` returns the module regardless.
 _UPGRADE_MODULE: Final[ModuleType] = importlib.import_module("pipx.commands.upgrade")
 
+_LOOPBACK_HOSTS: Final[frozenset[str]] = frozenset({"localhost", "127.0.0.1", "::1"})
 _PIPX_TESTS_DIR: Final[Path] = Path(".pipx_tests")
 _PIPX_TESTS_PACKAGE_LIST_DIR: Final[Path] = Path("testdata/tests_packages")
 _IGNORE_PROJECT_OUTPUT: Final[Callable[[str, list[str]], set[str]]] = shutil.ignore_patterns("build", "*.egg-info")
@@ -159,6 +161,37 @@ def _backend_test_baseline(monkeypatch: pytest.MonkeyPatch) -> None:
     _uv_backend_module._check_uv_version.cache_clear()  # ruff:ignore[private-member-access]
     get_backend.cache_clear()
     reset_backend_override_warnings()
+
+
+@pytest.fixture(autouse=True)
+def _block_external_network(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fail a test that dials the real internet instead of letting it flake on somebody else's rate limit.
+
+    The standalone-python tests used to reach github.com, so a 403 there turned into an unclosed SSLSocket and an
+    unraisable ResourceWarning attributed to whichever test happened to be running when the GC caught up. The local
+    pypiserver lives on loopback, which stays reachable; --net-pypiserver and --all-packages want real indexes and
+    opt out.
+    """
+    if request.config.option.net_pypiserver or request.config.option.all_packages:
+        return
+    connect = socket.socket.connect
+
+    def guarded_connect(self: socket.socket, address: tuple[str | int, ...] | str | bytes) -> None:
+        if isinstance(address, tuple) and not _is_loopback(str(address[0])):
+            msg = f"test connected to {address[0]}; mock the remote instead of reaching it"
+            raise RuntimeError(msg)
+        connect(self, address)
+
+    monkeypatch.setattr(socket.socket, "connect", guarded_connect)
+
+
+def _is_loopback(host: str) -> bool:
+    if host in _LOOPBACK_HOSTS:
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:  # a hostname that never resolved, so it cannot be loopback
+        return False
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1501,6 +1501,7 @@ def test_passed_python_and_force_flag_warning(capsys: pytest.CaptureFixture[str]
         pytest.param("3.0", "--fetch-missing-python", True, id="3.0-deprecated-flag"),
     ],
 )
+@pytest.mark.usefixtures("mocked_github_api")
 def test_install_fetch_missing_python_invalid(
     capsys: pytest.CaptureFixture[str], python_version: str, fetch_flag: str, expect_deprecation: bool
 ) -> None:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -8,6 +8,9 @@ import shutil
 import subprocess
 import sys
 import textwrap
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
 from typing import TYPE_CHECKING, Final
 from unittest import mock
 
@@ -15,7 +18,7 @@ import pytest
 from filelock import AcquireReturnProxy, FileLock, Timeout
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping, Sequence
+    from collections.abc import Callable, Iterator, Mapping, Sequence
     from pathlib import Path
 
     from pytest_mock import MockerFixture
@@ -394,18 +397,27 @@ def test_cache_sweep_ignores_tag(
 
 @pytest.mark.usefixtures("pipx_temp_env")
 @mock.patch("os.execvpe", new=execvpe_mock)
-def test_run_script_from_internet() -> None:
-    run_pipx_cli_exit(
-        [
-            "run",
-            (
-                "https://gist.githubusercontent.com/cs01/"
-                "fa721a17a326e551ede048c5088f9e0f/raw/"
-                "6bdfbb6e9c1132b1c38fdd2f195d4a24c540c324/pipx-demo.py"
-            ),
-        ],
-        assert_exit=0,
-    )
+def test_run_script_from_url(served_script: str) -> None:
+    run_pipx_cli_exit(["run", served_script], assert_exit=0)
+
+
+@pytest.fixture
+def served_script(tmp_path: Path) -> Iterator[str]:
+    """Serves the script over loopback rather than fetching a third-party gist.
+
+    Pointing the test at somebody else's URL made it fail whenever that host rate-limited the runner, and the leaked
+    socket surfaced as an unraisable ResourceWarning in whichever test the GC happened to interrupt.
+    """
+    (tmp_path / "pipx-demo.py").write_text("print('pipx works!')\n", encoding="utf-8")
+    server = ThreadingHTTPServer(("127.0.0.1", 0), partial(SimpleHTTPRequestHandler, directory=str(tmp_path)))
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/pipx-demo.py"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`main` has been red for days, and every open PR inherits it. Three tests fail in rotation across runners, and all three trace back to the suite reaching the real internet.

`test_install_fetch_missing_python_invalid` asks pipx for a standalone Python 3.0 without mocking the release index, and `test_run_script_from_internet` fetches a gist from githubusercontent. When GitHub answers `403: rate limit exceeded` urllib leaves the `SSLSocket` unclosed, and since `filterwarnings = ["error"]` the resulting `ResourceWarning` reaches pytest's unraisable collector and fails whichever test the collector happens to interrupt. That is why `test_install_run_in_separate_directory`, which opens no connection of its own, has been failing as often as the two that do.

The fetch test now takes the `mocked_github_api` fixture the interpreter tests already use, and the script test now serves its payload over loopback so the URL parsing, size cap and decode still run against the real code path. On top of that an autouse fixture refuses any connection to a non-loopback address, so the next test that reaches out fails on its own line with the address it dialled rather than surfacing minutes later as somebody else's `ResourceWarning`. `--net-pypiserver` and `--all-packages` want real indexes and opt out.

Separately, `test_uninject_running_app` opened three pipes on its `Popen` and never closed them, which is the Windows half of the same red: the GC finalizes the pipes whenever it gets there and the `ResourceWarning` errors out. `Popen` as a context manager closes all three.

I ran the full suite with the guard armed, which is how the gist fetch surfaced.
