### PR TITLE
fix(cli): validate PIPX_MAX_LOGS before logging setup

### DIFF
--- a/changelog.d/2029.bugfix.md
+++ b/changelog.d/2029.bugfix.md
@@ -1,0 +1,2 @@
+Report a clear error when PIPX_MAX_LOGS is not a non-negative integer, instead of crashing on every pipx command. Empty
+or whitespace-only values fall back to the default everywhere, including log setup.

--- a/src/pipx/constants.py
+++ b/src/pipx/constants.py
@@ -64,6 +64,22 @@ def _compute_cooldown(raw: str | None) -> tuple[int | None, bool]:
 _COOLDOWN, _COOLDOWN_INVALID = _compute_cooldown(_COOLDOWN_RAW)
 
 
+_MAX_LOGS_RAW = os.environ.get("PIPX_MAX_LOGS")
+
+
+def _compute_max_logs(raw: str | None) -> tuple[int, bool]:
+    if raw is None or not (stripped := raw.strip()):
+        return 10, False
+    try:
+        logs = int(stripped)
+    except ValueError:
+        return 10, True
+    return (logs, False) if logs >= 0 else (10, True)
+
+
+_MAX_LOGS, _MAX_LOGS_INVALID = _compute_max_logs(_MAX_LOGS_RAW)
+
+
 ExitCode = NewType("ExitCode", int)
 # pipx shell exit codes
 EXIT_CODE_OK = ExitCode(0)

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -38,12 +38,15 @@ from pipx.constants import (
     _FETCH_PYTHON,
     _FETCH_PYTHON_INVALID,
     _FETCH_PYTHON_RAW,
+    _MAX_LOGS_INVALID,
+    _MAX_LOGS_RAW,
     EXIT_CODE_OK,
     EXIT_CODE_SPECIFIED_PYTHON_EXECUTABLE_NOT_FOUND,
     MINIMUM_PYTHON_VERSION,
     WINDOWS,
     ExitCode,
     FetchPythonOptions,
+    _compute_max_logs,
 )
 from pipx.emojis import hazard
 from pipx.interpreter import (
@@ -303,6 +306,12 @@ def _validate_fetch_python() -> None:
 def _validate_cooldown() -> None:
     if _COOLDOWN_INVALID:
         msg = f"PIPX_COOLDOWN must be unset or a non-negative integer, got {_COOLDOWN_RAW!r}."
+        raise PipxError(msg)
+
+
+def _validate_max_logs() -> None:
+    if _MAX_LOGS_INVALID:
+        msg = f"PIPX_MAX_LOGS must be unset or a non-negative integer, got {_MAX_LOGS_RAW!r}."
         raise PipxError(msg)
 
 
@@ -1858,7 +1867,10 @@ def delete_oldest_logs(file_list: list[Path], keep_number: int) -> None:
 
 
 def _setup_log_file(pipx_log_dir: Path | None = None) -> Path:
-    max_logs = int(os.getenv("PIPX_MAX_LOGS", "10"))
+    # parse through the shared _compute_max_logs so blank values fall back to the
+    # default here too: raw int() re-parsing crashed on PIPX_MAX_LOGS="" or "   "
+    # even though dispatch validation had already passed them as unset
+    max_logs, _ = _compute_max_logs(os.getenv("PIPX_MAX_LOGS"))
     pipx_log_dir = pipx_log_dir or paths.ctx.logs
     # don't use utils.mkdir, to prevent emission of log message
     pipx_log_dir.mkdir(parents=True, exist_ok=True)
@@ -2035,6 +2047,7 @@ def _dispatch(argv: list[str]) -> ExitCode:
     parsed_pipx_args = parse_pipx_args(parser, argv)
     _validate_fetch_python()
     _validate_cooldown()
+    _validate_max_logs()
     setup(parsed_pipx_args)
     check_args(parsed_pipx_args)
     if not parsed_pipx_args.command:

--- a/tests/test_max_logs.py
+++ b/tests/test_max_logs.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
+from helpers import run_pipx_cli
+from pipx import constants, main
 from pipx.main import (
     _setup_log_file,  # ruff:ignore[import-private-name]  # test exercises private helper, no public API
     delete_oldest_logs,
@@ -11,8 +15,6 @@ from pipx.main import (
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-    import pytest
 
 
 def test_delete_oldest_logs_keeps_specified_number(tmp_path: Path) -> None:
@@ -121,3 +123,41 @@ def test_max_logs_with_large_value(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     # Should have 5 old logs + 1 new log = 6 total
     remaining = list(tmp_path.glob("cmd_*.log"))
     assert len(remaining) == 6
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected_logs", "expected_invalid"),
+    [
+        pytest.param(None, 10, False, id="unset"),
+        pytest.param("", 10, False, id="empty"),
+        pytest.param("   ", 10, False, id="whitespace-only"),
+        pytest.param("10", 10, False, id="default"),
+        pytest.param(" 5 ", 5, False, id="whitespace-padded"),
+        pytest.param("0", 0, False, id="zero"),
+        pytest.param("-1", 10, True, id="negative"),
+        pytest.param("garbage", 10, True, id="not-an-integer"),
+    ],
+)
+def test_compute_max_logs(raw: str | None, expected_logs: int, expected_invalid: bool) -> None:
+    assert constants._compute_max_logs(raw) == (expected_logs, expected_invalid)  # ruff:ignore[private-member-access]  # no public API
+
+
+def test_cli_rejects_invalid_env_max_logs(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setattr(main, "_MAX_LOGS_INVALID", True)
+    monkeypatch.setattr(main, "_MAX_LOGS_RAW", "garbage")
+
+    assert run_pipx_cli(["list"])
+
+    assert "PIPX_MAX_LOGS must be unset or a non-negative integer, got 'garbage'." in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("raw", ["", "   "], ids=["empty", "whitespace-only"])
+def test_cli_blank_env_max_logs_falls_back_to_default(
+    raw: str, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Blank values pass validation as unset, so log setup must not re-crash on a raw int() parse."""
+    monkeypatch.setenv("PIPX_MAX_LOGS", raw)
+
+    assert not run_pipx_cli(["list"])
+
+    assert "ValueError" not in capsys.readouterr().err


### PR DESCRIPTION
### Summary

`PIPX_MAX_LOGS` set to a non-integer like `PIPX_MAX_LOGS=abc` crashed every pipx command (except `--version`) with a raw `ValueError: invalid literal for int() with base 10: 'abc'` traceback during logging setup, bcs `_setup_log_file()` parses it with `int()` before any command runs, the sibling env vars `PIPX_COOLDOWN` and `PIPX_FETCH_PYTHON` already validate their values at dispatch and stop with a clean error

This mirrors the cooldown pattern, the raw value is parsed once in `constants.py` (`_compute_max_logs` → `_MAX_LOGS` + `_MAX_LOGS_INVALID`), a new `_validate_max_logs()` runs in `_dispatch` before anything else, and an invalid value now stops with

```
PIPX_MAX_LOGS must be unset or a non-negative integer, got 'abc'.
```

Reproduced pre-change

```
$ pipx list
nothing has been installed with pipx 😴          # exit 0
$ PIPX_MAX_LOGS=abc pipx list
Traceback (most recent call last):
  ...
ValueError: invalid literal for int() with base 10: 'abc'
```

Post-fix exit code is 1 with the message above, valid values (0, 5, 10, 100) keep their existing pruning behavior unchanged, and blank values (empty or whitespace-only) fall back to the default 10 everywhere after a review caught `_setup_log_file()` still re-parsing the raw value with `int()` on them

### Related

Follows the same variable hot zone as #1988 (prune logs when `PIPX_MAX_LOGS` is 0) and #2024 (report `PIPX_MAX_LOGS` from `pipx environment`), no open issue tracks this exact crash, the env-var validation pattern is the one added for `PIPX_COOLDOWN` in #2018

### Tests

- `test_compute_max_logs`, 8 parse cases (unset, empty, whitespace-only, 10, whitespace-padded, 0, negative, garbage), fails without the change
- `test_cli_rejects_invalid_env_max_logs`, CLI exits 1 with the clean message, without the validation guard it raises AttributeError (no guard exists)
- `test_cli_blank_env_max_logs_falls_back_to_default`, empty and whitespace-only inputs run the whole CLI through log setup without crashing, fails on the old raw `int()` re-parse

`pytest tests/test_max_logs.py tests/test_main.py tests/test_environment.py` → 104 passed, `ruff check` and `ruff format` clean, all pre-commit hooks pass

### Checklist

- [x] ran the linter to address style issues (`pre-commit run --all-files`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `changelog.d/` folder (`2029.bugfix.md`, bugfix type)
- [ ] updated/extended the documentation, not needed bcs the env-var table already documents `PIPX_MAX_LOGS` (number of log files to keep, default 10), the code was what disagreed with it, after #2024