### PR TITLE
Avoid KeyError in _REQUIRES_PYTHON_SCRIPT

### DIFF
--- a/changelog.d/2026.bugfix.md
+++ b/changelog.d/2026.bugfix.md
@@ -1,0 +1,1 @@
+Fix `KeyError` stderr noise when installing packages in Python3.15.

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -63,7 +63,7 @@ _LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 _REQUIRES_PYTHON_SCRIPT: Final[str] = (
     "import sys;"
     "from importlib.metadata import distribution;"
-    "print(distribution(sys.argv[1]).metadata['Requires-Python'] or '');"
+    "print(distribution(sys.argv[1]).metadata.get('Requires-Python') or '');"
     "print('.'.join(str(part) for part in sys.version_info[:3]))"
 )
 _BACKEND_METADATA_VERSION: Final[Version] = Version("0.6")


### PR DESCRIPTION
metadata raises KeyError for missing keys in Python3.15+. This error can be safely ignored, but it causes python to print a stacktrace when installing a package without 'Requires-Python' field in metadata, though the package is actually installed successfully.

This PR updates _REQUIRES_PYTHON_SCRIPT to avoid stderr noise caused by KeyError.

- [x] ran the linter to address style issues (`pre-commit run --all-files`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [x] added news fragment in `changelog.d/` folder (choose a type: `feature`, `bugfix`, `doc`, `removal`, or `misc`)
- [ ] updated/extended the documentation
